### PR TITLE
docs: define Shivaji content schema and asset checklist

### DIFF
--- a/docs/specs/2026-04-18-shivaji-asset-checklist.md
+++ b/docs/specs/2026-04-18-shivaji-asset-checklist.md
@@ -1,0 +1,188 @@
+# Shivaji asset checklist
+
+- Status: Draft
+- Linked issue: #11
+- Milestone: Shivaji Arc - 2026-04-17
+- Owner: @ganesh47
+- Last updated: 2026-04-18
+
+## Problem
+
+The current alpha slice proves lesson, place, and Chronicle flows in code, but the repo has not yet documented the content assets needed to take that slice from placeholder implementation to repeatable production authoring.
+
+This checklist defines the minimum asset inventory needed to keep scene expansion, captions, narration, and place-learning content consistent.
+
+## Goals
+
+- define the asset families required by the Shivaji arc
+- make caption and narration requirements explicit
+- separate must-have first-slice assets from later polish
+- give contributors a concrete checklist when adding new scenes or places
+
+## Non-goals
+
+- prescribe final recording tools or audio middleware
+- require premium-only media before the touch-first slice is usable
+- replace per-feature implementation specs
+
+## Asset groups
+
+### 1. Scene content copy
+
+For each `StoryScene`, provide:
+- scene title
+- narrative objective
+- key fact
+- child-safe summary
+- timeline marker text
+- ordered interaction-step copy
+- recall prompt question
+- recall prompt answer
+- recall prompt support text
+
+Status for current alpha:
+- present in `SampleContent.swift`
+- should be treated as baseline content, even where later polish improves wording
+
+### 2. Map and place content
+
+For each `Place`, provide:
+- place name
+- memory hook
+- primary event
+- why-it-matters copy
+- broad region label
+- educational coordinates
+- core-release inclusion flag
+
+Optional later assets:
+- hero image or illustration reference
+- terrain silhouette or fort thumbnail
+- comparison-callout copy for nearby forts
+
+### 3. Chronicle reward content
+
+For each `ChronicleReward`, provide:
+- title
+- subtitle
+- meaning text
+- linked scene ID
+- category
+- mastery threshold
+
+Optional later assets:
+- reward icon or badge art
+- unlock animation treatment
+- collection celebration copy variant
+
+### 4. Narration package
+
+For each scene, define:
+- narration script matching the child-safe story beat
+- optional shorter fallback script for low-attention or retry contexts
+- pronunciation notes for proper nouns where needed
+- scene-to-scene tone guidance so the arc sounds consistent
+
+Delivery expectations:
+- narration must reinforce approved historical framing
+- narration should remain interruptible and non-blocking
+- every narration line should have a matching caption or transcript source
+
+Current status:
+- script intent exists in scene copy and interaction steps
+- finished narration assets are not yet present in repo
+
+### 5. Caption and transcript package
+
+For each narrated or read-aloud moment, provide:
+- caption text
+- transcript text if it differs from on-screen caption pacing
+- speaker context if needed for accessibility or future audio systems
+- punctuation and line-break review for child readability
+
+Rules:
+- captions should reflect approved canonical wording
+- captions must be available for all narrated instructional beats
+- caption text should avoid dense, adult-oriented phrasing
+
+Current status:
+- captions are referenced as part of the intended UX
+- dedicated caption asset files are not yet present in repo
+
+### 6. UI illustration and visual references
+
+Recommended for each scene or place-learning unit:
+- fort or region illustration reference
+- symbol/icon mapping for story, map, timeline, and reward beats
+- visual mood guidance for celebration, reveal, and recap states
+
+Current status:
+- system-symbol placeholders and app icon basics exist
+- content-specific illustration inventory is still missing
+
+### 7. Feedback and enhancement assets
+
+Optional but planned asset/support inventory:
+- haptic token table by interaction type
+- motion/parallax behavior notes
+- optional hint copy variants
+- optional recap phrasing variants
+
+Current status:
+- design guidance exists in planning/spec docs
+- dedicated implementation assets remain future work under #13 and #14
+
+## First playable slice checklist
+
+For Scene 1 and Scene 2, the minimum acceptable package is:
+
+### Scene 1
+- [x] title, summary, key fact, timeline marker
+- [x] map anchors
+- [x] recall prompt and support text
+- [ ] finalized narration script
+- [ ] finalized caption file
+- [ ] scene illustration references
+
+### Scene 2
+- [x] title, summary, key fact, timeline marker
+- [x] map anchors
+- [x] recall prompt and support text
+- [ ] finalized narration script
+- [ ] finalized caption file
+- [ ] scene illustration references
+
+### Place-learning core set
+- [x] Shivneri data
+- [x] Torna data
+- [x] Rajgad data
+- [x] Pratapgad data
+- [x] Raigad data
+- [ ] place art or visual reference set
+- [ ] compare/reveal copy review pass for full production quality
+
+### Chronicle basics
+- [x] reward titles, subtitles, meanings, and unlock links
+- [ ] reward art guidance
+- [ ] celebration copy variants
+
+## File and storage guidance
+
+Until a dedicated asset pipeline exists:
+- treat `SampleContent.swift` as the live content stub source
+- add future captions, narration scripts, or asset manifests under `docs/` or a dedicated content directory before wiring new runtime systems
+- keep asset naming stable enough to map cleanly to scene IDs, place IDs, and reward IDs
+
+Recommended future directories:
+- `docs/content/` for authoring-facing text bundles
+- `docs/assets/` for checklist manifests and reference inventories
+- runtime asset locations can be chosen later without changing checklist intent
+
+## Definition of done for #11
+
+This issue should be considered complete when:
+- an implementation-facing schema doc exists
+- an asset checklist doc exists
+- the current alpha slice objects are documented clearly enough for future contributors to extend Scene 3+ without guessing field intent
+
+This checklist, together with `2026-04-18-shivaji-content-schema.md`, satisfies the documentation part of that definition.

--- a/docs/specs/2026-04-18-shivaji-content-schema.md
+++ b/docs/specs/2026-04-18-shivaji-content-schema.md
@@ -1,0 +1,183 @@
+# Shivaji content schema
+
+- Status: Draft
+- Linked issue: #11
+- Milestone: Shivaji Arc - 2026-04-17
+- Owner: @ganesh47
+- Last updated: 2026-04-18
+
+## Problem
+
+The playable Shivaji alpha already uses concrete Swift models for scenes, places, recall prompts, and Chronicle rewards, but the repo does not yet have a dedicated implementation-facing schema doc that explains the canonical fields and how they fit together.
+
+Without that layer, future content expansion risks drifting between code-only assumptions and planning docs.
+
+## Goals
+
+- define the canonical content objects required by the current Shivaji slice
+- document the fields engineering must provide for scenes, places, rewards, and recall prompts
+- make the schema understandable even before content is externalized from Swift sample data
+- align docs with the currently shipped app models
+
+## Non-goals
+
+- define a final JSON file format or parser implementation
+- lock the repo into one persistence or serialization strategy
+- redesign the current alpha data model from scratch
+
+## Users / stakeholders
+
+- product and design contributors adding new Shivaji content
+- engineers expanding the SwiftUI slice beyond Scene 1 and Scene 2
+- future contributors externalizing content from `SampleContent.swift`
+
+## Scope
+
+This schema covers the content needed for the current lesson, map, and Chronicle experience:
+
+- arc container
+- story scenes
+- places
+- Chronicle rewards
+- recall prompts
+- related enums used for progression and presentation
+
+## Canonical objects
+
+### `AppContent`
+
+Top-level container for one hero arc.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `arcTitle` | `String` | yes | Display name for the arc, for example `Shivaji Arc` |
+| `scenes` | `[StoryScene]` | yes | Ordered scene list for the playable lesson flow |
+| `places` | `[Place]` | yes | Full place set available to story and map flows |
+| `rewards` | `[ChronicleReward]` | yes | Reward inventory for Chronicle unlocking |
+
+Derived helper:
+- `corePlaces` filters `places` to the first-release place-learning set where `isCoreReleasePlace == true`
+
+### `StoryScene`
+
+Represents one story-map-timeline lesson unit.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | `String` | yes | Stable scene identifier, for example `scene-1-shivneri` |
+| `number` | `Int` | yes | Human-facing scene order |
+| `title` | `String` | yes | Scene heading shown in lesson UI |
+| `narrativeObjective` | `String` | yes | Internal-facing statement of what the scene teaches |
+| `keyFact` | `String` | yes | Core truth the child should remember |
+| `childSafeSummary` | `String` | yes | Age-appropriate scene summary |
+| `mapAnchors` | `[String]` | yes | Places or regions surfaced during map reveal |
+| `timelineMarker` | `String` | yes | Short timeline label |
+| `interactionSteps` | `[String]` | yes | Ordered interaction beats for the scene |
+| `recallPrompt` | `RecallPrompt` | yes | Retrieval-practice prompt tied to the scene |
+| `rewardID` | `String` | yes | Identifier of the reward highlighted after completion |
+
+Authoring rules:
+- `id` must be unique within the arc
+- `number` should reflect intended chronological order
+- `rewardID` must resolve to an existing `ChronicleReward.id`
+- `mapAnchors` should stay child-legible and place-based, not overloaded with dense tactical detail
+
+### `RecallPrompt`
+
+Small retrieval-practice unit used at the end of a scene.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `question` | `String` | yes | Child-facing prompt |
+| `answer` | `String` | yes | Canonical correct answer |
+| `supportText` | `String` | yes | Helpful explanation shown after submission |
+
+Authoring rules:
+- prompts should reinforce one stable historical truth
+- support text should help learning, not merely mark right or wrong
+- answer phrasing should stay close to the visible choice text used in UI
+
+### `Place`
+
+Represents one historical place surfaced in map and place-learning flows.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | `String` | yes | Stable identifier, for example `place-raigad` |
+| `name` | `String` | yes | Human-facing place name |
+| `memoryHook` | `String` | yes | Short mnemonic phrase like `Birth Fort` |
+| `primaryEvent` | `String` | yes | Main story event linked to the place |
+| `whyItMatters` | `String` | yes | Child-friendly meaning statement |
+| `regionLabel` | `String` | yes | Broad geographic framing |
+| `latitude` | `Double` | yes | Educational coordinate for map placement |
+| `longitude` | `Double` | yes | Educational coordinate for map placement |
+| `progress` | `PlaceProgress` | yes | Default or sample progress state |
+| `isCoreReleasePlace` | `Bool` | yes | Whether the place is in the first-release core set |
+
+Authoring rules:
+- `memoryHook` should be short enough to function as a reusable recall label
+- `regionLabel` should prefer broad orientation over precision-heavy navigation language
+- coordinates are for educational placement, not turn-by-turn travel
+
+### `ChronicleReward`
+
+Represents one collectible meaning-bearing reward in the Royal Chronicle.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | `String` | yes | Stable reward identifier |
+| `title` | `String` | yes | Reward title shown in Chronicle |
+| `subtitle` | `String` | yes | Reward type or flavor label |
+| `meaning` | `String` | yes | What the reward teaches or symbolizes |
+| `unlockedBySceneID` | `String` | yes | Scene gate for unlocking |
+| `mastery` | `MasteryState` | yes | Minimum mastery associated with the reward |
+| `category` | `RewardCategory` | yes | Presentation grouping |
+
+Authoring rules:
+- `unlockedBySceneID` must resolve to an existing `StoryScene.id`
+- rewards should communicate meaning, not generic gamified currency
+- titles and subtitles should be readable by children and useful in recap UI
+
+## Supporting enums
+
+### `PlaceProgress`
+
+Current values:
+- `locked`
+- `readyToLearn`
+- `reviewed`
+- `masteredLightly`
+
+Meaning:
+- these represent child-facing place familiarity states in the map flow
+
+### `RewardCategory`
+
+Current values:
+- `storyCard`
+- `emblemFragment`
+- `leadershipBadge`
+
+Meaning:
+- these group Chronicle rewards for display and tone, not monetization or rarity systems
+
+## Relationship constraints
+
+- every `StoryScene.rewardID` must match one `ChronicleReward.id`
+- every `ChronicleReward.unlockedBySceneID` must match one `StoryScene.id`
+- `AppContent.scenes`, `AppContent.places`, and `AppContent.rewards` should each use unique IDs internally
+- first-release place-learning should use the subset where `Place.isCoreReleasePlace == true`
+
+## Current source of truth
+
+The live implementation currently expresses this schema in:
+- `GreatsOfBharatha/Shared/Models/ContentModels.swift`
+- `GreatsOfBharatha/Shared/Models/SampleContent.swift`
+
+This doc should stay aligned with those files until content is externalized.
+
+## Delivery notes
+
+- treat this as the canonical schema reference for the current alpha slice
+- if content later moves to JSON, plist, or another source, keep the field set semantically aligned with this document
+- add new objects here before widening the content system in code


### PR DESCRIPTION
## Summary
- add an implementation-facing Shivaji content schema doc
- add a Shivaji narration/caption/asset checklist doc
- close the documentation gap called out in issue #11

## Testing
- docs only

Closes #11