### PR TITLE
feat: prototype haptic lesson feedback

### DIFF
--- a/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
+++ b/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
@@ -46,12 +46,14 @@ struct SceneLessonView: View {
                 HStack(spacing: 12) {
                     Button("Previous") {
                         cardIndex = max(cardIndex - 1, 0)
+                        LessonFeedback.fire(.selection)
                     }
                     .buttonStyle(.bordered)
                     .disabled(cardIndex == 0)
 
                     Button(cardIndex == lessonCards.count - 1 ? "Review the map" : "Next card") {
                         cardIndex = min(cardIndex + 1, lessonCards.count - 1)
+                        LessonFeedback.fire(.selection)
                     }
                     .buttonStyle(.borderedProminent)
                     .frame(maxWidth: .infinity, alignment: .trailing)
@@ -102,10 +104,12 @@ struct SceneLessonView: View {
             recallState.feedbackText = scene.recallPrompt.supportText
             let mastery: MasteryState = scene.number == 2 && chosenPlanSteps.count >= 2 ? .observedClosely : .understood
             appModel.lessonStore.markScene(scene.id, mastery: mastery)
+            LessonFeedback.fire(.success)
         } else {
             recallState.hasAnsweredCorrectly = false
             recallState.feedbackText = "Try again. \(scene.recallPrompt.supportText)"
             appModel.lessonStore.markScene(scene.id, mastery: .witnessed)
+            LessonFeedback.fire(.warning)
         }
     }
 
@@ -220,7 +224,11 @@ private struct MapAnchorCard: View {
             }
 
             Button(revealedMapAnchors == scene.mapAnchors.count ? "All anchors revealed" : "Reveal next anchor") {
-                revealedMapAnchors = min(revealedMapAnchors + 1, scene.mapAnchors.count)
+                let nextValue = min(revealedMapAnchors + 1, scene.mapAnchors.count)
+                if nextValue != revealedMapAnchors {
+                    revealedMapAnchors = nextValue
+                    LessonFeedback.fire(nextValue == scene.mapAnchors.count ? .success : .reveal)
+                }
             }
             .buttonStyle(.bordered)
         }
@@ -248,6 +256,7 @@ private struct FortPlanningCard: View {
                     } else {
                         chosenPlanSteps.insert(step.id)
                     }
+                    LessonFeedback.fire(.selection)
                 } label: {
                     HStack(spacing: 12) {
                         Image(systemName: chosenPlanSteps.contains(step.id) ? "checkmark.circle.fill" : step.symbol)
@@ -293,6 +302,7 @@ private struct RecallPanel: View {
                 let isSelected = selectedChoiceID == choice.id
                 Button {
                     selectedChoiceID = choice.id
+                    LessonFeedback.fire(.selection)
                 } label: {
                     HStack(alignment: .top, spacing: 12) {
                         Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")

--- a/GreatsOfBharatha/Features/Map/PlacesHubView.swift
+++ b/GreatsOfBharatha/Features/Map/PlacesHubView.swift
@@ -115,9 +115,11 @@ struct PlaceDetailView: View {
                                 selectedCandidateID = nil
                                 revealed = false
                                 comparisonMode = false
+                                LessonFeedback.fire(.selection)
                             } else {
                                 revealed = true
                                 comparisonMode = true
+                                LessonFeedback.fire(selectedCandidate?.id == place.id ? .success : .reveal)
                             }
                         }
                         .buttonStyle(.borderedProminent)
@@ -125,6 +127,7 @@ struct PlaceDetailView: View {
                         if revealed {
                             Button(comparisonMode ? "Hide compare view" : "Compare nearby forts") {
                                 comparisonMode.toggle()
+                                LessonFeedback.fire(.selection)
                             }
                             .buttonStyle(.bordered)
                         }
@@ -156,6 +159,7 @@ struct PlaceDetailView: View {
 
                 Button {
                     selectedCandidateID = candidate.id
+                    LessonFeedback.fire(.selection)
                 } label: {
                     HStack(spacing: 12) {
                         Image(systemName: isCorrect ? "checkmark.circle.fill" : isSelected ? "mappin.circle.fill" : "mappin.circle")

--- a/GreatsOfBharatha/Shared/Theme/LessonFeedback.swift
+++ b/GreatsOfBharatha/Shared/Theme/LessonFeedback.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct LessonFeedback {
+    enum HapticToken {
+        case selection
+        case reveal
+        case success
+        case warning
+    }
+
+    static func fire(_ token: HapticToken) {
+#if os(iOS)
+        switch token {
+        case .selection:
+            UISelectionFeedbackGenerator().selectionChanged()
+        case .reveal:
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.prepare()
+            generator.impactOccurred()
+        case .success:
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        case .warning:
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        }
+#else
+        _ = token
+#endif
+    }
+}

--- a/GreatsOfBharatha/Shared/Theme/LessonFeedback.swift
+++ b/GreatsOfBharatha/Shared/Theme/LessonFeedback.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 struct LessonFeedback {
     enum HapticToken {
         case selection


### PR DESCRIPTION
## Summary
- add lightweight haptic tokens for lesson interactions
- fire feedback on map reveal, recall checking, card navigation, and fort selection flows
- keep a safe no-op fallback for non-iOS builds

## Notes
- this advances #13 with one meaningful premium interaction that does not gate progression
- local Xcode validation is unavailable in this workspace, so GitHub Actions is the validation path

## Testing
- GitHub Actions

Closes #13