### PR TITLE
Implement responsive design-system foundations and migrate core screens

### DIFF
--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -9,6 +9,20 @@
 /* Begin PBXBuildFile section */
 		06EF311D881705EB5C28A94B /* ShivajiLessonStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAABCCD639D0C3267861E9A8 /* ShivajiLessonStore.swift */; };
 		073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C5A02CDD2D6DA5162F535 /* MasteryState.swift */; };
+		0A4A9F770C1A4F32965E1011 /* GBButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F760C1A4F32965E1011 /* GBButtonStyle.swift */; };
+		0A4A9F790C1A4F32965E1011 /* GBSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F780C1A4F32965E1011 /* GBSectionHeader.swift */; };
+		0A4A9F7B0C1A4F32965E1011 /* GBTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F7A0C1A4F32965E1011 /* GBTypography.swift */; };
+		0A4A9F7D0C1A4F32965E1011 /* GBIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F7C0C1A4F32965E1011 /* GBIcon.swift */; };
+		0A4A9F7F0C1A4F32965E1011 /* GBBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F7E0C1A4F32965E1011 /* GBBadge.swift */; };
+		0A4A9F810C1A4F32965E1011 /* GBQuestProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F800C1A4F32965E1011 /* GBQuestProgress.swift */; };
+		0A4A9F830C1A4F32965E1011 /* GBMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F820C1A4F32965E1011 /* GBMotion.swift */; };
+		0A4A9F850C1A4F32965E1011 /* GBCardStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F840C1A4F32965E1011 /* GBCardStyle.swift */; };
+		0A4A9F870C1A4F32965E1011 /* GBSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F860C1A4F32965E1011 /* GBSurface.swift */; };
+		0A4A9F890C1A4F32965E1011 /* GBHeroCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F880C1A4F32965E1011 /* GBHeroCard.swift */; };
+		0A4A9F8B0C1A4F32965E1011 /* GBColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F8A0C1A4F32965E1011 /* GBColor.swift */; };
+		0A4A9F8D0C1A4F32965E1011 /* GBRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F8C0C1A4F32965E1011 /* GBRadius.swift */; };
+		0A4A9F8F0C1A4F32965E1011 /* GBSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F8E0C1A4F32965E1011 /* GBSpacing.swift */; };
+		0A4A9F910C1A4F32965E1011 /* GBLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F900C1A4F32965E1011 /* GBLayoutContext.swift */; };
 		16E40D4D9552B57A027D9FF5 /* StoryHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA3B33CD2FFC1A53263C40A /* StoryHomeView.swift */; };
 		1F8C2F1A8E2D4A1B9C7D1234 /* DebugNavigationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C2F198E2D4A1B9C7D1234 /* DebugNavigationRoute.swift */; };
 		229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE540544C5E9622DB91B7EF8 /* ContentView.swift */; };
@@ -41,6 +55,20 @@
 /* Begin PBXFileReference section */
 		0C84A1BE87F4CAA5D6281AD6 /* SceneLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLessonView.swift; sourceTree = "<group>"; };
 		0C857F8C6F22867D7E8B067F /* ShivajiLessonViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShivajiLessonViews.swift; sourceTree = "<group>"; };
+		0A4A9F760C1A4F32965E1011 /* GBButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBButtonStyle.swift; sourceTree = "<group>"; };
+		0A4A9F780C1A4F32965E1011 /* GBSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSectionHeader.swift; sourceTree = "<group>"; };
+		0A4A9F7A0C1A4F32965E1011 /* GBTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBTypography.swift; sourceTree = "<group>"; };
+		0A4A9F7C0C1A4F32965E1011 /* GBIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBIcon.swift; sourceTree = "<group>"; };
+		0A4A9F7E0C1A4F32965E1011 /* GBBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBBadge.swift; sourceTree = "<group>"; };
+		0A4A9F800C1A4F32965E1011 /* GBQuestProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBQuestProgress.swift; sourceTree = "<group>"; };
+		0A4A9F820C1A4F32965E1011 /* GBMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBMotion.swift; sourceTree = "<group>"; };
+		0A4A9F840C1A4F32965E1011 /* GBCardStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBCardStyle.swift; sourceTree = "<group>"; };
+		0A4A9F860C1A4F32965E1011 /* GBSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSurface.swift; sourceTree = "<group>"; };
+		0A4A9F880C1A4F32965E1011 /* GBHeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBHeroCard.swift; sourceTree = "<group>"; };
+		0A4A9F8A0C1A4F32965E1011 /* GBColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBColor.swift; sourceTree = "<group>"; };
+		0A4A9F8C0C1A4F32965E1011 /* GBRadius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBRadius.swift; sourceTree = "<group>"; };
+		0A4A9F8E0C1A4F32965E1011 /* GBSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSpacing.swift; sourceTree = "<group>"; };
+		0A4A9F900C1A4F32965E1011 /* GBLayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBLayoutContext.swift; sourceTree = "<group>"; };
 		1F8C2F198E2D4A1B9C7D1234 /* DebugNavigationRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugNavigationRoute.swift; sourceTree = "<group>"; };
 		2C6D8E0E1A2B3C4D5E6F7081 /* LessonFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonFeedback.swift; sourceTree = "<group>"; };
 		38AE753749107F40681898D3 /* GreatsOfBharathaTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = GreatsOfBharathaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -64,6 +92,51 @@
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
+		0A4A9F920C1A4F32965E1011 /* Tokens */ = {
+			isa = PBXGroup;
+			children = (
+				0A4A9F8A0C1A4F32965E1011 /* GBColor.swift */,
+				0A4A9F7C0C1A4F32965E1011 /* GBIcon.swift */,
+				0A4A9F820C1A4F32965E1011 /* GBMotion.swift */,
+				0A4A9F8C0C1A4F32965E1011 /* GBRadius.swift */,
+				0A4A9F8E0C1A4F32965E1011 /* GBSpacing.swift */,
+				0A4A9F7A0C1A4F32965E1011 /* GBTypography.swift */,
+			);
+			path = Tokens;
+			sourceTree = "<group>";
+		};
+		0A4A9F930C1A4F32965E1011 /* Foundation */ = {
+			isa = PBXGroup;
+			children = (
+				0A4A9F7E0C1A4F32965E1011 /* GBBadge.swift */,
+				0A4A9F760C1A4F32965E1011 /* GBButtonStyle.swift */,
+				0A4A9F840C1A4F32965E1011 /* GBCardStyle.swift */,
+				0A4A9F900C1A4F32965E1011 /* GBLayoutContext.swift */,
+				0A4A9F860C1A4F32965E1011 /* GBSurface.swift */,
+			);
+			path = Foundation;
+			sourceTree = "<group>";
+		};
+		0A4A9F940C1A4F32965E1011 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				0A4A9F880C1A4F32965E1011 /* GBHeroCard.swift */,
+				0A4A9F800C1A4F32965E1011 /* GBQuestProgress.swift */,
+				0A4A9F780C1A4F32965E1011 /* GBSectionHeader.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		0A4A9F950C1A4F32965E1011 /* DesignSystem */ = {
+			isa = PBXGroup;
+			children = (
+				0A4A9F920C1A4F32965E1011 /* Tokens */,
+				0A4A9F930C1A4F32965E1011 /* Foundation */,
+				0A4A9F940C1A4F32965E1011 /* Components */,
+			);
+			path = DesignSystem;
+			sourceTree = "<group>";
+		};
 		0570398737C6B4A9BAA4000C /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -173,6 +246,7 @@
 				AE4ACA8DD1F96BF699DB84C3 /* ALPHA_README.md */,
 				AF8E819340759100DB074CD4 /* README_BOOTSTRAP.md */,
 				B103BD6B19B2767D7BF88F0A /* App */,
+				0A4A9F950C1A4F32965E1011 /* DesignSystem */,
 				4883D0626FEE9C29B53D471D /* Features */,
 				57AE668B589447AA164CAEE2 /* Shared */,
 			);
@@ -274,6 +348,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A4A9F7F0C1A4F32965E1011 /* GBBadge.swift in Sources */,
+				0A4A9F770C1A4F32965E1011 /* GBButtonStyle.swift in Sources */,
+				0A4A9F850C1A4F32965E1011 /* GBCardStyle.swift in Sources */,
+				0A4A9F8B0C1A4F32965E1011 /* GBColor.swift in Sources */,
+				0A4A9F890C1A4F32965E1011 /* GBHeroCard.swift in Sources */,
+				0A4A9F7D0C1A4F32965E1011 /* GBIcon.swift in Sources */,
+				0A4A9F910C1A4F32965E1011 /* GBLayoutContext.swift in Sources */,
+				0A4A9F830C1A4F32965E1011 /* GBMotion.swift in Sources */,
+				0A4A9F810C1A4F32965E1011 /* GBQuestProgress.swift in Sources */,
+				0A4A9F8D0C1A4F32965E1011 /* GBRadius.swift in Sources */,
+				0A4A9F790C1A4F32965E1011 /* GBSectionHeader.swift in Sources */,
+				0A4A9F8F0C1A4F32965E1011 /* GBSpacing.swift in Sources */,
+				0A4A9F870C1A4F32965E1011 /* GBSurface.swift in Sources */,
+				0A4A9F7B0C1A4F32965E1011 /* GBTypography.swift in Sources */,
 				7B4A1D2E3F40516273849506 /* CaptureRootView.swift in Sources */,
 				1F8C2F1A8E2D4A1B9C7D1234 /* DebugNavigationRoute.swift in Sources */,
 				EE2374F1DB13184A06C4BBCA /* AppModel.swift in Sources */,

--- a/GreatsOfBharatha/DesignSystem/Components/GBHeroCard.swift
+++ b/GreatsOfBharatha/DesignSystem/Components/GBHeroCard.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct GBHeroCard: View {
+    let eyebrow: String
+    let title: String
+    let subtitle: String
+    let detail: String
+    let ctaTitle: String
+    var badgeTitle: String?
+    var emphasis: GBEmphasis = .story
+    var progress: Double?
+    var action: (() -> Void)?
+
+    @Environment(\.gbLayoutContext) private var layoutContext
+
+    var body: some View {
+        GBSurface(style: .accented(emphasis), padding: layoutContext.widthClass == .compact ? GBSpacing.medium : GBSpacing.large) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack(alignment: .top, spacing: GBSpacing.small) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                        Text(eyebrow)
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.86))
+                        Text(title)
+                            .font(.system(layoutContext.widthClass == .compact ? .title2 : .largeTitle, design: .rounded, weight: .bold))
+                            .foregroundStyle(GBColor.Content.inverse)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Text(subtitle)
+                            .font(.title3.weight(.semibold))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.96))
+                    }
+
+                    Spacer(minLength: GBSpacing.small)
+
+                    if let badgeTitle {
+                        GBBadge(title: badgeTitle, symbol: heroSymbol, emphasis: emphasis)
+                    }
+                }
+
+                Text(detail)
+                    .font(.body)
+                    .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let progress {
+                    ProgressView(value: progress)
+                        .tint(GBColor.Content.inverse)
+                }
+
+                if let action {
+                    Button(ctaTitle, action: action)
+                        .buttonStyle(.gbSecondary)
+                        .padding(.top, GBSpacing.xxxSmall)
+                } else {
+                    Label(ctaTitle, systemImage: GBIcon.next)
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(GBColor.Content.inverse)
+                        .padding(.top, GBSpacing.xxxSmall)
+                }
+            }
+            .frame(minHeight: layoutContext.heroMinHeight, alignment: .topLeading)
+        }
+    }
+
+    private var heroSymbol: String {
+        switch emphasis {
+        case .story:
+            GBIcon.story
+        case .place:
+            GBIcon.place
+        case .chronicle:
+            GBIcon.chronicle
+        case .neutral:
+            GBIcon.next
+        }
+    }
+}
+
+#Preview("Hero Card") {
+    GBLayoutContextReader { _ in
+        GBHeroCard(
+            eyebrow: "Shivaji Maharaj",
+            title: "Your journey continues",
+            subtitle: "Rajgad becomes the next fort to remember.",
+            detail: "Hear the story, find the fort, and earn a Chronicle reward without extra screen noise.",
+            ctaTitle: "Continue journey",
+            badgeTitle: "Next adventure",
+            emphasis: .story,
+            progress: 0.45
+        )
+        .padding()
+    }
+    .background(GBColor.Background.app)
+}

--- a/GreatsOfBharatha/DesignSystem/Components/GBQuestProgress.swift
+++ b/GreatsOfBharatha/DesignSystem/Components/GBQuestProgress.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct GBQuestProgress: View {
+    struct Step: Identifiable, Equatable {
+        let id: String
+        let title: String
+        let symbol: String
+    }
+
+    let steps: [Step]
+    let currentStepID: String
+
+    @Environment(\.gbLayoutContext) private var layoutContext
+
+    var body: some View {
+        Group {
+            if layoutContext.prefersHorizontalQuestProgress {
+                compactRow
+            } else {
+                regularColumn
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var compactRow: some View {
+        HStack(alignment: .top, spacing: GBSpacing.xxSmall) {
+            ForEach(steps.indices, id: \.self) { index in
+                let step = steps[index]
+
+                HStack(spacing: GBSpacing.xxSmall) {
+                    questStep(step)
+                    if index < steps.index(before: steps.endIndex) {
+                        Capsule()
+                            .fill(connectorColor(for: step))
+                            .frame(height: 4)
+                    }
+                }
+            }
+        }
+    }
+
+    private var regularColumn: some View {
+        VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+            ForEach(steps.indices, id: \.self) { index in
+                let step = steps[index]
+
+                VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                    questStep(step)
+                    if index < steps.index(before: steps.endIndex) {
+                        Rectangle()
+                            .fill(connectorColor(for: step))
+                            .frame(width: 2, height: 18)
+                            .padding(.leading, GBSpacing.small)
+                    }
+                }
+            }
+        }
+    }
+
+    private func questStep(_ step: Step) -> some View {
+        let isCurrent = step.id == currentStepID
+
+        return HStack(spacing: GBSpacing.xxSmall) {
+            Image(systemName: step.symbol)
+                .font(.subheadline.weight(.semibold))
+            Text(step.title)
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .foregroundStyle(isCurrent ? GBColor.Content.primary : GBColor.Content.secondary)
+        .padding(.horizontal, GBSpacing.xSmall)
+        .padding(.vertical, GBSpacing.xxSmall)
+        .frame(maxWidth: layoutContext.prefersHorizontalQuestProgress ? .infinity : nil, alignment: .leading)
+        .background(stepBackground(isCurrent: isCurrent), in: Capsule())
+        .overlay(
+            Capsule()
+                .stroke(isCurrent ? GBColor.accent(for: emphasis(for: step.id)).opacity(0.28) : GBColor.Border.default, lineWidth: 1)
+        )
+        .accessibilityLabel(accessibilityLabel(for: step, isCurrent: isCurrent))
+    }
+
+    private func stepBackground(isCurrent: Bool) -> Color {
+        isCurrent ? GBColor.Background.elevated : GBColor.Background.surface.opacity(0.72)
+    }
+
+    private func connectorColor(for step: Step) -> Color {
+        step.id == currentStepID ? GBColor.accent(for: emphasis(for: step.id)).opacity(0.35) : GBColor.Border.default
+    }
+
+    private func emphasis(for stepID: String) -> GBEmphasis {
+        switch stepID {
+        case "story":
+            .story
+        case "place":
+            .place
+        case "chronicle":
+            .chronicle
+        default:
+            .neutral
+        }
+    }
+
+    private func accessibilityLabel(for step: Step, isCurrent: Bool) -> String {
+        isCurrent ? "\(step.title), current step" : step.title
+    }
+}
+
+extension GBQuestProgress.Step {
+    static let story = GBQuestProgress.Step(id: "story", title: "Story", symbol: GBIcon.story)
+    static let place = GBQuestProgress.Step(id: "place", title: "Find Place", symbol: GBIcon.place)
+    static let chronicle = GBQuestProgress.Step(id: "chronicle", title: "Chronicle", symbol: GBIcon.chronicle)
+}
+
+#Preview("Quest Progress") {
+    GBLayoutContextReader { _ in
+        GBQuestProgress(
+            steps: [.story, .place, .chronicle],
+            currentStepID: "place"
+        )
+        .padding()
+    }
+    .background(GBColor.Background.app)
+}
+

--- a/GreatsOfBharatha/DesignSystem/Components/GBQuestProgress.swift
+++ b/GreatsOfBharatha/DesignSystem/Components/GBQuestProgress.swift
@@ -106,7 +106,6 @@ struct GBQuestProgress: View {
         isCurrent ? "\(step.title), current step" : step.title
     }
 }
-
 extension GBQuestProgress.Step {
     static let story = GBQuestProgress.Step(id: "story", title: "Story", symbol: GBIcon.story)
     static let place = GBQuestProgress.Step(id: "place", title: "Find Place", symbol: GBIcon.place)
@@ -123,4 +122,3 @@ extension GBQuestProgress.Step {
     }
     .background(GBColor.Background.app)
 }
-

--- a/GreatsOfBharatha/DesignSystem/Components/GBSectionHeader.swift
+++ b/GreatsOfBharatha/DesignSystem/Components/GBSectionHeader.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct GBSectionHeader: View {
+    enum Tone {
+        case `default`
+        case inverse
+    }
+
+    let eyebrow: String?
+    let title: String
+    let subtitle: String?
+    let tone: Tone
+    var trailing: AnyView?
+
+    init(
+        eyebrow: String? = nil,
+        title: String,
+        subtitle: String? = nil,
+        tone: Tone = .default,
+        trailing: AnyView? = nil
+    ) {
+        self.eyebrow = eyebrow
+        self.title = title
+        self.subtitle = subtitle
+        self.tone = tone
+        self.trailing = trailing
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: GBSpacing.small) {
+            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                if let eyebrow {
+                    Text(eyebrow.uppercased())
+                        .gbCaption()
+                        .foregroundStyle(secondaryColor)
+                }
+
+                Text(title)
+                    .gbTitle()
+                    .foregroundStyle(primaryColor)
+
+                if let subtitle {
+                    Text(subtitle)
+                        .gbBody()
+                        .foregroundStyle(secondaryColor)
+                }
+            }
+
+            Spacer(minLength: GBSpacing.small)
+
+            trailing
+        }
+    }
+
+    private var primaryColor: Color {
+        switch tone {
+        case .default:
+            GBColor.Content.primary
+        case .inverse:
+            GBColor.Content.inverse
+        }
+    }
+
+    private var secondaryColor: Color {
+        switch tone {
+        case .default:
+            GBColor.Content.secondary
+        case .inverse:
+            GBColor.Content.inverse.opacity(0.84)
+        }
+    }
+}
+
+#Preview("Section Header") {
+    GBSectionHeader(
+        eyebrow: "Journey",
+        title: "Fort trail",
+        subtitle: "See how each place fits the story before you open the board.",
+        trailing: AnyView(GBBadge(title: "3 ready", symbol: GBIcon.place, emphasis: .place))
+    )
+    .padding()
+}

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBBadge.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBBadge.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct GBBadge: View {
+    let title: String
+    var symbol: String?
+    var emphasis: GBEmphasis = .neutral
+
+    var body: some View {
+        Label {
+            Text(title)
+        } icon: {
+            if let symbol {
+                Image(systemName: symbol)
+            }
+        }
+        .font(.caption.weight(.semibold))
+        .lineLimit(1)
+        .padding(.horizontal, GBSpacing.xSmall)
+        .padding(.vertical, GBSpacing.xxSmall)
+        .background(background, in: Capsule())
+        .foregroundStyle(foreground)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var background: Color {
+        switch emphasis {
+        case .story:
+            GBColor.Accent.story.opacity(0.16)
+        case .place:
+            GBColor.Accent.place.opacity(0.16)
+        case .chronicle:
+            GBColor.Accent.chronicle.opacity(0.16)
+        case .neutral:
+            GBColor.Background.elevated
+        }
+    }
+
+    private var foreground: Color {
+        switch emphasis {
+        case .story:
+            GBColor.Accent.story
+        case .place:
+            GBColor.Accent.place
+        case .chronicle:
+            GBColor.Accent.chronicle
+        case .neutral:
+            GBColor.Content.secondary
+        }
+    }
+}
+
+#Preview("Badge") {
+    HStack(spacing: GBSpacing.xxSmall) {
+        GBBadge(title: "Story", symbol: GBIcon.story, emphasis: .story)
+        GBBadge(title: "Find Place", symbol: GBIcon.place, emphasis: .place)
+        GBBadge(title: "Chronicle", symbol: GBIcon.chronicle, emphasis: .chronicle)
+    }
+    .padding()
+    .background(GBColor.Background.app)
+}
+

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBBadge.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBBadge.swift
@@ -48,7 +48,6 @@ struct GBBadge: View {
         }
     }
 }
-
 #Preview("Badge") {
     HStack(spacing: GBSpacing.xxSmall) {
         GBBadge(title: "Story", symbol: GBIcon.story, emphasis: .story)
@@ -58,4 +57,3 @@ struct GBBadge: View {
     .padding()
     .background(GBColor.Background.app)
 }
-

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBButtonStyle.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBButtonStyle.swift
@@ -24,13 +24,12 @@ struct GBButtonStyle: ButtonStyle {
             .animation(GBMotion.quick, value: configuration.isPressed)
     }
 
-    @ViewBuilder
-    private func background(configuration: Configuration) -> some ShapeStyle {
+    private func background(configuration: Configuration) -> AnyShapeStyle {
         switch kind {
         case .primary(let emphasis):
-            GBColor.gradient(for: emphasis)
+            AnyShapeStyle(GBColor.gradient(for: emphasis))
         case .secondary:
-            GBColor.Background.elevated.opacity(configuration.isPressed ? 0.88 : 1)
+            AnyShapeStyle(GBColor.Background.elevated.opacity(configuration.isPressed ? 0.88 : 1))
         }
     }
 

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBButtonStyle.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBButtonStyle.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct GBButtonStyle: ButtonStyle {
+    enum Kind {
+        case primary(GBEmphasis)
+        case secondary
+    }
+
+    let kind: Kind
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline.weight(.semibold))
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, GBSpacing.small)
+            .padding(.vertical, GBSpacing.small)
+            .background(background(configuration: configuration), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous)
+                    .stroke(borderColor, lineWidth: showsBorder ? 1 : 0)
+            )
+            .foregroundStyle(foregroundColor)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+            .animation(GBMotion.quick, value: configuration.isPressed)
+    }
+
+    @ViewBuilder
+    private func background(configuration: Configuration) -> some ShapeStyle {
+        switch kind {
+        case .primary(let emphasis):
+            GBColor.gradient(for: emphasis)
+        case .secondary:
+            GBColor.Background.elevated.opacity(configuration.isPressed ? 0.88 : 1)
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch kind {
+        case .primary:
+            GBColor.Content.inverse
+        case .secondary:
+            GBColor.Content.primary
+        }
+    }
+
+    private var borderColor: Color {
+        GBColor.Border.emphasis
+    }
+
+    private var showsBorder: Bool {
+        switch kind {
+        case .primary:
+            false
+        case .secondary:
+            true
+        }
+    }
+}
+
+extension ButtonStyle where Self == GBButtonStyle {
+    static func gbPrimary(_ emphasis: GBEmphasis = .story) -> GBButtonStyle {
+        GBButtonStyle(kind: .primary(emphasis))
+    }
+
+    static var gbSecondary: GBButtonStyle {
+        GBButtonStyle(kind: .secondary)
+    }
+}

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBCardStyle.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBCardStyle.swift
@@ -9,10 +9,8 @@ struct GBCardStyle: ViewModifier {
         }
     }
 }
-
 extension View {
     func gbCardStyle(_ emphasis: GBEmphasis = .neutral) -> some View {
         modifier(GBCardStyle(emphasis: emphasis))
     }
 }
-

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBCardStyle.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBCardStyle.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct GBCardStyle: ViewModifier {
+    let emphasis: GBEmphasis
+
+    func body(content: Content) -> some View {
+        GBSurface(style: emphasis == .neutral ? .plain : .accented(emphasis)) {
+            content
+        }
+    }
+}
+
+extension View {
+    func gbCardStyle(_ emphasis: GBEmphasis = .neutral) -> some View {
+        modifier(GBCardStyle(emphasis: emphasis))
+    }
+}
+

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBLayoutContext.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBLayoutContext.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct GBLayoutContext: Equatable {
+    enum WidthClass: Equatable {
+        case compact
+        case regular
+    }
+
+    let widthClass: WidthClass
+    let containerPadding: CGFloat
+    let sectionSpacing: CGFloat
+    let cardSpacing: CGFloat
+    let maxContentWidth: CGFloat?
+
+    var prefersHorizontalQuestProgress: Bool {
+        widthClass == .compact
+    }
+
+    var heroMinHeight: CGFloat {
+        widthClass == .compact ? 220 : 260
+    }
+
+    static let compact = GBLayoutContext(
+        widthClass: .compact,
+        containerPadding: GBSpacing.small,
+        sectionSpacing: GBSpacing.medium,
+        cardSpacing: GBSpacing.small,
+        maxContentWidth: nil
+    )
+
+    static let regular = GBLayoutContext(
+        widthClass: .regular,
+        containerPadding: GBSpacing.large,
+        sectionSpacing: GBSpacing.large,
+        cardSpacing: GBSpacing.medium,
+        maxContentWidth: 920
+    )
+}
+
+private struct GBLayoutContextKey: EnvironmentKey {
+    static let defaultValue: GBLayoutContext = .compact
+}
+
+extension EnvironmentValues {
+    var gbLayoutContext: GBLayoutContext {
+        get { self[GBLayoutContextKey.self] }
+        set { self[GBLayoutContextKey.self] = newValue }
+    }
+}
+
+struct GBLayoutContextReader<Content: View>: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    private let content: (GBLayoutContext) -> Content
+
+    init(@ViewBuilder content: @escaping (GBLayoutContext) -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        let context = horizontalSizeClass == .regular ? GBLayoutContext.regular : GBLayoutContext.compact
+
+        content(context)
+            .environment(\.gbLayoutContext, context)
+    }
+}
+

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBLayoutContext.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBLayoutContext.swift
@@ -36,7 +36,6 @@ struct GBLayoutContext: Equatable {
         maxContentWidth: 920
     )
 }
-
 private struct GBLayoutContextKey: EnvironmentKey {
     static let defaultValue: GBLayoutContext = .compact
 }
@@ -64,4 +63,3 @@ struct GBLayoutContextReader<Content: View>: View {
             .environment(\.gbLayoutContext, context)
     }
 }
-

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBSurface.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBSurface.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct GBSurface<Content: View>: View {
+    enum Style {
+        case plain
+        case elevated
+        case accented(GBEmphasis)
+    }
+
+    private let style: Style
+    private let padding: CGFloat
+    private let content: Content
+
+    init(
+        style: Style = .plain,
+        padding: CGFloat = GBSpacing.medium,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.style = style
+        self.padding = padding
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(padding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(backgroundStyle, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(borderColor, lineWidth: 1)
+            )
+    }
+
+    private var cornerRadius: CGFloat {
+        switch style {
+        case .accented:
+            GBRadius.hero
+        case .plain, .elevated:
+            GBRadius.card
+        }
+    }
+
+    @ViewBuilder
+    private var backgroundStyle: some ShapeStyle {
+        switch style {
+        case .plain:
+            GBColor.Background.surface
+        case .elevated:
+            GBColor.Background.elevated
+        case .accented(let emphasis):
+            GBColor.gradient(for: emphasis)
+        }
+    }
+
+    private var borderColor: Color {
+        switch style {
+        case .accented:
+            .white.opacity(0.12)
+        case .plain, .elevated:
+            GBColor.Border.default
+        }
+    }
+}
+
+#Preview("Surface") {
+    GBSurface(style: .elevated) {
+        VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+            Text("Surface").gbTitle()
+            Text("Shared container treatment for cards and grouped sections.").gbBody()
+        }
+    }
+    .padding()
+    .background(GBColor.Background.app)
+}
+

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBSurface.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBSurface.swift
@@ -41,15 +41,14 @@ struct GBSurface<Content: View>: View {
         }
     }
 
-    @ViewBuilder
-    private var backgroundStyle: some ShapeStyle {
+    private var backgroundStyle: AnyShapeStyle {
         switch style {
         case .plain:
-            GBColor.Background.surface
+            AnyShapeStyle(GBColor.Background.surface)
         case .elevated:
-            GBColor.Background.elevated
+            AnyShapeStyle(GBColor.Background.elevated)
         case .accented(let emphasis):
-            GBColor.gradient(for: emphasis)
+            AnyShapeStyle(GBColor.gradient(for: emphasis))
         }
     }
 

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBSurface.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBSurface.swift
@@ -62,7 +62,6 @@ struct GBSurface<Content: View>: View {
         }
     }
 }
-
 #Preview("Surface") {
     GBSurface(style: .elevated) {
         VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
@@ -73,4 +72,3 @@ struct GBSurface<Content: View>: View {
     .padding()
     .background(GBColor.Background.app)
 }
-

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBColor.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBColor.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+enum GBEmphasis: CaseIterable {
+    case story
+    case place
+    case chronicle
+    case neutral
+}
+
+enum GBColor {
+    enum Background {
+        static let app = Color(uiColor: .systemGroupedBackground)
+        static let surface = Color(uiColor: .secondarySystemGroupedBackground)
+        static let elevated = Color(uiColor: .tertiarySystemBackground)
+        static let heroWarmStart = Color(red: 0.86, green: 0.41, blue: 0.16)
+        static let heroWarmEnd = Color(red: 0.95, green: 0.73, blue: 0.27)
+        static let heroCoolStart = Color(red: 0.20, green: 0.44, blue: 0.70)
+        static let heroCoolEnd = Color(red: 0.34, green: 0.64, blue: 0.80)
+        static let chronicleStart = Color(red: 0.35, green: 0.28, blue: 0.56)
+        static let chronicleEnd = Color(red: 0.62, green: 0.50, blue: 0.25)
+    }
+
+    enum Content {
+        static let primary = Color.primary
+        static let secondary = Color.secondary
+        static let tertiary = Color(uiColor: .tertiaryLabel)
+        static let inverse = Color.white
+    }
+
+    enum Accent {
+        static let story = Color.orange
+        static let place = Color.blue
+        static let chronicle = Color(red: 0.56, green: 0.42, blue: 0.19)
+        static let success = Color.green
+        static let warning = Color.yellow
+    }
+
+    enum Border {
+        static let `default` = Color.primary.opacity(0.08)
+        static let emphasis = Color.primary.opacity(0.16)
+    }
+
+    enum State {
+        static let locked = Color.gray
+    }
+
+    static func gradient(for emphasis: GBEmphasis) -> LinearGradient {
+        switch emphasis {
+        case .story:
+            LinearGradient(
+                colors: [Background.heroWarmStart, Background.heroWarmEnd],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        case .place:
+            LinearGradient(
+                colors: [Background.heroCoolStart, Background.heroCoolEnd],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        case .chronicle:
+            LinearGradient(
+                colors: [Background.chronicleStart, Background.chronicleEnd],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        case .neutral:
+            LinearGradient(
+                colors: [Background.surface, Background.elevated],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        }
+    }
+
+    static func accent(for emphasis: GBEmphasis) -> Color {
+        switch emphasis {
+        case .story:
+            Accent.story
+        case .place:
+            Accent.place
+        case .chronicle:
+            Accent.chronicle
+        case .neutral:
+            Content.secondary
+        }
+    }
+}
+

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBColor.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBColor.swift
@@ -6,7 +6,6 @@ enum GBEmphasis: CaseIterable {
     case chronicle
     case neutral
 }
-
 enum GBColor {
     enum Background {
         static let app = Color(uiColor: .systemGroupedBackground)
@@ -86,4 +85,3 @@ enum GBColor {
         }
     }
 }
-

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBIcon.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBIcon.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+enum GBIcon {
+    static let story = "book.closed.fill"
+    static let place = "map.fill"
+    static let chronicle = "book.pages.fill"
+    static let success = "checkmark.seal.fill"
+    static let locked = "lock.fill"
+    static let next = "arrow.right.circle.fill"
+    static let reward = "sparkles"
+    static let timeline = "clock.arrow.circlepath"
+    static let region = "location.north.line.fill"
+    static let fort = "flag.fill"
+}
+

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBIcon.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBIcon.swift
@@ -12,4 +12,3 @@ enum GBIcon {
     static let region = "location.north.line.fill"
     static let fort = "flag.fill"
 }
-

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBMotion.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBMotion.swift
@@ -5,4 +5,3 @@ enum GBMotion {
     static let standard = Animation.easeInOut(duration: 0.28)
     static let emphasized = Animation.spring(response: 0.38, dampingFraction: 0.82)
 }
-

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBMotion.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBMotion.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+enum GBMotion {
+    static let quick = Animation.easeOut(duration: 0.18)
+    static let standard = Animation.easeInOut(duration: 0.28)
+    static let emphasized = Animation.spring(response: 0.38, dampingFraction: 0.82)
+}
+

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBRadius.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBRadius.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+enum GBRadius {
+    static let control: CGFloat = 14
+    static let badge: CGFloat = 16
+    static let card: CGFloat = 24
+    static let hero: CGFloat = 30
+}
+

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBRadius.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBRadius.swift
@@ -6,4 +6,3 @@ enum GBRadius {
     static let card: CGFloat = 24
     static let hero: CGFloat = 30
 }
-

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBSpacing.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBSpacing.swift
@@ -10,4 +10,3 @@ enum GBSpacing {
     static let xLarge: CGFloat = 32
     static let xxLarge: CGFloat = 40
 }
-

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBSpacing.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBSpacing.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+enum GBSpacing {
+    static let xxxSmall: CGFloat = 4
+    static let xxSmall: CGFloat = 8
+    static let xSmall: CGFloat = 12
+    static let small: CGFloat = 16
+    static let medium: CGFloat = 20
+    static let large: CGFloat = 24
+    static let xLarge: CGFloat = 32
+    static let xxLarge: CGFloat = 40
+}
+

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBTypography.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBTypography.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+enum GBTypography {
+    static func display(_ text: Text) -> some View {
+        text
+            .font(.system(.largeTitle, design: .rounded, weight: .bold))
+            .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+    }
+
+    static func title(_ text: Text) -> some View {
+        text
+            .font(.system(.title3, design: .rounded, weight: .bold))
+            .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+    }
+
+    static func headline(_ text: Text) -> some View {
+        text
+            .font(.headline.weight(.semibold))
+            .dynamicTypeSize(...DynamicTypeSize.accessibility3)
+    }
+
+    static func body(_ text: Text) -> some View {
+        text
+            .font(.body)
+            .dynamicTypeSize(...DynamicTypeSize.accessibility3)
+    }
+
+    static func caption(_ text: Text) -> some View {
+        text
+            .font(.caption.weight(.semibold))
+            .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+    }
+}
+
+extension Text {
+    func gbDisplay() -> some View { GBTypography.display(self) }
+    func gbTitle() -> some View { GBTypography.title(self) }
+    func gbHeadline() -> some View { GBTypography.headline(self) }
+    func gbBody() -> some View { GBTypography.body(self) }
+    func gbCaption() -> some View { GBTypography.caption(self) }
+}
+

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBTypography.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBTypography.swift
@@ -31,7 +31,6 @@ enum GBTypography {
             .dynamicTypeSize(...DynamicTypeSize.accessibility2)
     }
 }
-
 extension Text {
     func gbDisplay() -> some View { GBTypography.display(self) }
     func gbTitle() -> some View { GBTypography.title(self) }
@@ -39,4 +38,3 @@ extension Text {
     func gbBody() -> some View { GBTypography.body(self) }
     func gbCaption() -> some View { GBTypography.caption(self) }
 }
-

--- a/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
+++ b/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
@@ -21,64 +21,100 @@ struct ChronicleView: View {
     }
 
     var body: some View {
-        List {
-            if let highlightedReward {
-                Section("New Chronicle reward") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text(highlightedReward.title)
-                            .font(.headline)
-                        Text(highlightedReward.meaning)
-                            .font(.body)
-                        if celebratedRewardIDs.contains(highlightedReward.id) {
-                            Label("Added to your Chronicle", systemImage: "checkmark.seal.fill")
-                                .font(.subheadline)
-                                .foregroundStyle(.green)
-                        } else {
-                            Button {
-                                celebratedRewardIDs.insert(highlightedReward.id)
-                                LessonFeedback.fire(.celebration)
-                            } label: {
-                                Label("Collect reward", systemImage: "sparkles")
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.borderedProminent)
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    heroCard
+
+                    GBSurface(style: .elevated) {
+                        VStack(alignment: .leading, spacing: GBSpacing.small) {
+                            GBSectionHeader(
+                                eyebrow: "Quest",
+                                title: "Keep the meaning, not just the completion",
+                                subtitle: "The Chronicle is where each learned moment becomes a keepsake."
+                            )
+
+                            GBQuestProgress(
+                                steps: [.story, .place, .chronicle],
+                                currentStepID: "chronicle"
+                            )
                         }
                     }
-                    .padding(.vertical, 6)
-                }
-            }
 
-            Section {
-                Text("Meaning-bearing rewards for story progress, not anxiety-heavy grades.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
+                    if let highlightedReward {
+                        HighlightRewardCard(
+                            reward: highlightedReward,
+                            collected: celebratedRewardIDs.contains(highlightedReward.id)
+                        ) {
+                            celebratedRewardIDs.insert(highlightedReward.id)
+                            LessonFeedback.fire(.celebration)
+                        }
+                    }
 
-            Section("Unlocked rewards") {
-                if unlockedRewards.isEmpty {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Finish a lesson scene to place its meaning into the Royal Chronicle.")
+                    GBSurface(style: .elevated) {
+                        Text("Meaning-bearing rewards for story progress, not anxiety-heavy grades.")
                             .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                        Text(debugMasterySummary)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(GBColor.Content.secondary)
                     }
-                    .padding(.vertical, 8)
-                } else {
-                    ForEach(unlockedRewards) { reward in
-                        rewardRow(reward, unlocked: true)
-                    }
-                }
-            }
 
-            Section("Still to unlock") {
-                ForEach(lockedRewards) { reward in
-                    rewardRow(reward, unlocked: false)
+                    VStack(alignment: .leading, spacing: context.cardSpacing) {
+                        GBSectionHeader(
+                            eyebrow: "Unlocked",
+                            title: "Rewards already in your Chronicle",
+                            subtitle: unlockedRewards.isEmpty ? "Finish a lesson scene to place its meaning into the Royal Chronicle." : "Each reward should remind the child what was learned."
+                        )
+
+                        if unlockedRewards.isEmpty {
+                            EmptyChronicleCard(debugMasterySummary: debugMasterySummary)
+                        } else {
+                            ForEach(unlockedRewards) { reward in
+                                RewardCard(
+                                    reward: reward,
+                                    unlocked: true,
+                                    isHighlighted: highlightRewardID == reward.id,
+                                    isCollected: celebratedRewardIDs.contains(reward.id)
+                                )
+                            }
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: context.cardSpacing) {
+                        GBSectionHeader(
+                            eyebrow: "Locked",
+                            title: "Still to unlock",
+                            subtitle: "These rewards stay hidden until their linked lesson scene is complete."
+                        )
+
+                        ForEach(lockedRewards) { reward in
+                            RewardCard(
+                                reward: reward,
+                                unlocked: false,
+                                isHighlighted: false,
+                                isCollected: false
+                            )
+                        }
+                    }
                 }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
             }
+            .background(GBColor.Background.app)
         }
         .navigationTitle("Royal Chronicle")
+    }
+
+    private var heroCard: some View {
+        GBHeroCard(
+            eyebrow: "Royal Chronicle",
+            title: unlockedRewards.isEmpty ? "Your keepsakes will appear here" : "Your Shivaji keepsakes are growing",
+            subtitle: appModel.lessonStore.chronicleHeadline,
+            detail: "Chronicle rewards should feel ceremonial and specific, tying story progress back to forts, memory, and meaning.",
+            ctaTitle: "\(unlockedRewards.count) unlocked",
+            badgeTitle: "\(rewards.count) total",
+            emphasis: .chronicle,
+            progress: rewards.isEmpty ? nil : Double(unlockedRewards.count) / Double(rewards.count)
+        )
     }
 
     private var debugMasterySummary: String {
@@ -86,37 +122,95 @@ struct ChronicleView: View {
         let scene2 = appModel.lessonStore.mastery(for: "scene-2-torna-rajgad")?.rawValue ?? "nil"
         return "Debug mastery: \(scene1) / \(scene2)"
     }
+}
 
-    @ViewBuilder
-    private func rewardRow(_ reward: ChronicleReward, unlocked: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(reward.title)
-                    .font(.headline)
-                if highlightRewardID == reward.id {
-                    Text(celebratedRewardIDs.contains(reward.id) ? "COLLECTED" : "NEW")
-                        .font(.caption2.bold())
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 4)
-                        .background((celebratedRewardIDs.contains(reward.id) ? Color.green.opacity(0.18) : Color.orange.opacity(0.18)), in: Capsule())
-                        .foregroundStyle(celebratedRewardIDs.contains(reward.id) ? .green : .orange)
+private struct HighlightRewardCard: View {
+    let reward: ChronicleReward
+    let collected: Bool
+    let onCollect: () -> Void
+
+    var body: some View {
+        GBSurface(style: .accented(.chronicle)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "New Reward",
+                    title: reward.title,
+                    subtitle: reward.meaning,
+                    tone: .inverse,
+                    trailing: AnyView(GBBadge(title: collected ? "Collected" : "New", symbol: collected ? GBIcon.success : GBIcon.chronicle, emphasis: .chronicle))
+                )
+
+                if collected {
+                    Label("Added to your Chronicle", systemImage: GBIcon.success)
+                        .font(.subheadline)
+                        .foregroundStyle(GBColor.Content.inverse)
+                } else {
+                    Button {
+                        onCollect()
+                    } label: {
+                        Label("Collect reward", systemImage: GBIcon.reward)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.gbSecondary)
                 }
-                Spacer()
-                Text(reward.category.rawValue)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
-
-            Text(reward.subtitle)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-            Text(unlocked ? reward.meaning : "Complete the linked lesson scene to reveal this Chronicle reward.")
-                .font(.body)
-            Label(reward.mastery.rawValue, systemImage: unlocked ? "medal.fill" : "lock.fill")
-                .font(.caption)
-                .foregroundStyle(unlocked ? .orange : .secondary)
         }
-        .padding(.vertical, 6)
-        .background(highlightRewardID == reward.id ? Color.orange.opacity(0.08) : Color.clear)
+    }
+}
+
+private struct EmptyChronicleCard: View {
+    let debugMasterySummary: String
+
+    var body: some View {
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                Text("Finish a lesson scene to place its meaning into the Royal Chronicle.")
+                    .font(.subheadline)
+                    .foregroundStyle(GBColor.Content.secondary)
+                Text(debugMasterySummary)
+                    .font(.caption)
+                    .foregroundStyle(GBColor.Content.secondary)
+            }
+        }
+    }
+}
+
+private struct RewardCard: View {
+    let reward: ChronicleReward
+    let unlocked: Bool
+    let isHighlighted: Bool
+    let isCollected: Bool
+
+    var body: some View {
+        GBSurface(style: isHighlighted ? .elevated : .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack(alignment: .top, spacing: GBSpacing.small) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                        Text(reward.title)
+                            .gbTitle()
+                            .foregroundStyle(GBColor.Content.primary)
+                        Text(reward.subtitle)
+                            .font(.subheadline)
+                            .foregroundStyle(GBColor.Content.secondary)
+                    }
+
+                    Spacer()
+
+                    if isHighlighted {
+                        GBBadge(title: isCollected ? "Collected" : "New", symbol: isCollected ? GBIcon.success : GBIcon.reward, emphasis: .chronicle)
+                    } else {
+                        GBBadge(title: reward.category.rawValue, symbol: unlocked ? GBIcon.chronicle : GBIcon.locked, emphasis: unlocked ? .chronicle : .neutral)
+                    }
+                }
+
+                Text(unlocked ? reward.meaning : "Complete the linked lesson scene to reveal this Chronicle reward.")
+                    .gbBody()
+                    .foregroundStyle(GBColor.Content.primary)
+
+                Label(reward.mastery.rawValue, systemImage: unlocked ? "medal.fill" : GBIcon.locked)
+                    .font(.caption)
+                    .foregroundStyle(unlocked ? GBColor.Accent.chronicle : GBColor.Content.secondary)
+            }
+        }
     }
 }

--- a/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
+++ b/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
@@ -4,60 +4,91 @@ struct LessonHomeView: View {
     @EnvironmentObject private var appModel: AppModel
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                if let nextScene {
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    if let nextScene {
+                        NavigationLink {
+                            SceneLessonView(scene: nextScene)
+                        } label: {
+                            GBHeroCard(
+                                eyebrow: appModel.content.arcTitle,
+                                title: appModel.lessonStore.completedScenes == 0 ? "Hear the story first" : "Your story path is still open",
+                                subtitle: nextScene.title,
+                                detail: "Follow one scene at a time, remember the fort, then add its meaning to your Chronicle.",
+                                ctaTitle: appModel.lessonStore.completedScenes == 0 ? "Start Scene 1" : "Continue journey",
+                                badgeTitle: appModel.lessonStore.completedScenes == appModel.lessonStore.totalScenes ? "Journey complete" : "Next scene",
+                                emphasis: .story,
+                                progress: appModel.lessonStore.overallProgress
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    GBSurface(style: .elevated) {
+                        VStack(alignment: .leading, spacing: GBSpacing.small) {
+                            GBSectionHeader(
+                                eyebrow: "Quest",
+                                title: "Story to fort to Chronicle",
+                                subtitle: "Keep the loop simple: hear a moment, remember its place, and collect the meaning it unlocks."
+                            )
+
+                            GBQuestProgress(
+                                steps: [.story, .place, .chronicle],
+                                currentStepID: "story"
+                            )
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: context.cardSpacing) {
+                        GBSectionHeader(
+                            eyebrow: "Story Path",
+                            title: "Choose a Shivaji Maharaj moment",
+                            subtitle: "Each scene keeps one story beat, one place clue, and one quick recall before the reward."
+                        )
+
+                        ForEach(appModel.content.scenes) { scene in
+                            NavigationLink {
+                                SceneLessonView(scene: scene)
+                            } label: {
+                                SceneRowCard(
+                                    scene: scene,
+                                    mastery: appModel.lessonStore.mastery(for: scene.id),
+                                    isNext: scene.id == appModel.lessonStore.nextSceneID
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
                     NavigationLink {
-                        SceneLessonView(scene: nextScene)
+                        PlacesHubView(places: appModel.content.corePlaces)
                     } label: {
-                        HeroProgressCard(
-                            title: appModel.content.arcTitle,
-                            progress: appModel.lessonStore.overallProgress,
-                            completedScenes: appModel.lessonStore.completedScenes,
-                            totalScenes: appModel.lessonStore.totalScenes,
-                            nextSceneTitle: nextScene.title,
-                            ctaTitle: appModel.lessonStore.completedScenes == 0 ? "Start Scene 1" : "Continue journey"
+                        PlacesLoopCard(
+                            readyCount: appModel.content.corePlaces.filter { appModel.lessonStore.progress(for: $0) != .locked }.count,
+                            totalCount: appModel.content.corePlaces.count
+                        )
+                    }
+                    .buttonStyle(.plain)
+
+                    NavigationLink {
+                        ChronicleView(rewards: appModel.content.rewards)
+                    } label: {
+                        ChronicleTeaserCard(
+                            headline: appModel.lessonStore.chronicleHeadline,
+                            unlockedCount: appModel.lessonStore.unlockedRewards(from: appModel.content.rewards).count,
+                            totalCount: appModel.content.rewards.count
                         )
                     }
                     .buttonStyle(.plain)
                 }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Choose a moment from Shivaji Maharaj's journey.")
-                        .font(.title3.bold())
-                    Text("Short story steps, place clues, and one quick recall help each scene feel easy to finish.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-
-                ForEach(appModel.content.scenes) { scene in
-                    NavigationLink {
-                        SceneLessonView(scene: scene)
-                    } label: {
-                        SceneRowCard(
-                            scene: scene,
-                            mastery: appModel.lessonStore.mastery(for: scene.id),
-                            isNext: scene.id == appModel.lessonStore.nextSceneID
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                NavigationLink {
-                    ChronicleView(rewards: appModel.content.rewards)
-                } label: {
-                    ChronicleTeaserCard(
-                        headline: appModel.lessonStore.chronicleHeadline,
-                        unlockedCount: appModel.lessonStore.unlockedRewards(from: appModel.content.rewards).count,
-                        totalCount: appModel.content.rewards.count
-                    )
-                }
-                .buttonStyle(.plain)
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
             }
-            .padding()
+            .background(GBColor.Background.app)
         }
         .navigationTitle("Greats of Bharatha")
-        .background(Color(uiColor: .systemGroupedBackground))
     }
 
     private var nextScene: StoryScene? {
@@ -68,116 +99,84 @@ struct LessonHomeView: View {
     }
 }
 
-private struct HeroProgressCard: View {
-    let title: String
-    let progress: Double
-    let completedScenes: Int
-    let totalScenes: Int
-    let nextSceneTitle: String
-    let ctaTitle: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack {
-                Text(title)
-                    .font(.headline)
-                    .foregroundStyle(.white.opacity(0.88))
-                Spacer()
-                Text(completedScenes == totalScenes ? "Journey complete" : "Next adventure")
-                    .font(.caption.bold())
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(.white.opacity(0.18), in: Capsule())
-            }
-
-            Text(completedScenes == 0 ? "Begin Shivaji Maharaj's journey." : "Your journey continues.")
-                .font(.title2.bold())
-            Text(nextSceneTitle)
-                .font(.title3.weight(.semibold))
-                .foregroundStyle(.white.opacity(0.96))
-            Text("Explore the story, spot the places, and earn a Chronicle reward.")
-                .font(.subheadline)
-                .foregroundStyle(.white.opacity(0.88))
-
-            ProgressView(value: progress)
-                .tint(.white)
-
-            HStack {
-                Text("\(completedScenes) of \(totalScenes) scenes complete")
-                Spacer()
-                Label(ctaTitle, systemImage: "arrow.right.circle.fill")
-                    .font(.subheadline.bold())
-            }
-            .font(.subheadline)
-            .foregroundStyle(.white)
-        }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            LinearGradient(colors: [.orange.opacity(0.95), .yellow.opacity(0.55)], startPoint: .topLeading, endPoint: .bottomTrailing)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-    }
-}
-
 private struct SceneRowCard: View {
     let scene: StoryScene
     let mastery: MasteryState?
     let isNext: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 12) {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 8) {
-                        Text("Scene \(scene.number)")
-                            .font(.caption.bold())
-                            .foregroundStyle(.secondary)
-                        if isNext {
-                            Text("Up next")
-                                .font(.caption.bold())
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
-                                .background(Color.orange.opacity(0.15), in: Capsule())
-                                .foregroundStyle(.orange)
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack(alignment: .top, spacing: GBSpacing.small) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                        HStack(spacing: GBSpacing.xxSmall) {
+                            GBBadge(title: "Scene \(scene.number)", symbol: GBIcon.story, emphasis: .story)
+                            if isNext {
+                                GBBadge(title: "Up next", symbol: GBIcon.next, emphasis: .story)
+                            }
                         }
+
+                        Text(scene.title)
+                            .gbTitle()
+                            .foregroundStyle(GBColor.Content.primary)
+                            .lineLimit(2)
+
+                        Text(scene.childSafeSummary)
+                            .gbBody()
+                            .foregroundStyle(GBColor.Content.secondary)
+                            .lineLimit(2)
                     }
-                    Text(scene.title)
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-                        .lineLimit(2)
-                    Text(scene.childSafeSummary)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
+
+                    Spacer(minLength: GBSpacing.small)
+
+                    if let mastery {
+                        GBBadge(title: mastery.rawValue, symbol: GBIcon.reward, emphasis: .story)
+                    }
                 }
 
-                Spacer()
-
-                if let mastery {
-                    Text(mastery.rawValue)
-                        .font(.caption.bold())
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(Color.orange.opacity(0.15))
-                        .foregroundStyle(.orange)
-                        .clipShape(Capsule())
+                HStack(spacing: GBSpacing.small) {
+                    Label(scene.timelineMarker, systemImage: GBIcon.timeline)
+                    Spacer()
+                    Label(isNext ? "Start" : "Review", systemImage: GBIcon.next)
+                        .font(.subheadline.weight(.semibold))
                 }
+                .font(.subheadline)
+                .foregroundStyle(GBColor.Content.secondary)
             }
-
-            HStack(spacing: 12) {
-                Label(scene.timelineMarker, systemImage: "clock.arrow.circlepath")
-                Spacer()
-                Label(isNext ? "Start" : "Review", systemImage: "arrow.right")
-                    .font(.subheadline.bold())
-            }
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background)
-        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+}
+
+private struct PlacesLoopCard: View {
+    let readyCount: Int
+    let totalCount: Int
+
+    var body: some View {
+        GBSurface(style: .accented(.place)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack(alignment: .top, spacing: GBSpacing.small) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                        Text("Find the fort next")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.86))
+                        Text("Open the place trail")
+                            .font(.title3.weight(.bold))
+                            .foregroundStyle(GBColor.Content.inverse)
+                        Text("Keep the story connected to real forts so the journey feels spatial, not just sequential.")
+                            .font(.body)
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
+                    }
+
+                    Spacer()
+
+                    GBBadge(title: "\(readyCount) of \(totalCount) ready", symbol: GBIcon.place, emphasis: .place)
+                }
+
+                Label("See the Sahyadri fort path", systemImage: GBIcon.next)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(GBColor.Content.inverse)
+            }
+        }
     }
 }
 
@@ -187,27 +186,26 @@ private struct ChronicleTeaserCard: View {
     let totalCount: Int
 
     var body: some View {
-        HStack(spacing: 14) {
-            Image(systemName: "book.pages.fill")
-                .font(.title2)
-                .foregroundStyle(.orange)
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Royal Chronicle")
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                Text(headline)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                Text("\(unlockedCount) of \(totalCount) rewards unlocked")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        GBSurface(style: .accented(.chronicle)) {
+            HStack(spacing: GBSpacing.small) {
+                VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                    Text("Royal Chronicle")
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(GBColor.Content.inverse)
+                    Text(headline)
+                        .font(.body)
+                        .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
+                    Text("\(unlockedCount) of \(totalCount) rewards unlocked")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
+                }
+
+                Spacer()
+
+                Image(systemName: GBIcon.chronicle)
+                    .font(.title2)
+                    .foregroundStyle(GBColor.Content.inverse)
             }
-            Spacer()
-            Image(systemName: "chevron.right")
-                .foregroundStyle(.tertiary)
         }
-        .padding()
-        .background(.background)
-        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
     }
 }

--- a/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
+++ b/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
@@ -22,9 +22,9 @@ struct SceneLessonView: View {
 
     private var lessonCards: [SceneCardContent] {
         [
-            SceneCardContent(id: "summary", eyebrow: "Story spark", title: scene.title, body: scene.childSafeSummary, symbol: "book.closed.fill"),
+            SceneCardContent(id: "summary", eyebrow: "Story spark", title: scene.title, body: scene.childSafeSummary, symbol: GBIcon.story),
             SceneCardContent(id: "fact", eyebrow: "Remember this", title: scene.keyFact, body: scene.narrativeObjective, symbol: "sparkles.rectangle.stack.fill"),
-            SceneCardContent(id: "timeline", eyebrow: "Chronicle moment", title: scene.timelineMarker, body: "This is the moment you will remember when you open the Royal Chronicle.", symbol: "clock.arrow.circlepath")
+            SceneCardContent(id: "timeline", eyebrow: "Chronicle moment", title: scene.timelineMarker, body: "This is the moment you will remember when you open the Royal Chronicle.", symbol: GBIcon.timeline)
         ]
     }
 
@@ -40,111 +40,89 @@ struct SceneLessonView: View {
         cardIndex == lessonCards.count - 1 ? "Move to place clues" : "Continue story"
     }
 
+    private var activeQuestStepID: String {
+        if recallState.hasAnsweredCorrectly {
+            return "chronicle"
+        }
+        if revealedMapAnchors > 0 || !chosenPlanSteps.isEmpty {
+            return "place"
+        }
+        return "story"
+    }
+
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                SceneHeaderCard(scene: scene, progressValue: progressValue, mastery: appModel.lessonStore.mastery(for: scene.id))
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    SceneHeaderCard(
+                        scene: scene,
+                        progressValue: progressValue,
+                        mastery: appModel.lessonStore.mastery(for: scene.id)
+                    )
 
-                VStack(alignment: .leading, spacing: 12) {
-                    Text(currentStepTitle)
-                        .font(.subheadline.bold())
-                        .foregroundStyle(.orange)
+                    GBSurface(style: .elevated) {
+                        VStack(alignment: .leading, spacing: GBSpacing.small) {
+                            GBSectionHeader(
+                                eyebrow: "Quest",
+                                title: "Hear the story, remember the fort, keep the Chronicle",
+                                subtitle: "This scene only asks for one step at a time."
+                            )
 
-                    TabView(selection: $cardIndex) {
-                        ForEach(Array(lessonCards.enumerated()), id: \.offset) { index, card in
-                            StoryCardView(card: card, accentText: scene.timelineMarker, cardNumber: index + 1, totalCards: lessonCards.count)
-                                .padding(.horizontal, 4)
-                                .tag(index)
-                        }
-                    }
-#if os(iOS)
-                    .tabViewStyle(.page(indexDisplayMode: .never))
-#endif
-                    .frame(height: 340)
-
-                    HStack(spacing: 8) {
-                        ForEach(0..<lessonCards.count, id: \.self) { index in
-                            Capsule()
-                                .fill(index == cardIndex ? Color.orange : Color.orange.opacity(0.18))
-                                .frame(width: index == cardIndex ? 28 : 10, height: 10)
+                            GBQuestProgress(
+                                steps: [.story, .place, .chronicle],
+                                currentStepID: activeQuestStepID
+                            )
                         }
                     }
 
-                    HStack(spacing: 12) {
-                        if cardIndex > 0 {
-                            Button("Back") {
-                                cardIndex = max(cardIndex - 1, 0)
-                                LessonFeedback.fire(.selection)
-                            }
-                            .buttonStyle(.bordered)
-                        }
+                    StoryDeckCard(
+                        currentStepTitle: currentStepTitle,
+                        lessonCards: lessonCards,
+                        cardIndex: $cardIndex,
+                        nextCardButtonTitle: nextCardButtonTitle
+                    )
 
-                        Spacer()
+                    MapAnchorCard(scene: scene, revealedMapAnchors: $revealedMapAnchors)
 
-                        Button(nextCardButtonTitle) {
-                            cardIndex = min(cardIndex + 1, lessonCards.count - 1)
-                            LessonFeedback.fire(.selection)
-                        }
-                        .buttonStyle(.borderedProminent)
-                    }
-                }
-
-                MapAnchorCard(scene: scene, revealedMapAnchors: $revealedMapAnchors)
-
-                if scene.number == 2 {
-                    FortPlanningCard(chosenPlanSteps: $chosenPlanSteps)
-                }
-
-                VStack(alignment: .leading, spacing: 12) {
-                    Button(hintVisible ? "Hide clue" : "Need a clue?") {
-                        hintVisible.toggle()
-                        LessonFeedback.fire(.reveal)
-                    }
-                    .buttonStyle(.bordered)
-
-                    if hintVisible {
-                        GuidanceCard(
-                            title: "Story clue",
-                            message: curatedHint,
-                            systemImage: "lightbulb"
-                        )
+                    if scene.number == 2 {
+                        FortPlanningCard(chosenPlanSteps: $chosenPlanSteps)
                     }
 
-                    if recapVisible, recallState.hasAnsweredCorrectly {
-                        GuidanceCard(
-                            title: "You remembered it",
-                            message: sceneRecap,
-                            systemImage: "text.book.closed"
+                    SceneSupportCard(
+                        hintVisible: $hintVisible,
+                        recapVisible: recapVisible,
+                        hasAnsweredCorrectly: recallState.hasAnsweredCorrectly,
+                        curatedHint: curatedHint,
+                        sceneRecap: sceneRecap
+                    )
+
+                    RecallPanel(
+                        question: scene.recallPrompt,
+                        choices: sceneChoices,
+                        selectedChoiceID: $recallState.selectedChoiceID,
+                        feedbackText: recallState.feedbackText,
+                        completed: recallState.hasAnsweredCorrectly,
+                        onSubmit: submitRecall
+                    )
+
+                    if recallState.hasAnsweredCorrectly {
+                        CompletedSceneActions(
+                            scene: scene,
+                            places: appModel.content.corePlaces,
+                            rewards: appModel.content.rewards
                         )
                     }
                 }
-
-                RecallPanel(
-                    question: scene.recallPrompt,
-                    choices: sceneChoices,
-                    selectedChoiceID: $recallState.selectedChoiceID,
-                    feedbackText: recallState.feedbackText,
-                    completed: recallState.hasAnsweredCorrectly,
-                    onSubmit: submitRecall
-                )
-
-                if recallState.hasAnsweredCorrectly {
-                    NavigationLink {
-                        ChronicleView(rewards: appModel.content.rewards, highlightRewardID: scene.rewardID)
-                    } label: {
-                        Label("Open your Royal Chronicle reward", systemImage: "book.closed.fill")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
             }
-            .padding()
+            .background(GBColor.Background.app)
         }
         .navigationTitle("Scene \(scene.number)")
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
 #endif
-        .background(Color(uiColor: .systemGroupedBackground))
     }
 
     private func submitRecall() {
@@ -209,92 +187,146 @@ private struct SceneHeaderCard: View {
     let mastery: MasteryState?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack {
-                Text(scene.timelineMarker.uppercased())
-                    .font(.caption.bold())
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Text(mastery?.rawValue ?? "Ready to learn")
-                    .font(.caption.bold())
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(Color.orange.opacity(0.12), in: Capsule())
-                    .foregroundStyle(.orange)
-            }
-            Text(scene.title)
-                .font(.title2.bold())
-            Text(scene.narrativeObjective)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-            ProgressView(value: progressValue)
-                .tint(.orange)
-            HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Royal Chronicle reward")
-                        .font(.caption.bold())
-                        .foregroundStyle(.secondary)
-                    Text(scene.rewardID.replacingOccurrences(of: "reward-", with: "").replacingOccurrences(of: "-", with: " ").capitalized)
-                        .font(.subheadline.weight(.semibold))
+        GBSurface(style: .accented(.story)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack(alignment: .top, spacing: GBSpacing.small) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                        Text(scene.timelineMarker.uppercased())
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
+                        Text(scene.title)
+                            .font(.system(.title2, design: .rounded, weight: .bold))
+                            .foregroundStyle(GBColor.Content.inverse)
+                        Text(scene.narrativeObjective)
+                            .font(.body)
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
+                    }
+
+                    Spacer(minLength: GBSpacing.small)
+
+                    GBBadge(
+                        title: mastery?.rawValue ?? "Ready",
+                        symbol: mastery == nil ? GBIcon.story : GBIcon.reward,
+                        emphasis: .story
+                    )
                 }
-                Spacer()
-                Text("Small steps, one clear finish")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+
+                ProgressView(value: progressValue)
+                    .tint(GBColor.Content.inverse)
+
+                HStack(alignment: .firstTextBaseline, spacing: GBSpacing.small) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                        Text("Royal Chronicle reward")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
+                        Text(scene.rewardID.replacingOccurrences(of: "reward-", with: "").replacingOccurrences(of: "-", with: " ").capitalized)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(GBColor.Content.inverse)
+                    }
+
+                    Spacer()
+
+                    Text("Small steps, one clear finish")
+                        .font(.caption)
+                        .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
+                }
             }
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background)
-        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+}
+
+private struct StoryDeckCard: View {
+    let currentStepTitle: String
+    let lessonCards: [SceneCardContent]
+    @Binding var cardIndex: Int
+    let nextCardButtonTitle: String
+
+    var body: some View {
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Story",
+                    title: currentStepTitle,
+                    subtitle: "Keep one memory hook visible before moving to place clues."
+                )
+
+                TabView(selection: $cardIndex) {
+                    ForEach(Array(lessonCards.enumerated()), id: \.offset) { index, card in
+                        StoryCardView(card: card, cardNumber: index + 1, totalCards: lessonCards.count)
+                            .padding(.horizontal, GBSpacing.xxxSmall)
+                            .tag(index)
+                    }
+                }
+#if os(iOS)
+                .tabViewStyle(.page(indexDisplayMode: .never))
+#endif
+                .frame(height: 340)
+
+                HStack(spacing: GBSpacing.xxSmall) {
+                    ForEach(0..<lessonCards.count, id: \.self) { index in
+                        Capsule()
+                            .fill(index == cardIndex ? GBColor.Accent.story : GBColor.Accent.story.opacity(0.18))
+                            .frame(width: index == cardIndex ? 28 : 10, height: 10)
+                    }
+                }
+
+                HStack(spacing: GBSpacing.small) {
+                    if cardIndex > 0 {
+                        Button("Back") {
+                            cardIndex = max(cardIndex - 1, 0)
+                            LessonFeedback.fire(.selection)
+                        }
+                        .buttonStyle(.gbSecondary)
+                    }
+
+                    Button(nextCardButtonTitle) {
+                        cardIndex = min(cardIndex + 1, lessonCards.count - 1)
+                        LessonFeedback.fire(.selection)
+                    }
+                    .buttonStyle(.gbPrimary(.story))
+                }
+            }
+        }
     }
 }
 
 private struct StoryCardView: View {
     let card: SceneCardContent
-    let accentText: String
     let cardNumber: Int
     let totalCards: Int
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                Text(card.eyebrow.uppercased())
-                    .font(.caption.bold())
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Text("\(cardNumber)/\(totalCards)")
-                    .font(.caption.bold())
-                    .foregroundStyle(.orange)
+        GBSurface(style: .elevated, padding: GBSpacing.large) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack {
+                    Text(card.eyebrow.uppercased())
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(GBColor.Content.secondary)
+                    Spacer()
+                    Text("\(cardNumber)/\(totalCards)")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(GBColor.Accent.story)
+                }
+
+                Image(systemName: card.symbol)
+                    .font(.system(size: 36, weight: .semibold))
+                    .foregroundStyle(GBColor.Content.inverse)
+                    .frame(width: 68, height: 68)
+                    .background(GBColor.gradient(for: .story), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
+
+                Text(card.title)
+                    .gbTitle()
+                    .foregroundStyle(GBColor.Content.primary)
+
+                Text(card.body)
+                    .gbBody()
+                    .foregroundStyle(GBColor.Content.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: 0)
             }
-            Image(systemName: card.symbol)
-                .font(.system(size: 42))
-                .foregroundStyle(.white)
-                .frame(width: 72, height: 72)
-                .background(Color.orange.opacity(0.82))
-                .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-            Text(card.title)
-                .font(.title3.bold())
-            Text(card.body)
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
-            Label(accentText, systemImage: "sparkles")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
-        .padding(22)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 28, style: .continuous)
-                .fill(Color(uiColor: .secondarySystemGroupedBackground))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 28, style: .continuous)
-                .stroke(Color.orange.opacity(0.14), lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
     }
 }
 
@@ -303,50 +335,53 @@ private struct MapAnchorCard: View {
     @Binding var revealedMapAnchors: Int
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("Place clues")
-                    .font(.headline)
-                Spacer()
-                Text("\(revealedMapAnchors)/\(scene.mapAnchors.count) found")
-                    .font(.caption.bold())
-                    .foregroundStyle(.secondary)
-            }
-            Text("Reveal the places from this moment one by one.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+        GBSurface(style: .accented(.place)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Find Place",
+                    title: "Reveal the fort clues",
+                    subtitle: "Place names appear one by one so the story stays connected to the map.",
+                    tone: .inverse,
+                    trailing: AnyView(
+                        GBBadge(
+                            title: "\(revealedMapAnchors)/\(scene.mapAnchors.count)",
+                            symbol: GBIcon.place,
+                            emphasis: .place
+                        )
+                    )
+                )
 
-            ForEach(Array(scene.mapAnchors.enumerated()), id: \.offset) { index, anchor in
-                HStack(spacing: 12) {
-                    Image(systemName: index < revealedMapAnchors ? "mappin.circle.fill" : "mappin.circle")
-                        .foregroundStyle(index < revealedMapAnchors ? .orange : .secondary)
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(index < revealedMapAnchors ? anchor : "Hidden place clue")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.primary)
-                        Text(index < revealedMapAnchors ? "This place is now part of your scene map." : "Tap reveal when you are ready for the next clue.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                ForEach(Array(scene.mapAnchors.enumerated()), id: \.offset) { index, anchor in
+                    HStack(alignment: .top, spacing: GBSpacing.small) {
+                        Image(systemName: index < revealedMapAnchors ? "mappin.circle.fill" : "mappin.circle")
+                            .foregroundStyle(GBColor.Content.inverse)
+                            .font(.title3)
+
+                        VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                            Text(index < revealedMapAnchors ? anchor : "Hidden place clue")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(GBColor.Content.inverse)
+                            Text(index < revealedMapAnchors ? "This place now anchors the scene in your memory." : "Reveal the next clue when you are ready.")
+                                .font(.caption)
+                                .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
+                        }
+
+                        Spacer()
                     }
-                    Spacer()
+                    .padding(GBSpacing.small)
+                    .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
                 }
-                .padding()
-                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-            }
 
-            Button(revealedMapAnchors == scene.mapAnchors.count ? "All place clues found" : "Reveal next place clue") {
-                let nextValue = min(revealedMapAnchors + 1, scene.mapAnchors.count)
-                if nextValue != revealedMapAnchors {
-                    revealedMapAnchors = nextValue
-                    LessonFeedback.fire(nextValue == scene.mapAnchors.count ? .success : .reveal)
+                Button(revealedMapAnchors == scene.mapAnchors.count ? "All place clues found" : "Reveal next place clue") {
+                    let nextValue = min(revealedMapAnchors + 1, scene.mapAnchors.count)
+                    if nextValue != revealedMapAnchors {
+                        revealedMapAnchors = nextValue
+                        LessonFeedback.fire(nextValue == scene.mapAnchors.count ? .success : .reveal)
+                    }
                 }
+                .buttonStyle(.gbSecondary)
             }
-            .buttonStyle(.borderedProminent)
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background)
-        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
     }
 }
 
@@ -354,44 +389,85 @@ private struct FortPlanningCard: View {
     @Binding var chosenPlanSteps: Set<String>
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Planning practice")
-                .font(.headline)
-            Text("Pick two smart fort choices to prepare a mountain base.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Place Practice",
+                    title: "Choose smart fort planning steps",
+                    subtitle: "Pick two choices that would help a mountain base stay ready."
+                )
 
-            ForEach(LessonPlanStep.starterSet) { step in
-                Button {
-                    if chosenPlanSteps.contains(step.id) {
-                        chosenPlanSteps.remove(step.id)
-                    } else {
-                        chosenPlanSteps.insert(step.id)
-                    }
-                    LessonFeedback.fire(.selection)
-                } label: {
-                    HStack(spacing: 12) {
-                        Image(systemName: chosenPlanSteps.contains(step.id) ? "checkmark.circle.fill" : step.symbol)
-                            .foregroundStyle(chosenPlanSteps.contains(step.id) ? .green : .orange)
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(step.title)
-                                .foregroundStyle(.primary)
-                            Text(step.detail)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                ForEach(LessonPlanStep.starterSet) { step in
+                    Button {
+                        if chosenPlanSteps.contains(step.id) {
+                            chosenPlanSteps.remove(step.id)
+                        } else {
+                            chosenPlanSteps.insert(step.id)
                         }
-                        Spacer()
+                        LessonFeedback.fire(.selection)
+                    } label: {
+                        HStack(spacing: GBSpacing.small) {
+                            Image(systemName: chosenPlanSteps.contains(step.id) ? GBIcon.success : step.symbol)
+                                .foregroundStyle(chosenPlanSteps.contains(step.id) ? GBColor.Accent.success : GBColor.Accent.place)
+                            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                                Text(step.title)
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(GBColor.Content.primary)
+                                Text(step.detail)
+                                    .font(.caption)
+                                    .foregroundStyle(GBColor.Content.secondary)
+                            }
+                            Spacer()
+                        }
+                        .padding(GBSpacing.small)
+                        .background(GBColor.Background.elevated, in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
                     }
-                    .padding()
-                    .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
             }
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background)
-        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+}
+
+private struct SceneSupportCard: View {
+    @Binding var hintVisible: Bool
+    let recapVisible: Bool
+    let hasAnsweredCorrectly: Bool
+    let curatedHint: String
+    let sceneRecap: String
+
+    var body: some View {
+        GBSurface(style: .elevated) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Help",
+                    title: "Use one clue if you need it",
+                    subtitle: "Hints stay optional so the main task remains clear."
+                )
+
+                Button(hintVisible ? "Hide clue" : "Need a clue?") {
+                    hintVisible.toggle()
+                    LessonFeedback.fire(.reveal)
+                }
+                .buttonStyle(.gbSecondary)
+
+                if hintVisible {
+                    GuidanceCard(
+                        title: "Story clue",
+                        message: curatedHint,
+                        systemImage: "lightbulb"
+                    )
+                }
+
+                if recapVisible, hasAnsweredCorrectly {
+                    GuidanceCard(
+                        title: "You remembered it",
+                        message: sceneRecap,
+                        systemImage: "text.book.closed"
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -401,21 +477,20 @@ private struct GuidanceCard: View {
     let systemImage: String
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: systemImage)
-                .foregroundStyle(.orange)
-            VStack(alignment: .leading, spacing: 6) {
-                Text(title)
-                    .font(.subheadline.bold())
-                Text(message)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+        GBSurface(style: .plain, padding: GBSpacing.small) {
+            HStack(alignment: .top, spacing: GBSpacing.small) {
+                Image(systemName: systemImage)
+                    .foregroundStyle(GBColor.Accent.story)
+                VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                    Text(title)
+                        .font(.subheadline.weight(.bold))
+                    Text(message)
+                        .font(.subheadline)
+                        .foregroundStyle(GBColor.Content.secondary)
+                }
+                Spacer()
             }
-            Spacer()
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 }
 
@@ -428,59 +503,96 @@ private struct RecallPanel: View {
     let onSubmit: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Quick recall")
-                .font(.headline)
-            Text("One last check before you collect your Chronicle reward.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-            Text(question.question)
-                .font(.body)
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Chronicle Gate",
+                    title: "One quick recall before the reward",
+                    subtitle: "Choose the place that matches the key fact from this scene."
+                )
 
-            ForEach(choices) { choice in
-                let isSelected = selectedChoiceID == choice.id
-                Button {
-                    selectedChoiceID = choice.id
-                    LessonFeedback.fire(.selection)
-                } label: {
-                    HStack(alignment: .top, spacing: 12) {
-                        Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
-                            .foregroundStyle(isSelected ? .orange : .secondary)
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(choice.title)
-                                .foregroundStyle(.primary)
-                            Text(choice.detail)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                Text(question.question)
+                    .gbBody()
+                    .foregroundStyle(GBColor.Content.primary)
+
+                ForEach(choices) { choice in
+                    let isSelected = selectedChoiceID == choice.id
+                    Button {
+                        selectedChoiceID = choice.id
+                        LessonFeedback.fire(.selection)
+                    } label: {
+                        HStack(alignment: .top, spacing: GBSpacing.small) {
+                            Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                                .foregroundStyle(isSelected ? GBColor.Accent.story : GBColor.Content.secondary)
+                            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                                Text(choice.title)
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(GBColor.Content.primary)
+                                Text(choice.detail)
+                                    .font(.caption)
+                                    .foregroundStyle(GBColor.Content.secondary)
+                            }
+                            Spacer()
                         }
-                        Spacer()
+                        .padding(GBSpacing.small)
+                        .background(
+                            isSelected ? GBColor.Accent.story.opacity(0.10) : GBColor.Background.elevated,
+                            in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous)
+                        )
                     }
-                    .padding()
-                    .background(Color.secondary.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
-            }
 
-            Button(completed ? "Answer checked" : "Collect my answer") {
-                onSubmit()
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(selectedChoiceID == nil || completed)
+                Button(completed ? "Answer checked" : "Collect my answer") {
+                    onSubmit()
+                }
+                .buttonStyle(.gbPrimary(.chronicle))
+                .disabled(selectedChoiceID == nil || completed)
 
-            if let feedbackText {
-                Text(feedbackText)
-                    .font(.subheadline)
-                    .foregroundStyle(completed ? .green : .secondary)
-                    .padding()
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(completed ? Color.green.opacity(0.12) : Color.orange.opacity(0.12))
-                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                if let feedbackText {
+                    GBSurface(style: .elevated, padding: GBSpacing.small) {
+                        Text(feedbackText)
+                            .font(.subheadline)
+                            .foregroundStyle(completed ? GBColor.Accent.success : GBColor.Content.secondary)
+                    }
+                }
             }
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background)
-        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+}
+
+private struct CompletedSceneActions: View {
+    let scene: StoryScene
+    let places: [Place]
+    let rewards: [ChronicleReward]
+
+    var body: some View {
+        GBSurface(style: .accented(.chronicle)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Complete",
+                    title: "The scene is ready to keep",
+                    subtitle: "Open the Royal Chronicle reward or revisit the fort trail while the memory is fresh.",
+                    tone: .inverse,
+                    trailing: AnyView(GBBadge(title: "Reward ready", symbol: GBIcon.chronicle, emphasis: .chronicle))
+                )
+
+                NavigationLink {
+                    ChronicleView(rewards: rewards, highlightRewardID: scene.rewardID)
+                } label: {
+                    Label("Open your Royal Chronicle reward", systemImage: GBIcon.chronicle)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.gbSecondary)
+
+                NavigationLink {
+                    PlacesHubView(places: places)
+                } label: {
+                    Label("Review the fort trail", systemImage: GBIcon.place)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.gbSecondary)
+            }
+        }
     }
 }

--- a/GreatsOfBharatha/Features/Map/PlacesHubView.swift
+++ b/GreatsOfBharatha/Features/Map/PlacesHubView.swift
@@ -13,152 +13,149 @@ struct PlacesHubView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                heroCard
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    heroCard
 
-                VStack(alignment: .leading, spacing: 14) {
-                    Text("Fort trail")
-                        .font(.title3.bold())
-                    Text("See how the forts relate to each other, then step into one place at a time.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                    GBSurface(style: .elevated) {
+                        HStack(spacing: GBSpacing.small) {
+                            PlaceSummaryPill(title: "Ready now", value: "\(readyPlaces.count)", emphasis: .place)
+                            PlaceSummaryPill(title: "Collected", value: "\(masteredCount)", emphasis: .chronicle)
+                            PlaceSummaryPill(title: "Core forts", value: "\(places.filter(\.isCoreReleasePlace).count)", emphasis: .neutral)
+                        }
+                    }
 
-                    ForEach(Array(places.enumerated()), id: \.element.id) { index, place in
-                        let progress = appModel.lessonStore.progress(for: place)
-                        Group {
-                            if progress == .locked {
-                                placeTrailCard(place, index: index)
-                            } else {
-                                NavigationLink {
-                                    PlaceDetailView(place: place, progress: progress)
-                                } label: {
-                                    placeTrailCard(place, index: index)
+                    GBSurface(style: .elevated) {
+                        VStack(alignment: .leading, spacing: GBSpacing.small) {
+                            GBSectionHeader(
+                                eyebrow: "Quest",
+                                title: "Hold the story on the fort board",
+                                subtitle: "The place trail is the middle step between a story moment and its Chronicle reward."
+                            )
+
+                            GBQuestProgress(
+                                steps: [.story, .place, .chronicle],
+                                currentStepID: "place"
+                            )
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: context.cardSpacing) {
+                        GBSectionHeader(
+                            eyebrow: "Fort Trail",
+                            title: "Walk the ready forts in order",
+                            subtitle: "Open any ready fort to pin it on the board and compare it with nearby places."
+                        )
+
+                        ForEach(Array(places.enumerated()), id: \.element.id) { index, place in
+                            let progress = appModel.lessonStore.progress(for: place)
+                            Group {
+                                if progress == .locked {
+                                    PlaceTrailCard(place: place, index: index, progress: progress)
+                                } else {
+                                    NavigationLink {
+                                        PlaceDetailView(place: place, progress: progress)
+                                    } label: {
+                                        PlaceTrailCard(place: place, index: index, progress: progress)
+                                    }
+                                    .buttonStyle(.plain)
                                 }
-                                .buttonStyle(.plain)
                             }
                         }
                     }
                 }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
             }
-            .padding()
+            .background(GBColor.Background.app)
         }
         .navigationTitle("Places")
-        .background(Color(uiColor: .systemGroupedBackground))
     }
 
     private var heroCard: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Journey across the forts")
-                        .font(.title2.bold())
-                    Text("Match each fort to its moment so the map starts feeling like a real story world.")
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                Image(systemName: "map.fill")
-                    .font(.title)
-                    .foregroundStyle(.orange)
-            }
-
-            HStack(spacing: 10) {
-                summaryPill(title: "Ready now", value: "\(readyPlaces.count)", tint: .orange)
-                summaryPill(title: "Collected", value: "\(masteredCount)", tint: .green)
-                summaryPill(title: "Core forts", value: "\(places.filter(\.isCoreReleasePlace).count)", tint: .blue)
-            }
-
-            VStack(alignment: .leading, spacing: 10) {
-                Label("Start with a ready fort, spot its place on the Sahyadri board, then compare it with its nearby neighbors.", systemImage: "sparkles")
-                    .font(.subheadline.weight(.medium))
-                Text("Each fort card keeps one memory hook, one big event, and one region clue visible at a glance.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            LinearGradient(
-                colors: [Color.orange.opacity(0.20), Color.blue.opacity(0.12), Color.green.opacity(0.10)],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            ),
-            in: RoundedRectangle(cornerRadius: 28, style: .continuous)
+        GBHeroCard(
+            eyebrow: "Sahyadri Fort Trail",
+            title: "Remember the place, not just the plot",
+            subtitle: "The forts turn the story into a real landscape.",
+            detail: "Pin one fort at a time, compare it with nearby mountains, and keep the geography tied to Shivaji Maharaj's journey.",
+            ctaTitle: "Open a ready fort",
+            badgeTitle: "\(readyPlaces.count) ready now",
+            emphasis: .place,
+            progress: places.isEmpty ? nil : Double(readyPlaces.count) / Double(places.count)
         )
     }
+}
 
-    private func summaryPill(title: String, value: String, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+private struct PlaceSummaryPill: View {
+    let title: String
+    let value: String
+    let emphasis: GBEmphasis
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
             Text(title)
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(GBColor.Content.secondary)
             Text(value)
                 .font(.headline)
-                .foregroundStyle(tint)
+                .foregroundStyle(GBColor.accent(for: emphasis))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .padding(GBSpacing.xSmall)
+        .background(GBColor.Background.surface, in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
     }
+}
 
-    private func placeTrailCard(_ place: Place, index: Int) -> some View {
-        let progress = appModel.lessonStore.progress(for: place)
+private struct PlaceTrailCard: View {
+    let place: Place
+    let index: Int
+    let progress: PlaceProgress
 
-        return VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Stop \(index + 1)")
-                        .font(.caption.bold())
-                        .foregroundStyle(.secondary)
-                    Text(place.name)
-                        .font(.headline)
-                    Text(place.memoryHook)
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(.orange)
+    var body: some View {
+        GBSurface(style: progress == .locked ? .elevated : .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack(alignment: .top, spacing: GBSpacing.small) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                        HStack(spacing: GBSpacing.xxSmall) {
+                            GBBadge(title: "Stop \(index + 1)", symbol: GBIcon.place, emphasis: .place)
+                            if place.isCoreReleasePlace {
+                                GBBadge(title: "Core fort", symbol: GBIcon.fort, emphasis: .neutral)
+                            }
+                        }
+
+                        Text(place.name)
+                            .gbTitle()
+                            .foregroundStyle(GBColor.Content.primary)
+
+                        Text(place.memoryHook)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(GBColor.Accent.place)
+                    }
+
+                    Spacer()
+
+                    GBBadge(title: progress.rawValue, symbol: progressIcon(progress), emphasis: progressEmphasis(progress))
                 }
 
-                Spacer()
+                HStack(spacing: GBSpacing.small) {
+                    Label(place.primaryEvent, systemImage: GBIcon.fort)
+                    Label(place.regionLabel, systemImage: GBIcon.region)
+                }
+                .font(.caption)
+                .foregroundStyle(GBColor.Content.secondary)
 
-                Text(progress.rawValue)
-                    .font(.caption2.weight(.semibold))
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 7)
-                    .background(progressColor(progress).opacity(0.15), in: Capsule())
-                    .foregroundStyle(progressColor(progress))
+                HStack {
+                    Text(progress == .locked ? "Unlock this fort through the story first." : "Open fort board")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(progress == .locked ? GBColor.Content.secondary : GBColor.Content.primary)
+                    Spacer()
+                    Image(systemName: progress == .locked ? GBIcon.locked : GBIcon.next)
+                        .foregroundStyle(progressColor(progress))
+                }
             }
-
-            HStack(spacing: 12) {
-                Label(place.primaryEvent, systemImage: "flag.fill")
-                Label(place.regionLabel, systemImage: "location.north.line.fill")
-            }
-            .font(.caption)
-            .foregroundStyle(.secondary)
-
-            HStack {
-                Text(progress == .locked ? "Unlock this fort through the story first." : "Open fort board")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(progress == .locked ? .secondary : .primary)
-                Spacer()
-                Image(systemName: progress == .locked ? "lock.fill" : "arrow.right.circle.fill")
-                    .foregroundStyle(progress == .locked ? Color.secondary : Color.orange)
-            }
-        }
-        .padding()
-        .background(.background, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .stroke(progressColor(progress).opacity(0.20), lineWidth: 1)
-        )
-        .opacity(progress == .locked ? 0.82 : 1)
-    }
-
-    private func progressColor(_ progress: PlaceProgress) -> Color {
-        switch progress {
-        case .locked: return .gray
-        case .readyToLearn: return .orange
-        case .reviewed: return .blue
-        case .masteredLightly: return .green
+            .opacity(progress == .locked ? 0.84 : 1)
         }
     }
 }
@@ -204,244 +201,252 @@ struct PlaceDetailView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                headerCard
-                mapPreviewCard
-                memoryFactsCard
-                externalMapCard
-                fortBoard
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    headerCard
+
+                    GBSurface(style: .elevated) {
+                        VStack(alignment: .leading, spacing: GBSpacing.small) {
+                            GBSectionHeader(
+                                eyebrow: "Quest",
+                                title: "Pin this fort on the Sahyadri board",
+                                subtitle: "Use the clue, pick a marker, then reveal the answer before leaving for the Chronicle."
+                            )
+
+                            GBQuestProgress(
+                                steps: [.story, .place, .chronicle],
+                                currentStepID: "place"
+                            )
+                        }
+                    }
+
+                    mapPreviewCard
+                    memoryFactsCard
+                    externalMapCard
+                    fortBoard
+                }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
             }
-            .padding()
+            .background(GBColor.Background.app)
         }
         .navigationTitle(place.name)
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
 #endif
-        .background(Color(uiColor: .systemGroupedBackground))
     }
 
     private var headerCard: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(place.memoryHook.uppercased())
-                        .font(.caption.bold())
-                        .foregroundStyle(.orange)
-                    Text(place.name)
-                        .font(.largeTitle.bold())
-                    Text(place.whyItMatters)
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
+        GBSurface(style: .accented(.place)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack(alignment: .top, spacing: GBSpacing.small) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                        Text(place.memoryHook.uppercased())
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.84))
+                        Text(place.name)
+                            .font(.system(.largeTitle, design: .rounded, weight: .bold))
+                            .foregroundStyle(GBColor.Content.inverse)
+                        Text(place.whyItMatters)
+                            .font(.title3.weight(.semibold))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.92))
+                    }
+                    Spacer()
+                    GBBadge(title: progress.rawValue, symbol: progressIcon(progress), emphasis: .place)
                 }
-                Spacer()
-                Label(progress.rawValue, systemImage: progressIcon)
-                    .font(.caption.weight(.semibold))
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 8)
-                    .background(progressColor.opacity(0.14), in: Capsule())
-                    .foregroundStyle(progressColor)
-            }
 
-            HStack(spacing: 12) {
-                detailChip(title: "Story moment", value: place.primaryEvent, symbol: "flag.fill")
-                detailChip(title: "Region clue", value: place.regionLabel, symbol: "mountain.2.fill")
+                HStack(spacing: GBSpacing.small) {
+                    detailChip(title: "Story moment", value: place.primaryEvent, symbol: GBIcon.fort)
+                    detailChip(title: "Region clue", value: place.regionLabel, symbol: "mountain.2.fill")
+                }
             }
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
     }
 
     private var mapPreviewCard: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Sahyadri fort board")
-                .font(.headline)
-            Text("The current fort glows brighter so its place on the trail is easier to remember.")
-                .foregroundStyle(.secondary)
-            Text("Preview only. Use \"Pin the fort\" below to interact.")
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.secondary)
+        GBSurface(style: .elevated) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Board Preview",
+                    title: "See where this fort sits",
+                    subtitle: "The current fort glows brighter so its place on the trail is easier to remember."
+                )
 
-            schematicBoard(interactive: false)
-                .allowsHitTesting(false)
-                .frame(height: 280)
+                Text("Preview only. Use \"Pin the fort\" below to interact.")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(GBColor.Content.secondary)
 
-            HStack(spacing: 12) {
-                Label("Orange pin: today’s fort", systemImage: "mappin.circle.fill")
-                Label("Light pins: nearby forts", systemImage: "mappin.circle")
+                schematicBoard(interactive: false)
+                    .allowsHitTesting(false)
+                    .frame(height: 280)
+
+                HStack(spacing: GBSpacing.small) {
+                    Label("Bright pin: today's fort", systemImage: "mappin.circle.fill")
+                    Label("Light pins: nearby forts", systemImage: "mappin.circle")
+                }
+                .font(.caption)
+                .foregroundStyle(GBColor.Content.secondary)
             }
-            .font(.caption)
-            .foregroundStyle(.secondary)
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
     }
 
     private var memoryFactsCard: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Remember this fort")
-                .font(.headline)
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Remember",
+                    title: "Keep this fort in one glance",
+                    subtitle: "Use a short hook, one event, and one region clue."
+                )
 
-            VStack(alignment: .leading, spacing: 10) {
-                factRow(title: "Hook", value: place.memoryHook)
-                factRow(title: "Big event", value: place.primaryEvent)
-                factRow(title: "Region", value: place.regionLabel)
+                VStack(alignment: .leading, spacing: GBSpacing.small) {
+                    factRow(title: "Hook", value: place.memoryHook)
+                    factRow(title: "Big event", value: place.primaryEvent)
+                    factRow(title: "Region", value: place.regionLabel)
+                }
             }
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
     }
 
     private var externalMapCard: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Optional real-world map")
-                .font(.headline)
-            Text("Keep using the Sahyadri fort board here as the main learning view. If you want, you can open Apple Maps externally to see this fort on a real-world map.")
-                .foregroundStyle(.secondary)
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Optional",
+                    title: "Open the real-world map",
+                    subtitle: "Keep the Sahyadri board as the main learning view. Apple Maps stays an optional external reference."
+                )
 
-            Button {
-                guard let appleMapsURL else { return }
-                openURL(appleMapsURL)
-            } label: {
-                Label("Open in Apple Maps", systemImage: "arrow.up.right.square")
-                    .frame(maxWidth: .infinity)
+                Button {
+                    guard let appleMapsURL else { return }
+                    openURL(appleMapsURL)
+                } label: {
+                    Label("Open in Apple Maps", systemImage: "arrow.up.right.square")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.gbSecondary)
+
+                Text("This leaves GreatsOfBharatha and opens Apple Maps.")
+                    .font(.caption)
+                    .foregroundStyle(GBColor.Content.secondary)
             }
-            .buttonStyle(.bordered)
-
-            Text("This leaves GreatsOfBharatha and opens Apple Maps.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
     }
 
     private var fortBoard: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Pin the fort")
-                        .font(.headline)
-                    Text("Use the clue, choose a marker on the board, then reveal the answer.")
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                Text(place.memoryHook)
-                    .font(.caption.bold())
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 8)
-                    .background(Color.orange.opacity(0.14), in: Capsule())
-                    .foregroundStyle(.orange)
-            }
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Place Challenge",
+                    title: "Pin the fort",
+                    subtitle: "Use the clue, choose a marker on the board, then reveal the answer.",
+                    trailing: AnyView(GBBadge(title: place.memoryHook, symbol: GBIcon.place, emphasis: .place))
+                )
 
-            VStack(alignment: .leading, spacing: 8) {
-                Label(place.primaryEvent, systemImage: "sparkles")
-                    .font(.subheadline.weight(.semibold))
-                Text(feedbackText)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
-            .padding()
-            .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-
-            schematicBoard(interactive: true)
-                .frame(height: 320)
-
-            if let selectedCandidate {
-                selectedCandidateSummary(selectedCandidate)
-            }
-
-            HStack(spacing: 12) {
-                Button(revealed ? "Reset challenge" : "Reveal answer") {
-                    if revealed {
-                        selectedCandidateID = nil
-                        revealed = false
-                        comparisonMode = false
-                        LessonFeedback.fire(.selection)
-                    } else {
-                        revealed = true
-                        comparisonMode = true
-                        LessonFeedback.fire(selectedCandidate?.id == place.id ? .success : .reveal)
+                GBSurface(style: .elevated, padding: GBSpacing.small) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                        Label(place.primaryEvent, systemImage: GBIcon.reward)
+                            .font(.subheadline.weight(.semibold))
+                        Text(feedbackText)
+                            .font(.subheadline)
+                            .foregroundStyle(GBColor.Content.secondary)
                     }
                 }
-                .buttonStyle(.borderedProminent)
+
+                schematicBoard(interactive: true)
+                    .frame(height: 320)
+
+                if let selectedCandidate {
+                    selectedCandidateSummary(selectedCandidate)
+                }
+
+                HStack(spacing: GBSpacing.small) {
+                    Button(revealed ? "Reset challenge" : "Reveal answer") {
+                        if revealed {
+                            selectedCandidateID = nil
+                            revealed = false
+                            comparisonMode = false
+                            LessonFeedback.fire(.selection)
+                        } else {
+                            revealed = true
+                            comparisonMode = true
+                            LessonFeedback.fire(selectedCandidate?.id == place.id ? .success : .reveal)
+                        }
+                    }
+                    .buttonStyle(.gbPrimary(.place))
+
+                    if revealed {
+                        Button(comparisonMode ? "Hide compare cards" : "Compare nearby forts") {
+                            comparisonMode.toggle()
+                            LessonFeedback.fire(.selection)
+                        }
+                        .buttonStyle(.gbSecondary)
+                    }
+                }
 
                 if revealed {
-                    Button(comparisonMode ? "Hide compare cards" : "Compare nearby forts") {
-                        comparisonMode.toggle()
-                        LessonFeedback.fire(.selection)
-                    }
-                    .buttonStyle(.bordered)
+                    Text("Reveal: \(place.name) is remembered for \(place.primaryEvent.lowercased()) and sits \(place.regionLabel.lowercased()).")
+                        .font(.subheadline)
+                        .foregroundStyle(GBColor.Content.secondary)
+                }
+
+                if comparisonMode {
+                    comparisonCards
                 }
             }
-
-            if revealed {
-                Text("Reveal: \(place.name) is remembered for \(place.primaryEvent.lowercased()) and sits \(place.regionLabel.lowercased()).")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
-
-            if comparisonMode {
-                comparisonCards
-            }
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
     }
 
     private func selectedCandidateSummary(_ candidate: Place) -> some View {
         let matchesTarget = candidate.id == place.id
 
-        return HStack(alignment: .top, spacing: 12) {
-            Image(systemName: matchesTarget && revealed ? "checkmark.seal.fill" : "mappin.and.ellipse")
-                .foregroundStyle(matchesTarget && revealed ? .green : .orange)
-                .font(.title3)
+        return GBSurface(style: .elevated, padding: GBSpacing.small) {
+            HStack(alignment: .top, spacing: GBSpacing.small) {
+                Image(systemName: matchesTarget && revealed ? GBIcon.success : "mappin.and.ellipse")
+                    .foregroundStyle(matchesTarget && revealed ? GBColor.Accent.success : GBColor.Accent.place)
+                    .font(.title3)
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(candidate.name)
-                    .font(.headline)
-                Text(candidate.primaryEvent)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                Text(candidate.regionLabel)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                    Text(candidate.name)
+                        .font(.headline)
+                    Text(candidate.primaryEvent)
+                        .font(.subheadline)
+                        .foregroundStyle(GBColor.Content.secondary)
+                    Text(candidate.regionLabel)
+                        .font(.caption)
+                        .foregroundStyle(GBColor.Content.secondary)
+                }
+
+                Spacer()
             }
-
-            Spacer()
         }
-        .padding()
-        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
     }
 
     private var comparisonCards: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: GBSpacing.small) {
             Text("Compare the nearby forts")
-                .font(.subheadline.bold())
+                .font(.subheadline.weight(.bold))
 
             ForEach(challengeCandidates.filter { $0.id != place.id }) { candidate in
-                HStack(alignment: .top, spacing: 12) {
-                    Image(systemName: "arrow.left.and.right.circle.fill")
-                        .foregroundStyle(.orange)
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("\(candidate.name) vs \(place.name)")
-                            .font(.subheadline.weight(.semibold))
-                        Text("\(candidate.name): \(candidate.primaryEvent)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text("\(place.name): \(place.primaryEvent)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                GBSurface(style: .elevated, padding: GBSpacing.small) {
+                    HStack(alignment: .top, spacing: GBSpacing.small) {
+                        Image(systemName: "arrow.left.and.right.circle.fill")
+                            .foregroundStyle(GBColor.Accent.place)
+                        VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                            Text("\(candidate.name) vs \(place.name)")
+                                .font(.subheadline.weight(.semibold))
+                            Text("\(candidate.name): \(candidate.primaryEvent)")
+                                .font(.caption)
+                                .foregroundStyle(GBColor.Content.secondary)
+                            Text("\(place.name): \(place.primaryEvent)")
+                                .font(.caption)
+                                .foregroundStyle(GBColor.Content.secondary)
+                        }
+                        Spacer()
                     }
-                    Spacer()
                 }
-                .padding()
-                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
             }
         }
     }
@@ -449,10 +454,10 @@ struct PlaceDetailView: View {
     private func schematicBoard(interactive: Bool) -> some View {
         GeometryReader { geometry in
             ZStack {
-                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                RoundedRectangle(cornerRadius: GBRadius.hero, style: .continuous)
                     .fill(
                         LinearGradient(
-                            colors: [Color.blue.opacity(0.13), Color.orange.opacity(0.10), Color.green.opacity(0.08)],
+                            colors: [GBColor.Accent.place.opacity(0.15), GBColor.Accent.story.opacity(0.10), GBColor.Accent.success.opacity(0.08)],
                             startPoint: .topLeading,
                             endPoint: .bottomTrailing
                         )
@@ -467,37 +472,25 @@ struct PlaceDetailView: View {
                     }
                 }
                 .stroke(style: StrokeStyle(lineWidth: 4, lineCap: .round, dash: [10, 10]))
-                .foregroundStyle(.secondary.opacity(0.35))
+                .foregroundStyle(GBColor.Content.secondary.opacity(0.35))
 
                 VStack {
                     HStack {
                         Text("N")
-                            .font(.caption.bold())
+                            .font(.caption.weight(.bold))
                             .padding(8)
                             .background(.ultraThinMaterial, in: Circle())
                         Spacer()
-                        Text("Plateau trail")
-                            .font(.caption.weight(.medium))
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(.ultraThinMaterial, in: Capsule())
+                        boardLabel("Plateau trail")
                     }
                     Spacer()
                     HStack {
-                        Text("Konkan side")
-                            .font(.caption.weight(.medium))
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(.ultraThinMaterial, in: Capsule())
+                        boardLabel("Konkan side")
                         Spacer()
-                        Text("Pune side")
-                            .font(.caption.weight(.medium))
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(.ultraThinMaterial, in: Capsule())
+                        boardLabel("Pune side")
                     }
                 }
-                .padding(16)
+                .padding(GBSpacing.small)
 
                 ForEach(challengeCandidates) { candidate in
                     let isCurrent = candidate.id == place.id
@@ -533,6 +526,14 @@ struct PlaceDetailView: View {
         }
     }
 
+    private func boardLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(.ultraThinMaterial, in: Capsule())
+    }
+
     private func pinMarker(
         candidate: Place,
         isCurrent: Bool,
@@ -542,13 +543,13 @@ struct PlaceDetailView: View {
         interactive: Bool
     ) -> some View {
         VStack(spacing: 6) {
-            Image(systemName: showAsCorrect ? "checkmark.circle.fill" : isSelected ? "mappin.circle.fill" : isCurrent && !interactive ? "mappin.circle.fill" : "mappin.circle")
+            Image(systemName: showAsCorrect ? GBIcon.success : isSelected ? "mappin.circle.fill" : isCurrent && !interactive ? "mappin.circle.fill" : "mappin.circle")
                 .font(isCurrent ? .title : .title2)
-                .foregroundStyle(showAsCorrect ? .green : showAsMistake ? .orange : isCurrent ? .orange : .primary.opacity(0.78))
-                .shadow(color: isCurrent ? .orange.opacity(0.25) : .clear, radius: 10)
+                .foregroundStyle(showAsCorrect ? GBColor.Accent.success : showAsMistake ? GBColor.Accent.story : isCurrent ? GBColor.Accent.place : GBColor.Content.primary.opacity(0.78))
+                .shadow(color: isCurrent ? GBColor.Accent.place.opacity(0.24) : .clear, radius: 10)
             Text(revealed || !interactive || isSelected ? candidate.name : "?")
-                .font(.caption2.bold())
-                .foregroundStyle(.primary)
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(GBColor.Content.primary)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
                 .background(.ultraThinMaterial, in: Capsule())
@@ -570,44 +571,65 @@ struct PlaceDetailView: View {
         return CGPoint(x: x, y: y)
     }
 
-    private var progressColor: Color {
-        switch progress {
-        case .locked: return .gray
-        case .readyToLearn: return .orange
-        case .reviewed: return .blue
-        case .masteredLightly: return .green
-        }
-    }
-
-    private var progressIcon: String {
-        switch progress {
-        case .locked: return "lock.fill"
-        case .readyToLearn: return "sparkles"
-        case .reviewed: return "eye.fill"
-        case .masteredLightly: return "star.fill"
-        }
-    }
-
     private func detailChip(title: String, value: String, symbol: String) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Label(title, systemImage: symbol)
-                .font(.caption.bold())
-                .foregroundStyle(.secondary)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
             Text(value)
                 .font(.subheadline.weight(.medium))
+                .foregroundStyle(GBColor.Content.inverse)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
     }
 
     private func factRow(title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.caption.bold())
-                .foregroundStyle(.secondary)
-            Text(value)
-                .font(.body)
+        GBSurface(style: .elevated, padding: GBSpacing.small) {
+            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                Text(title)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(GBColor.Content.secondary)
+                Text(value)
+                    .font(.body)
+                    .foregroundStyle(GBColor.Content.primary)
+            }
         }
+    }
+}
+
+private func progressColor(_ progress: PlaceProgress) -> Color {
+    switch progress {
+    case .locked:
+        GBColor.State.locked
+    case .readyToLearn:
+        GBColor.Accent.place
+    case .reviewed:
+        .blue
+    case .masteredLightly:
+        GBColor.Accent.success
+    }
+}
+
+private func progressIcon(_ progress: PlaceProgress) -> String {
+    switch progress {
+    case .locked:
+        GBIcon.locked
+    case .readyToLearn:
+        GBIcon.reward
+    case .reviewed:
+        "eye.fill"
+    case .masteredLightly:
+        "star.fill"
+    }
+}
+
+private func progressEmphasis(_ progress: PlaceProgress) -> GBEmphasis {
+    switch progress {
+    case .locked:
+        .neutral
+    case .readyToLearn, .reviewed, .masteredLightly:
+        .place
     }
 }

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,22 @@
+# Design docs
+
+This directory holds durable design-system guidance for GreatsOfBharatha.
+
+Linked umbrella issue: #38
+
+## Current docs
+
+- `../specs/2026-04-20-responsive-design-system-spec.md` - umbrella responsive design-system spec
+- `iconography.md` - icon sourcing, usage rules, and attribution policy
+- `ai-asset-workflow.md` - workflow for AI-assisted asset generation, review, and import
+- `asset-briefs/` - approved asset briefs before generation starts
+- `prompts/` - prompt drafts used for external generation tools
+- `review-notes/` - review outcomes and decisions for generated or sourced assets
+
+## Working rule
+
+No asset or icon should enter the product without:
+1. a clear purpose
+2. provenance or license tracking
+3. review for product fit and historical/child-safety concerns
+4. a durable repo record

--- a/docs/design/ai-asset-workflow.md
+++ b/docs/design/ai-asset-workflow.md
@@ -1,0 +1,88 @@
+# AI-assisted asset workflow
+
+This workflow is for future art, sprites, motifs, Chronicle cards, and other visual assets created with tools like nano-banana, ChatGPT, or other generators.
+
+## Principle
+
+AI can accelerate exploration. It should not bypass product judgment, historical respect, or style consistency.
+
+## Approved workflow
+
+### 1. Write a brief first
+Before any generation, create an asset brief in `asset-briefs/`.
+
+Required fields:
+- asset name
+- purpose
+- target screen/component
+- target age band
+- educational meaning
+- required mood
+- style references
+- aspect ratio / sizing needs
+- animation intent, if any
+- historical/cultural constraints
+- provenance notes
+
+### 2. Generate candidate sets
+Create multiple candidates externally.
+
+Recommended working pattern:
+- one conservative set
+- one more playful set
+- one system-fitting refinement set
+
+Store prompt drafts or generation notes in `prompts/` when they are worth preserving.
+
+### 3. Review before import
+Review candidates for:
+- child clarity
+- historical respect
+- style fit with the app
+- readability at target size
+- whether the asset improves learning or only decorates
+
+Record the decision in `review-notes/`.
+
+### 4. Normalize approved outputs
+Before import:
+- crop and align consistently
+- normalize stroke/weight and palette where needed
+- export in the preferred final format
+- avoid shipping raw generated outputs without cleanup
+
+### 5. Import with provenance
+Each approved asset should carry:
+- source tool
+- date created
+- prompt or brief reference
+- editing notes
+- final owner approval
+
+## Format guidance
+
+Prefer, in order:
+1. vector or layered source when possible
+2. transparent PNG for illustration assets
+3. sprite sheets only when there is a clear runtime need
+
+## Product guardrails
+
+- do not use AI art just to fill space
+- do not let generated styles drift across scenes
+- do not introduce culturally sloppy motifs around real historical figures or forts
+- do not make reward art more important than learning clarity
+
+## Best future uses in GreatsOfBharatha
+
+- story spot illustrations
+- Chronicle card art systems
+- fort-board ornament sets
+- emblem fragments and seals
+- celebratory reward treatments
+
+## Avoid first
+
+- shipping a large generated asset pack without a style system
+- mixing many generator aesthetics in one release
+- using AI assets before the responsive design system and component language are stable

--- a/docs/design/asset-briefs/README.md
+++ b/docs/design/asset-briefs/README.md
@@ -1,0 +1,18 @@
+# Asset briefs
+
+Create one markdown brief per asset family before generation starts.
+
+Suggested file naming:
+- `YYYY-MM-DD-chronicle-card-art-brief.md`
+- `YYYY-MM-DD-place-board-marker-brief.md`
+- `YYYY-MM-DD-story-spot-illustration-brief.md`
+
+Minimum brief sections:
+- purpose
+- target screen
+- audience / age band
+- educational role
+- visual direction
+- constraints
+- export needs
+- provenance / approval

--- a/docs/design/iconography.md
+++ b/docs/design/iconography.md
@@ -1,0 +1,59 @@
+# Iconography policy
+
+## Core rule
+
+Use **SF Symbols first** for product shell, navigation, system actions, and common interaction metaphors.
+
+Why:
+- best native rendering in SwiftUI
+- accessibility and variable weight support
+- strong cross-platform path across iPhone, iPad, and future tvOS
+- lower maintenance than importing large third-party packs
+
+## When custom/open-source icons are allowed
+
+Use supplementary open-source icons only when SF Symbols does not express the product meaning well enough, especially for:
+- fort/place markers
+- Chronicle categories
+- historical motifs
+- collectible seals or emblems
+
+Recommended supplementary source options:
+- **Tabler Icons** (MIT)
+- **Phosphor Icons** (MIT)
+
+Pick one family for supplementation. Do not mix several packs casually.
+
+## Usage rules
+
+- navigation and shell icons should remain stable and mostly SF Symbols based
+- custom icons should be limited to domain-specific meaning, not basic UI chrome
+- imported icons must be normalized for stroke weight, corner feel, and optical size
+- only import the approved icons actually used by the app
+- document every imported icon in a manifest
+
+## Recommended manifest fields
+
+- local asset name
+- semantic meaning
+- source library
+- source URL
+- license
+- date imported
+- screens/components using it
+- notes on edits or normalization
+
+## Visual language guidance
+
+- **Learn / story** icons should feel narrative and guiding
+- **Places** icons should feel spatial and discoverable
+- **Chronicle** icons should feel ceremonial, collectible, and memory-bearing
+- challenge-state icons must read clearly at small sizes
+- never rely on icon shape alone to communicate state
+
+## Current recommendation for GreatsOfBharatha
+
+1. keep shell and most UI actions on SF Symbols
+2. use custom/open-source icons only for high-value domain surfaces
+3. create a repo-local attribution manifest before importing any non-SF symbol assets
+4. prefer consistency and meaning over novelty

--- a/docs/specs/000-index.md
+++ b/docs/specs/000-index.md
@@ -15,3 +15,8 @@ Use this directory for durable product and technical specifications.
 2. Draft spec from `docs/templates/spec-template.md`
 3. Review and refine in PRs/issues
 4. Mark approved and split delivery into feature issues if needed
+
+## Active highlighted specs
+
+- `2026-04-19-main-ux-iteration-spec.md`
+- `2026-04-20-responsive-design-system-spec.md`

--- a/docs/specs/2026-04-20-responsive-design-system-spec.md
+++ b/docs/specs/2026-04-20-responsive-design-system-spec.md
@@ -1,0 +1,588 @@
+# Responsive design system spec
+
+- Status: Draft
+- Linked issue: #38
+- Milestone: Shivaji Arc
+- Owner: @ganesh47
+- Last updated: 2026-04-20
+
+## Problem
+
+GreatsOfBharatha now has enough product shape that UI inconsistency is becoming a product risk, not just a polish issue.
+
+The current app already shows a promising loop, story, place memory, recall, and Chronicle reward, but it still behaves like a set of screens rather than one coherent system. The recent review pass surfaced the same root problems repeatedly:
+- the learning quest is not legible enough moment to moment
+- too many systems compete on single screens
+- place learning is promising but not yet the unmistakable star
+- Chronicle is structurally clear but emotionally underpowered
+- copy, iconography, and visual language are still too prototype-like in places
+- current layouts are iPhone-first and should be upgraded into a durable SwiftUI-native responsive system that scales to iPhone, iPad, and future Apple TV exploration
+
+Without a design system, each screen will continue solving the same hierarchy, spacing, state, responsiveness, and asset problems independently.
+
+## Goals
+
+- create a durable SwiftUI-native design system for GreatsOfBharatha
+- make the core quest legible across the product: story -> place -> Chronicle
+- establish responsive layout rules that work across iPhone portrait, iPhone landscape, iPad split view, iPad full-screen, and future tvOS adaptation
+- define shared tokens for color, type, spacing, shape, iconography, motion, and interaction states
+- make place learning the most distinctive visual and interaction surface in the app
+- turn Chronicle into a ceremonial, meaningful reward system instead of a flat list
+- prefer Apple-native implementation patterns first, with low-fragility, accessible components
+- define a workflow for free/open-source icons and future AI-assisted asset production
+
+## Non-goals
+
+- finalizing the complete visual identity for every future historical arc
+- shipping custom 3D or heavy real-time animation systems in this phase
+- replacing SF Symbols everywhere with custom icon packs just for novelty
+- designing a tvOS UI now, beyond keeping the system structurally open to it
+- adding large new content arcs before the existing loop is visually and interactionally coherent
+
+## Product design principles
+
+### 1. One quest, not many modules
+Every screen should reinforce one child-legible quest structure.
+
+Preferred child-facing framing:
+- hear the story
+- find the fort
+- earn the Chronicle
+
+Where the board interaction is foregrounded, this can extend to:
+- hear the story
+- remember the place
+- pin it on the board
+- keep it in your Chronicle
+
+### 2. One dominant action per screen
+Children should not need to parse five systems at once.
+The active step should dominate visually and semantically.
+Future steps can be hinted at, but not compete.
+
+### 3. Place learning is the signature mechanic
+The fort board, place comparisons, and spatial memory cues should become the most memorable product surface.
+If users mainly remember generic cards and progress rows, the product is underusing its differentiator.
+
+### 4. Rewards must prove learning
+Chronicle is not a sticker album. It is evidence of what the child now knows.
+Every reward should feel ceremonial, specific, and tied back to person, place, and significance.
+
+### 5. Calm, native, and premium without feeling static
+The UI should stay readable and low-anxiety, but it must stop feeling like stacked white cards with weak peaks.
+Use native SwiftUI strengths, typography, spacing, materials, and motion with more intention.
+
+### 6. Child-first language, parent-trust outcomes
+Instructional copy should be direct and concrete for children.
+System structure should remain explainable to adults, especially around learning outcomes and reward meaning.
+
+## Responsive platform matrix
+
+### iPhone compact width
+Primary target for V1.
+
+Rules:
+- single-column scroll surfaces
+- one hero action at top
+- step content revealed progressively
+- bottom tab bar remains primary shell
+- cards can be full-width, but must avoid long text blocks and nested sections competing at once
+
+### iPhone regular height landscape
+Needs graceful degradation rather than dense reuse of portrait layouts.
+
+Rules:
+- avoid tall hero cards that push the active task below the fold
+- prefer two-panel compositions only when content clearly benefits, such as place board + clue summary
+- keep tap targets large enough for handheld landscape use
+
+### iPad split view
+Critical for responsiveness.
+
+Rules:
+- components must survive 1/3, 1/2, and 2/3 split widths
+- avoid hard-coded full-width assumptions
+- cards should adapt between compact and regular presentation tokens
+- side-by-side layouts only when each pane retains clear focus
+
+### iPad full-screen
+Opportunity surface, not just scaled phone UI.
+
+Rules:
+- allow two-column story/place and collection/detail layouts
+- increase environmental feeling through whitespace, background treatment, and stronger visual anchors
+- place board can gain surrounding context, comparison panel, and richer reveal states
+
+### tvOS future readiness
+Not in current implementation scope, but design-system decisions should not block it.
+
+Rules:
+- avoid interactions that only make sense as tiny touch targets
+- keep components focus-friendly in principle
+- distinguish content container styles from navigation shell styles
+- structure scenes so the active learning step can be a clear focus region on larger screens
+
+## Design-system architecture
+
+Create a dedicated design layer inside the app.
+
+Recommended structure:
+
+```text
+GreatsOfBharatha/
+  DesignSystem/
+    Tokens/
+      GBColor.swift
+      GBTypography.swift
+      GBSpacing.swift
+      GBRadius.swift
+      GBShadow.swift
+      GBMotion.swift
+      GBIcon.swift
+    Foundation/
+      GBLayoutContext.swift
+      GBAdaptiveStack.swift
+      GBCardStyle.swift
+      GBSurface.swift
+      GBButtonStyle.swift
+      GBBadge.swift
+    Components/
+      GBHeroCard.swift
+      GBQuestProgress.swift
+      GBStoryCard.swift
+      GBClueCard.swift
+      GBRecallCard.swift
+      GBRewardReveal.swift
+      GBChronicleCard.swift
+      GBPlaceBoard.swift
+      GBPlaceTrailCard.swift
+      GBSectionHeader.swift
+    Patterns/
+      LessonScreenPattern.swift
+      PlaceScreenPattern.swift
+      ChronicleScreenPattern.swift
+```
+
+Guidance:
+- tokens should be static, centralized, and semantic
+- feature screens should compose design-system components rather than own their own visual language
+- components should derive sizing and composition from environment-driven layout context, not one-off geometry hacks
+
+## Token system
+
+### Color tokens
+Use semantic names, not implementation names.
+
+Core semantic groups:
+- `bg.app`
+- `bg.surface`
+- `bg.elevated`
+- `bg.heroWarm`
+- `bg.heroCool`
+- `content.primary`
+- `content.secondary`
+- `content.tertiary`
+- `accent.story`
+- `accent.place`
+- `accent.chronicle`
+- `accent.success`
+- `accent.warning`
+- `border.default`
+- `border.emphasis`
+- `state.locked`
+
+Behavior:
+- support light and dark appearance explicitly
+- preserve calm contrast ratios suitable for children
+- keep story, place, and Chronicle color families distinct enough to reinforce product structure
+- Chronicle should not share exactly the same emphasis language as story progression or place challenge
+
+### Typography tokens
+Prefer Apple-native text styles and semantic wrappers.
+
+Recommended styles:
+- display for arc/hero titles
+- title for scene/place/reward headings
+- headline for active-task labels
+- body for instructional sentences
+- caption for secondary metadata only
+
+Rules:
+- use Dynamic Type-friendly wrappers
+- limit multi-line body copy in primary action zones
+- prefer short sentence blocks over paragraphs
+- on iPad, increase line length carefully, not by simply scaling fonts up
+
+### Spacing and layout tokens
+Define a small, consistent scale.
+
+Suggested spacing ladder:
+- 4, 8, 12, 16, 20, 24, 32, 40
+
+Rules:
+- section spacing should communicate task separation
+- internal card spacing should make hierarchy obvious without bloating height
+- larger screens should increase outer margin and group spacing before increasing text density
+
+### Shape tokens
+Rounded rectangles are already the product language, but standardize them.
+
+Suggested radii:
+- compact controls: 12 to 16
+- standard cards: 20 to 24
+- hero surfaces: 28 to 32
+- badges/chips: capsule or 16+
+
+### Shadow and depth tokens
+Use depth sparingly.
+
+Rules:
+- default cards rely on contrast and border, not heavy shadows
+- ceremonial Chronicle or reward reveal states can use stronger elevation
+- place board can use depth selectively to signal interaction and current focus
+
+### Motion tokens
+Motion should support memory and ceremony, not decoration.
+
+Allowed use cases:
+- reward reveal
+- board pin confirmation
+- state transition between lesson steps
+- subtle hero emphasis on first load
+
+Avoid:
+- perpetual motion
+- large parallax systems
+- complex chained animation that makes CI capture fragile
+
+## Iconography strategy
+
+### Baseline rule
+Use **SF Symbols first** for product shell, navigation, system actions, and common UI metaphors.
+This is the best default for SwiftUI-native quality, accessibility, rendering behavior, and future platform coverage.
+
+### Open-source icon rule
+Use free/open-source custom icons only where SF Symbols is not expressive enough, especially for:
+- historical or domain motifs
+- Chronicle categories
+- fort/place board markers
+- collectible rarity or mastery seals
+
+Recommended sources:
+- **Tabler Icons** (MIT)
+- **Phosphor Icons** (MIT)
+
+Selection guidance:
+- pick one supplementary icon family, not several mixed packs
+- normalize stroke weight, corner feel, and optical size
+- import only approved icons into repo, not entire packages
+- keep a repo-local attribution manifest
+
+Recommended repo location:
+
+```text
+GreatsOfBharatha/Assets.xcassets/
+GreatsOfBharatha/Resources/Iconography/
+  README.md
+  attribution.md
+  source-manifest.json
+```
+
+Source manifest fields:
+- symbol name
+- source library
+- license
+- original URL
+- local asset name
+- usage surfaces
+- date imported
+
+### Product icon rules
+- navigation icons should remain stable across screens
+- story, place, and Chronicle each need a distinct semantic icon family
+- place markers must be recognizable at small sizes and from a distance on larger layouts
+- reward icons must feel collectible, not generic productivity badges
+
+## Core components and responsive behavior
+
+### App shell
+Includes navigation, tabs, top-level background behavior, and sectional rhythm.
+
+Requirements:
+- single shared shell language across Learn, Places, Chronicle
+- adaptive top padding and width constraints by size class
+- avoid screen-specific ad hoc background colors and card treatments
+
+### Hero card
+Used on Learn and possibly future arc hubs.
+
+Requirements:
+- one dominant CTA
+- concise progress framing
+- responsive title and subtitle hierarchy
+- supports compact and regular variants
+- no more than one secondary badge at top-right
+
+### Quest progress component
+Unifies the active learning loop.
+
+Requirements:
+- explicit steps with child-legible labels
+- highlights current step only
+- can render horizontally on iPhone, optionally vertically or sidebar-style on iPad
+
+Recommended labels:
+- Story
+- Find Place
+- Chronicle
+
+If board pinning is a dedicated step in some screens, use a four-step variant without inventing a second visual language.
+
+### Story card
+Requirements:
+- active card owns the screen
+- short readable copy blocks
+- image/illustration slot ready for future assets
+- clear next action
+- no secondary module should visually compete while story is active
+
+### Clue / place memory card
+Requirements:
+- concrete clue phrasing
+- space for one memory hook, one event, one region clue
+- supports hidden, revealed, success, and compare variants
+
+### Recall card
+Requirements:
+- retrieval-first behavior
+- avoid echo questions immediately after re-showing answer
+- make correctness feedback reinforce mastery, not only correctness
+- ready for reuse in delayed review mode later
+
+### Place board
+This is the flagship component.
+
+Requirements:
+- adaptive board aspect ratio
+- supports compact presentation on iPhone and richer contextual framing on iPad
+- current fort stands out clearly
+- nearby alternatives remain legible
+- pins, trails, and region hints use stable visual grammar
+- challenge state, reveal state, and compare state should feel distinct
+
+### Chronicle reward reveal
+Requirements:
+- separate reveal moment from catalog state
+- supports celebratory animation and a strong summary sentence
+- communicates what was learned, not just what was unlocked
+
+### Chronicle collection card
+Requirements:
+- category, title, memory value, and learning significance
+- locked state should tease meaning without becoming noisy inventory
+- unlocked states should feel like keepsakes
+
+## Screen-pattern guidance
+
+### Learn home
+Target outcome:
+- immediately communicates the next quest step
+- feels like entering an adventure, not browsing a syllabus
+
+Pattern:
+- hero next-action card
+- concise journey framing
+- scene cards with low reading load
+- Chronicle teaser only after primary journey content
+
+### Scene lesson
+Target outcome:
+- one obvious active task
+- transitions feel like progress within one quest
+
+Pattern:
+- top quest progress
+- active story or task card
+- only the current step visible in full emphasis
+- future steps hinted, not fully expanded
+
+### Places hub
+Target outcome:
+- feels like the next chapter of the same journey, not a side product
+
+Pattern:
+- journey framing at top
+- status labels rewritten to action-led language
+- trail list with strong next-up cues
+- on iPad, allow trail + selected summary split view
+
+### Place detail / board challenge
+Target outcome:
+- feels like discovery and reasoning
+
+Pattern:
+- clue / context panel
+- board as dominant visual
+- reveal / compare states
+- optional Apple Maps handoff stays secondary to the learning board
+
+### Chronicle
+Target outcome:
+- feels ceremonial and identity-building
+
+Pattern:
+- recent unlock highlight
+- clear grouping of unlocked vs next-to-earn
+- each item restates memory value
+- future catalog does not overwhelm recent reward meaning
+
+## Copy system guidance
+
+Preferred child-facing verbs:
+- listen
+- find
+- remember
+- pin
+- collect
+- compare
+- unlock
+
+Avoid or reduce in core child-facing flows:
+- linked lesson scene
+- reveal this Chronicle reward
+- complete the following
+- meaning-bearing rewards
+- debug/prototype/capture framing
+
+Parent-trust copy should be concise and placed in supportive surfaces, not in the middle of active child tasks.
+
+## Accessibility and quality bar
+
+- Dynamic Type support for all primary components
+- VoiceOver labels for quest progress, pins, reward states, and challenge feedback
+- color contrast validated for all semantic token pairs
+- no state should rely on color alone
+- all interactive targets should be at least Apple-recommended touch sizes
+- responsive layouts should be testable in previews for compact, regular, and split-screen environments
+
+## Asset and AI-assisted workflow
+
+Ganesh may use tools like nano-banana, ChatGPT, or other generators to help produce assets, sprites, concepts, or icon variations. This is useful, but only if the workflow stays controlled.
+
+### Asset categories
+- illustrations and story spot art
+- fort/place board motifs
+- Chronicle card art
+- icon candidates and ornament systems
+- character or environment sprites for future motion work
+
+### Workflow
+1. Write an asset brief in repo before generation.
+2. Generate multiple candidates externally.
+3. Review for child-safety, cultural respect, clarity, and product fit.
+4. Normalize style, naming, and sizing.
+5. Export approved assets into repo with attribution/provenance notes.
+6. Add preview screenshots or usage references.
+7. Only then wire them into SwiftUI components.
+
+Recommended repo structure:
+
+```text
+docs/design/
+  asset-briefs/
+  prompts/
+  review-notes/
+GreatsOfBharatha/Resources/Art/
+  Chronicle/
+  Places/
+  Story/
+```
+
+### Asset brief template fields
+- purpose
+- target screen/component
+- child age band
+- educational meaning
+- visual references
+- size/aspect needs
+- animation intent, if any
+- licensing / provenance
+- approved by
+
+### AI asset guardrails
+- never ship unreviewed generated outputs directly
+- avoid style drift across generated batches
+- keep a human-approved final edit pass
+- maintain cultural and historical respect, especially for real figures and places
+- prefer vector-first or layered source files when possible
+
+## Implementation plan
+
+### Phase 1: foundations
+- create `DesignSystem/` module structure inside the app target
+- introduce semantic tokens for color, typography, spacing, radius, elevation, and icon usage
+- create adaptive layout context helpers and base surfaces
+- remove visible debug or prototype framing from user-facing UI where still present
+
+### Phase 2: screen primitives
+- build quest progress component
+- build hero card, section header, badge, and card styles
+- build story card, clue card, recall card, and Chronicle card primitives
+- build first pass of responsive place board component
+
+### Phase 3: feature migration
+- migrate `LessonHomeView` to design-system hero and section patterns
+- migrate `SceneLessonView` to explicit quest-step structure
+- migrate `PlacesHubView` and place detail screens to responsive place system
+- migrate `ChronicleView` to reveal + collection pattern split
+
+### Phase 4: asset pipeline and iconography
+- add icon source manifest and attribution docs
+- import only approved open-source supplementary icons if SF Symbols is insufficient
+- create asset-brief and review workflow docs for future generated art
+
+### Phase 5: proof and follow-through
+- add SwiftUI previews for iPhone and iPad variants of core components
+- refresh UX artifact capture from CI
+- review against the product-critical findings that triggered this spec
+- split implementation into focused issues/PRs if required
+
+## Suggested GitHub issue breakdown
+
+Primary umbrella issue:
+- responsive SwiftUI-native design system for GreatsOfBharatha
+
+Follow-up execution issues:
+1. design-system foundations and semantic tokens
+2. quest progress and lesson-screen pattern
+3. responsive place board and places flow
+4. Chronicle reveal and collection redesign
+5. iconography and asset-source policy
+6. AI-assisted asset workflow and review docs
+
+## Acceptance criteria
+
+A design-system phase is successful when:
+- the app no longer feels like independent feature screens with separate visual logic
+- the quest structure is obvious at a glance
+- iPhone and iPad layouts both feel intentional, not merely stretched
+- place learning is visually and interactively the strongest lane
+- Chronicle rewards feel ceremonial and specific
+- icon usage is consistent, licensed, and documented
+- asset generation and import workflow is durable enough for future contributors
+
+## Open questions
+
+- should the product standardize on a 3-step quest model everywhere, or allow a 4-step model when board pinning needs explicit prominence?
+- should Places remain a tab in V1, or become more tightly integrated into guided lesson progression?
+- which surfaces truly need custom icons versus SF Symbols?
+- when should story art become required rather than optional?
+- what is the minimum motion system that materially improves reward ceremony without increasing fragility?
+
+## Immediate next moves
+
+1. Open the umbrella GitHub issue for the design-system workstream.
+2. Link this spec to that issue.
+3. Add a small set of design-system foundation files in SwiftUI.
+4. Create `docs/design/` support docs for icon attribution and asset workflow.
+5. Start migration with Learn home, place board, and Chronicle, in that order.


### PR DESCRIPTION
## Summary
Closes #38.

This PR lands the seeded responsive design-system work and carries it through to the app's core product loop.

What changed:
- adds the `GreatsOfBharatha/DesignSystem` foundation with semantic tokens, shared surfaces, badges, button styles, layout context, hero treatment, and quest-progress components
- preserves and expands the design docs under `docs/design/` plus the responsive design-system spec and spec index linkage
- migrates `LessonHomeView`, `SceneLessonView`, `PlacesHubView`, `PlaceDetailView`, and `ChronicleView` onto the shared system in an additive pass instead of a rewrite
- makes the story -> place -> Chronicle loop more legible across Learn, Places, and Chronicle
- keeps the Apple Maps escape hatch intact while making the Sahyadri fort board feel like the signature place-learning surface

## Asset follow-ups created
- #40 Sahyadri fort board background and ornament pack
- #41 Chronicle reward illustration system for Shivaji Arc keepsakes

## Validation
Ran repo-local validation available in this environment:
- `git diff --check`
- `gh auth status`

Could not run Apple build/test commands here because this Linux environment does not have `xcodebuild`, `swift`, or `plutil` installed.

## Notes
- Chronicle was migrated in this pass, but it still uses text-first reward content until the follow-up asset work lands.
- SF Symbols remain the default icon layer for now, consistent with the issue guardrails.
