### PR TITLE
docs: add prompt packets for asset issues #40 and #41

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -13,6 +13,14 @@ Linked umbrella issue: #38
 - `prompts/` - prompt drafts used for external generation tools
 - `review-notes/` - review outcomes and decisions for generated or sourced assets
 
+## Current asset packets
+
+- `asset-briefs/2026-04-20-sahyadri-fort-board-environment-pack.md` - issue #40 generation brief
+- `asset-briefs/2026-04-20-chronicle-reward-illustration-system.md` - issue #41 generation brief
+- `prompts/2026-04-20-issue-40-sahyadri-board-prompts.md` - prompt pack for board environment generation
+- `prompts/2026-04-20-issue-41-chronicle-reward-prompts.md` - prompt pack for Chronicle reward generation
+- `review-notes/2026-04-20-asset-review-checklist.md` - review checklist for both asset streams
+
 ## Working rule
 
 No asset or icon should enter the product without:

--- a/docs/design/asset-briefs/2026-04-20-chronicle-reward-illustration-system.md
+++ b/docs/design/asset-briefs/2026-04-20-chronicle-reward-illustration-system.md
@@ -1,0 +1,111 @@
+# Chronicle reward illustration system
+
+- Linked issue: #41
+- Status: Ready for generation
+- Last updated: 2026-04-20
+
+## Goal
+Create a first-pass illustration system for Chronicle rewards so unlocks feel ceremonial, specific, and collectible instead of text-only.
+
+## Product surfaces
+- `ChronicleView`
+- highlighted reward reveal card
+- unlocked reward cards in the Royal Chronicle
+
+## Child outcome
+The child should feel proud that they earned a keepsake that proves what they learned.
+
+## Audience
+- Primary: children 6 to 10
+- Secondary: parents looking for meaningful, non-chaotic educational rewards
+
+## Current reward set
+1. `Birth Fort`
+2. `First Big Fort`
+3. `Mountain Seal Fragment`
+4. `Planning Badge`
+
+## System direction
+- square master art per reward
+- crop-safe for vertical card use
+- silhouette-first reading at small sizes
+- shared visual language across all rewards
+- ceremonial warmth, not gamey loot energy
+
+## Visual direction
+- storybook emblem art
+- flat to lightly layered illustration
+- clean silhouette shapes
+- readable icon/core motif first, detail second
+- respectful, warm, optimistic, premium
+
+## What it should feel like
+- ceremonial
+- earned
+- memory-bearing
+- calm and proud
+- historically respectful
+
+## What to avoid
+- random sticker-pack energy
+- loud mobile-game reward FX
+- over-detailed scenes that collapse at card size
+- sloppy royal clichés
+- generic crowns, swords, or unrelated fantasy symbols
+
+## Reward-by-reward direction
+### 1. Birth Fort
+- motif: Shivneri silhouette
+- mood: dawn, origin, protection, beginning
+- composition: fort silhouette with early light and grounded mountain presence
+
+### 2. First Big Fort
+- motif: Torna silhouette
+- mood: breakthrough, ascent, first expansion of ambition
+- composition: upward momentum, strong ridgeline, fort claim energy without battle chaos
+
+### 3. Mountain Seal Fragment
+- motif: abstract emblem fragment combining mountain geometry and seal language
+- mood: collectible, meaningful, partial completion
+- composition: emblem shard / fragment treatment, mountain-rooted not metallic-fantasy
+
+### 4. Planning Badge
+- motif: strategic readiness and mountain-base planning
+- mood: intelligence, preparation, discipline
+- composition: map-plan / route / signal language, but child-legible and not militaristic
+
+## Palette guidance
+- warm golds, terracotta, stone, muted saffron, dusk blue accents where needed
+- keep values readable on light backgrounds in Chronicle cards
+- avoid neon or overly glossy gradients
+
+## Export requirements
+- square master image for each reward
+- high-res PNG or vector source preferred
+- transparent background variant if feasible
+- include one contact-sheet style overview showing all four together
+
+## Prompt 1, conservative
+Create a ceremonial reward illustration for a premium children’s history-learning app about Shivaji Maharaj. Use storybook emblem art with clear silhouette-first shapes, warm terracotta and gold tones, calm premium lighting, and respectful historical mood. The art must read clearly at small card size. Avoid fantasy loot aesthetics, loud effects, clutter, and generic royal clichés.
+
+## Prompt 2, reward set generator
+Create a cohesive set of four ceremonial reward illustrations for a children’s learning app. Rewards: Birth Fort, First Big Fort, Mountain Seal Fragment, Planning Badge. Use a unified storybook emblem style, clean silhouettes, lightly layered color, calm premium warmth, and readable small-size composition. Each reward should feel earned and educational, not like a random game sticker.
+
+## Prompt 3, per-reward refinement
+Refine this reward illustration for the Royal Chronicle in a SwiftUI-based children’s educational app. Keep the composition simple, premium, respectful, and highly readable on mobile cards. Emphasize one core motif, one emotional tone, and a collectible keepsake feeling. Avoid clutter, neon, heavy realism, and generic game reward styling.
+
+## Review checklist
+- Can the reward be recognized at small size?
+- Does it feel earned instead of random?
+- Is the style consistent across all four rewards?
+- Is the historical tone respectful?
+- Does it strengthen the Chronicle’s ceremony?
+
+## File drop expectations
+When attaching generated candidates to issue #41, include:
+- reward name
+- generator/tool used
+- prompt version used
+- edits applied after generation
+- preferred final candidate and why
+- any notes about readability at card size

--- a/docs/design/asset-briefs/2026-04-20-sahyadri-fort-board-environment-pack.md
+++ b/docs/design/asset-briefs/2026-04-20-sahyadri-fort-board-environment-pack.md
@@ -1,0 +1,106 @@
+# Sahyadri fort board environment pack
+
+- Linked issue: #40
+- Status: Ready for generation
+- Last updated: 2026-04-20
+
+## Goal
+Create a distinctive environment layer for the Sahyadri fort board so place-learning screens feel memorable, regional, and premium without reducing gameplay clarity.
+
+## Product surfaces
+- `PlacesHubView`
+- `PlaceDetailView`
+- future board-based place challenges
+
+## Child outcome
+The child should feel that forts belong to a real mountain world, not a generic board.
+
+## Audience
+- Primary: children 6 to 10
+- Secondary: parents who should feel the app is thoughtful, calm, and culturally grounded
+
+## Asset set
+1. **Main board background**
+   - stylized Sahyadri ridge-and-plateau environment
+   - landscape-first composition
+   - safe to crop for iPhone and iPad
+2. **Optional texture layer**
+   - subtle paper / painted-relief grain
+   - should be usable as a low-opacity overlay
+3. **Optional ornament pack**
+   - compass treatment
+   - ridge separators
+   - fort-marker halo treatment
+   - subtle direction accents for regional reading
+
+## Visual direction
+- stylized painted-relief map board
+- layered ridgelines and plateau edges
+- restrained contour cues
+- warm, earthy, calm palette with legible contrast for overlays
+- soft sense of altitude and geography
+- readable, not noisy
+
+## What it should feel like
+- adventurous
+- calm
+- elevated
+- rooted in western Maharashtra hill-fort terrain
+- premium but child-legible
+
+## What to avoid
+- fantasy treasure-map clichés
+- parchment overload
+- busy ornamental borders
+- dark muddy terrain that kills pin contrast
+- militaristic UI language or aggressive battle framing
+- photoreal aerial maps
+
+## Layout and export requirements
+- master artwork should favor a wide board aspect ratio
+- preserve a quiet central play region for pins and route overlays
+- keep high-detail clusters near edges, not the interaction center
+- export targets:
+  - 1x concept board preview
+  - high-res production PNG
+  - layered/vector source if available
+
+## Color guidance
+- terrain browns, stone neutrals, dusty olive, muted sunrise gold, restrained sky tint
+- avoid saturated greens/blues that overpower pins and labels
+- ensure orange, blue, and green UI accents still read on top
+
+## Interaction constraints
+- pins, labels, and route overlays must remain clearer than the background
+- current board interaction should not require a code rewrite to use the art
+- art should work behind both challenge and reveal states
+
+## Cultural and historical guardrails
+- keep the terrain grounded in Deccan hill-fort context
+- avoid generic medieval-European map language
+- use fort motifs carefully and sparingly
+- signal real geography, not fantasy worldbuilding
+
+## Prompt 1, conservative
+Create a stylized map-board environment for a children’s history-learning app about Shivaji Maharaj and Sahyadri forts. Show layered western Maharashtra mountain ridges, plateau edges, and hill-fort terrain in a calm painted-relief style. Keep the center of the board visually quiet for interactive pins and route overlays. Use warm earthy browns, stone neutrals, muted olive, and restrained sunrise gold. Make it feel adventurous, premium, and geographically grounded, not fantasy. Avoid parchment clichés, pirate-map language, photoreal satellite looks, and cluttered ornament.
+
+## Prompt 2, more playful
+Design a child-friendly Sahyadri fort board background for an educational adventure app. The board should feel like a memorable mountain world with layered ridges, soft contour cues, calm altitude, and subtle fort-region storytelling. Use a stylized storybook-relief map look with clean silhouettes and soft texture. Keep the middle area clear for gameplay. Make it warm, inviting, and regionally specific, with no noisy border art and no fantasy treasure-map tropes.
+
+## Prompt 3, system-fit refinement
+Refine this board background so it fits a modern SwiftUI design system for a premium children’s learning app. The artwork should support overlays, pins, labels, and path traces without fighting them. Prioritize a quiet central field, stronger edge framing, subtle ridge hierarchy, and a palette that keeps orange, blue, and green UI accents readable. Preserve western Maharashtra Sahyadri geography cues and a calm ceremonial tone.
+
+## Review checklist
+- Does it still feel readable behind pins and labels?
+- Does it look rooted in Sahyadri geography?
+- Is the center too busy?
+- Is it memorable without becoming noisy?
+- Does it feel like Greats of Bharatha, not generic ed-tech?
+
+## File drop expectations
+When attaching generated candidates to issue #40, include:
+- generator/tool used
+- prompt version used
+- any negative prompt or style constraints
+- edits applied after generation
+- which candidate is recommended and why

--- a/docs/design/prompts/2026-04-20-issue-40-sahyadri-board-prompts.md
+++ b/docs/design/prompts/2026-04-20-issue-40-sahyadri-board-prompts.md
@@ -1,0 +1,18 @@
+# Prompt pack for issue #40
+
+## Recommended generation sequence
+1. Run Prompt A for broad environment exploration.
+2. Run Prompt B for child-legibility and warmth.
+3. Run Prompt C on the strongest candidate for product-fit refinement.
+
+## Prompt A
+Create a stylized map-board environment for a children’s history-learning app about Shivaji Maharaj and Sahyadri forts. Show layered western Maharashtra mountain ridges, plateau edges, and hill-fort terrain in a calm painted-relief style. Keep the center of the board visually quiet for interactive pins and route overlays. Use warm earthy browns, stone neutrals, muted olive, and restrained sunrise gold. Make it feel adventurous, premium, and geographically grounded, not fantasy. Avoid parchment clichés, pirate-map language, photoreal satellite looks, and cluttered ornament.
+
+## Prompt B
+Design a child-friendly Sahyadri fort board background for an educational adventure app. The board should feel like a memorable mountain world with layered ridges, soft contour cues, calm altitude, and subtle fort-region storytelling. Use a stylized storybook-relief map look with clean silhouettes and soft texture. Keep the middle area clear for gameplay. Make it warm, inviting, and regionally specific, with no noisy border art and no fantasy treasure-map tropes.
+
+## Prompt C
+Refine this board background so it fits a modern SwiftUI design system for a premium children’s learning app. The artwork should support overlays, pins, labels, and path traces without fighting them. Prioritize a quiet central field, stronger edge framing, subtle ridge hierarchy, and a palette that keeps orange, blue, and green UI accents readable. Preserve western Maharashtra Sahyadri geography cues and a calm ceremonial tone.
+
+## Optional negative prompt
+No pirate map, no parchment scroll, no fantasy kingdom map, no medieval Europe styling, no battle scene, no photoreal satellite texture, no cluttered border, no dark muddy palette, no text labels baked into image.

--- a/docs/design/prompts/2026-04-20-issue-41-chronicle-reward-prompts.md
+++ b/docs/design/prompts/2026-04-20-issue-41-chronicle-reward-prompts.md
@@ -1,0 +1,24 @@
+# Prompt pack for issue #41
+
+## Recommended generation sequence
+1. Run Set Prompt A to explore the shared reward language.
+2. Run individual reward prompts for refinement.
+3. Run Product-fit Prompt to simplify and improve card readability.
+
+## Set Prompt A
+Create a cohesive set of four ceremonial reward illustrations for a children’s learning app about Shivaji Maharaj. Rewards: Birth Fort, First Big Fort, Mountain Seal Fragment, Planning Badge. Use a unified storybook emblem style, clean silhouettes, lightly layered color, calm premium warmth, and readable small-size composition. Each reward should feel earned and educational, not like a random game sticker. Avoid fantasy loot aesthetics, loud effects, clutter, neon, and generic royal clichés.
+
+## Birth Fort
+Create a ceremonial reward illustration called Birth Fort for a premium children’s history-learning app. Show a Shivneri-inspired fort silhouette with dawn light, calm protective mood, grounded mountain presence, and a respectful storybook emblem style. Keep the image simple, silhouette-first, warm, and highly readable at small card size.
+
+## First Big Fort
+Create a ceremonial reward illustration called First Big Fort for a premium children’s history-learning app. Show a Torna-inspired fort silhouette with upward momentum, breakthrough energy, ridgeline drama, and warm premium storybook emblem styling. Keep the image simple, earned-feeling, and readable at mobile card size.
+
+## Mountain Seal Fragment
+Create a ceremonial reward illustration called Mountain Seal Fragment for a premium children’s history-learning app. Use an abstract mountain-and-seal emblem fragment motif that feels collectible, meaningful, and rooted in hill-fort geography rather than fantasy treasure aesthetics. Keep the silhouette clear and the composition clean.
+
+## Planning Badge
+Create a ceremonial reward illustration called Planning Badge for a premium children’s history-learning app. Use route-planning, preparation, and mountain-base strategy motifs in a calm, respectful, child-legible emblem style. Avoid militaristic excess, clutter, and generic badge clichés.
+
+## Product-fit Prompt
+Refine this Chronicle reward illustration for a SwiftUI-based children’s educational app. Keep the composition simple, premium, respectful, and highly readable on mobile cards. Emphasize one core motif, one emotional tone, and a collectible keepsake feeling. Avoid clutter, neon, heavy realism, and generic game reward styling.

--- a/docs/design/review-notes/2026-04-20-asset-review-checklist.md
+++ b/docs/design/review-notes/2026-04-20-asset-review-checklist.md
@@ -1,0 +1,22 @@
+# Asset review checklist for #40 and #41
+
+Use this checklist when generated candidates are attached to the GitHub issues.
+
+## Shared checks
+- Does it improve product distinctiveness?
+- Is it readable on iPhone first?
+- Does it match the design system’s calm premium tone?
+- Is it culturally and historically respectful?
+- Does it avoid generic ed-tech / generic mobile-game styling?
+
+## Issue #40, fort board checks
+- Can gameplay overlays still dominate the board?
+- Is the center quiet enough?
+- Does the geography feel Sahyadri-specific?
+- Does the art help place memory rather than distract?
+
+## Issue #41, Chronicle checks
+- Does each reward feel earned?
+- Can each reward be recognized at card size?
+- Do all four feel like one family?
+- Does the ceremony increase without adding clutter?


### PR DESCRIPTION
## Summary
Adds durable repo-side asset packets for the two follow-up asset streams created from #38.

What this PR adds:
- detailed brief for the Sahyadri fort board environment pack (#40)
- detailed brief for the Chronicle reward illustration system (#41)
- prompt packs for both issue threads
- a shared review checklist for evaluating generated candidates
- README links so future contributors can find the packet files quickly

## Why
The assets are still pending, but the generation and review work should be structured, versioned, and prompt-ready in the repo instead of living only in issue bodies.

## Linked issues
- refs #40
- refs #41
