### PR TITLE
feat: simplify the kid-first lesson path

### DIFF
--- a/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
+++ b/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
@@ -3,6 +3,10 @@ import SwiftUI
 struct LessonHomeView: View {
     @EnvironmentObject private var appModel: AppModel
 
+    private var unlockedRewardsCount: Int {
+        appModel.lessonStore.unlockedRewards(from: appModel.content.rewards).count
+    }
+
     var body: some View {
         GBLayoutContextReader { context in
             ScrollView {
@@ -30,12 +34,12 @@ struct LessonHomeView: View {
                             GBSectionHeader(
                                 eyebrow: "Quest",
                                 title: "Story to fort to Chronicle",
-                                subtitle: "Keep the loop simple: hear a moment, remember its place, and collect the meaning it unlocks."
+                                subtitle: "Keep the loop simple: hear one moment, find its fort, then collect the meaning it unlocks."
                             )
 
                             GBQuestProgress(
                                 steps: [.story, .place, .chronicle],
-                                currentStepID: "story"
+                                currentStepID: unlockedRewardsCount > 0 ? "chronicle" : "story"
                             )
                         }
                     }
@@ -44,20 +48,30 @@ struct LessonHomeView: View {
                         GBSectionHeader(
                             eyebrow: "Story Path",
                             title: "Choose a Shivaji Maharaj moment",
-                            subtitle: "Each scene keeps one story beat, one place clue, and one quick recall before the reward."
+                            subtitle: "Only the next unfinished scene opens by default, so kids stay focused on one clear task."
                         )
 
                         ForEach(appModel.content.scenes) { scene in
-                            NavigationLink {
-                                SceneLessonView(scene: scene)
-                            } label: {
-                                SceneRowCard(
-                                    scene: scene,
-                                    mastery: appModel.lessonStore.mastery(for: scene.id),
-                                    isNext: scene.id == appModel.lessonStore.nextSceneID
-                                )
+                            let isUnlocked = appModel.lessonStore.isSceneUnlocked(scene)
+                            let card = SceneRowCard(
+                                scene: scene,
+                                mastery: appModel.lessonStore.mastery(for: scene.id),
+                                isNext: scene.id == appModel.lessonStore.nextSceneID,
+                                isLocked: !isUnlocked
+                            )
+
+                            Group {
+                                if isUnlocked {
+                                    NavigationLink {
+                                        SceneLessonView(scene: scene)
+                                    } label: {
+                                        card
+                                    }
+                                    .buttonStyle(.plain)
+                                } else {
+                                    card
+                                }
                             }
-                            .buttonStyle(.plain)
                         }
                     }
 
@@ -71,16 +85,28 @@ struct LessonHomeView: View {
                     }
                     .buttonStyle(.plain)
 
-                    NavigationLink {
-                        ChronicleView(rewards: appModel.content.rewards)
-                    } label: {
-                        ChronicleTeaserCard(
-                            headline: appModel.lessonStore.chronicleHeadline,
-                            unlockedCount: appModel.lessonStore.unlockedRewards(from: appModel.content.rewards).count,
-                            totalCount: appModel.content.rewards.count
-                        )
+                    Group {
+                        if unlockedRewardsCount > 0 {
+                            NavigationLink {
+                                ChronicleView(rewards: appModel.content.rewards)
+                            } label: {
+                                ChronicleTeaserCard(
+                                    headline: appModel.lessonStore.chronicleHeadline,
+                                    unlockedCount: unlockedRewardsCount,
+                                    totalCount: appModel.content.rewards.count,
+                                    isLocked: false
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        } else {
+                            ChronicleTeaserCard(
+                                headline: "Finish one scene to unlock the first keepsake.",
+                                unlockedCount: unlockedRewardsCount,
+                                totalCount: appModel.content.rewards.count,
+                                isLocked: true
+                            )
+                        }
                     }
-                    .buttonStyle(.plain)
                 }
                 .frame(maxWidth: context.maxContentWidth, alignment: .leading)
                 .padding(context.containerPadding)
@@ -103,6 +129,7 @@ private struct SceneRowCard: View {
     let scene: StoryScene
     let mastery: MasteryState?
     let isNext: Bool
+    let isLocked: Bool
 
     var body: some View {
         GBSurface(style: .plain) {
@@ -113,6 +140,9 @@ private struct SceneRowCard: View {
                             GBBadge(title: "Scene \(scene.number)", symbol: GBIcon.story, emphasis: .story)
                             if isNext {
                                 GBBadge(title: "Up next", symbol: GBIcon.next, emphasis: .story)
+                            }
+                            if isLocked {
+                                GBBadge(title: "Finish scene \(scene.number - 1) first", symbol: "lock.fill", emphasis: .neutral)
                             }
                         }
 
@@ -137,12 +167,13 @@ private struct SceneRowCard: View {
                 HStack(spacing: GBSpacing.small) {
                     Label(scene.timelineMarker, systemImage: GBIcon.timeline)
                     Spacer()
-                    Label(isNext ? "Start" : "Review", systemImage: GBIcon.next)
+                    Label(isLocked ? "Locked" : (isNext ? "Start" : "Review"), systemImage: isLocked ? "lock.fill" : GBIcon.next)
                         .font(.subheadline.weight(.semibold))
                 }
                 .font(.subheadline)
                 .foregroundStyle(GBColor.Content.secondary)
             }
+            .opacity(isLocked ? 0.72 : 1)
         }
     }
 }
@@ -184,6 +215,7 @@ private struct ChronicleTeaserCard: View {
     let headline: String
     let unlockedCount: Int
     let totalCount: Int
+    let isLocked: Bool
 
     var body: some View {
         GBSurface(style: .accented(.chronicle)) {
@@ -202,10 +234,11 @@ private struct ChronicleTeaserCard: View {
 
                 Spacer()
 
-                Image(systemName: GBIcon.chronicle)
+                Image(systemName: isLocked ? "lock.fill" : GBIcon.chronicle)
                     .font(.title2)
                     .foregroundStyle(GBColor.Content.inverse)
             }
         }
+        .opacity(isLocked ? 0.82 : 1)
     }
 }

--- a/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
+++ b/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
@@ -5,20 +5,13 @@ struct SceneLessonView: View {
     let scene: StoryScene
 
     @State private var cardIndex = 0
+    @State private var storyStepComplete = false
     @State private var recallState = LessonRecallState()
     @State private var revealedMapAnchors = 0
     @State private var chosenPlanSteps: Set<String> = []
+    @State private var bonusPlanningVisible = false
     @State private var hintVisible = false
     @State private var recapVisible = false
-
-    private var progressValue: Double {
-        let bonusStep = scene.number == 2 ? 1.0 : 0.0
-        let completedCards = Double(cardIndex + 1)
-        let answered = recallState.hasAnsweredCorrectly ? 1.0 : 0.0
-        let denominator = Double(scene.interactionSteps.count) + 1.0 + bonusStep
-        let planProgress = scene.number == 2 ? min(Double(chosenPlanSteps.count) / 2.0, 1.0) : 0.0
-        return min((completedCards + Double(revealedMapAnchors > 0 ? 1 : 0) + planProgress + answered) / denominator, 1.0)
-    }
 
     private var lessonCards: [SceneCardContent] {
         [
@@ -26,6 +19,17 @@ struct SceneLessonView: View {
             SceneCardContent(id: "fact", eyebrow: "Remember this", title: scene.keyFact, body: scene.narrativeObjective, symbol: "sparkles.rectangle.stack.fill"),
             SceneCardContent(id: "timeline", eyebrow: "Chronicle moment", title: scene.timelineMarker, body: "This is the moment you will remember when you open the Royal Chronicle.", symbol: GBIcon.timeline)
         ]
+    }
+
+    private var flow: SceneLessonFlow {
+        SceneLessonFlow(
+            totalStoryCards: lessonCards.count,
+            currentStoryCardIndex: cardIndex,
+            storyStepComplete: storyStepComplete,
+            totalMapAnchors: scene.mapAnchors.count,
+            revealedMapAnchors: revealedMapAnchors,
+            hasAnsweredCorrectly: recallState.hasAnsweredCorrectly
+        )
     }
 
     private var currentStepTitle: String {
@@ -36,18 +40,8 @@ struct SceneLessonView: View {
         }
     }
 
-    private var nextCardButtonTitle: String {
-        cardIndex == lessonCards.count - 1 ? "Move to place clues" : "Continue story"
-    }
-
-    private var activeQuestStepID: String {
-        if recallState.hasAnsweredCorrectly {
-            return "chronicle"
-        }
-        if revealedMapAnchors > 0 || !chosenPlanSteps.isEmpty {
-            return "place"
-        }
-        return "story"
+    private var storyButtonTitle: String {
+        cardIndex == lessonCards.count - 1 ? "Continue to place clues" : "Continue story"
     }
 
     var body: some View {
@@ -56,7 +50,7 @@ struct SceneLessonView: View {
                 VStack(alignment: .leading, spacing: context.sectionSpacing) {
                     SceneHeaderCard(
                         scene: scene,
-                        progressValue: progressValue,
+                        progressValue: flow.progressValue,
                         mastery: appModel.lessonStore.mastery(for: scene.id)
                     )
 
@@ -65,52 +59,59 @@ struct SceneLessonView: View {
                             GBSectionHeader(
                                 eyebrow: "Quest",
                                 title: "Hear the story, remember the fort, keep the Chronicle",
-                                subtitle: "This scene only asks for one step at a time."
+                                subtitle: "Only the active step stays on screen, so the scene feels easy to finish."
                             )
 
                             GBQuestProgress(
                                 steps: [.story, .place, .chronicle],
-                                currentStepID: activeQuestStepID
+                                currentStepID: flow.currentQuestStepID
                             )
                         }
                     }
 
-                    StoryDeckCard(
-                        currentStepTitle: currentStepTitle,
-                        lessonCards: lessonCards,
-                        cardIndex: $cardIndex,
-                        nextCardButtonTitle: nextCardButtonTitle
-                    )
+                    switch flow.activeStage {
+                    case .story:
+                        StoryDeckCard(
+                            currentStepTitle: currentStepTitle,
+                            lessonCards: lessonCards,
+                            cardIndex: $cardIndex,
+                            nextCardButtonTitle: storyButtonTitle,
+                            onFinishStory: completeStoryStep
+                        )
+                    case .place:
+                        MapAnchorCard(scene: scene, revealedMapAnchors: $revealedMapAnchors)
+                    case .chronicle:
+                        SceneSupportCard(
+                            hintVisible: $hintVisible,
+                            recapVisible: recapVisible,
+                            hasAnsweredCorrectly: recallState.hasAnsweredCorrectly,
+                            curatedHint: curatedHint,
+                            sceneRecap: sceneRecap
+                        )
 
-                    MapAnchorCard(scene: scene, revealedMapAnchors: $revealedMapAnchors)
-
-                    if scene.number == 2 {
-                        FortPlanningCard(chosenPlanSteps: $chosenPlanSteps)
-                    }
-
-                    SceneSupportCard(
-                        hintVisible: $hintVisible,
-                        recapVisible: recapVisible,
-                        hasAnsweredCorrectly: recallState.hasAnsweredCorrectly,
-                        curatedHint: curatedHint,
-                        sceneRecap: sceneRecap
-                    )
-
-                    RecallPanel(
-                        question: scene.recallPrompt,
-                        choices: sceneChoices,
-                        selectedChoiceID: $recallState.selectedChoiceID,
-                        feedbackText: recallState.feedbackText,
-                        completed: recallState.hasAnsweredCorrectly,
-                        onSubmit: submitRecall
-                    )
-
-                    if recallState.hasAnsweredCorrectly {
+                        RecallPanel(
+                            question: scene.recallPrompt,
+                            choices: sceneChoices,
+                            selectedChoiceID: $recallState.selectedChoiceID,
+                            feedbackText: recallState.feedbackText,
+                            completed: recallState.hasAnsweredCorrectly,
+                            onSubmit: submitRecall
+                        )
+                    case .complete:
                         CompletedSceneActions(
                             scene: scene,
                             places: appModel.content.corePlaces,
-                            rewards: appModel.content.rewards
+                            rewards: appModel.content.rewards,
+                            recapVisible: recapVisible,
+                            sceneRecap: sceneRecap,
+                            bonusPlanningVisible: $bonusPlanningVisible,
+                            showsPlanningChallenge: scene.number == 2,
+                            hasPlanningUpgrade: chosenPlanSteps.count >= 2
                         )
+
+                        if scene.number == 2, bonusPlanningVisible {
+                            BonusPlanningCard(chosenPlanSteps: $chosenPlanSteps)
+                        }
                     }
                 }
                 .frame(maxWidth: context.maxContentWidth, alignment: .leading)
@@ -123,6 +124,15 @@ struct SceneLessonView: View {
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
 #endif
+        .onChange(of: chosenPlanSteps) { _, newValue in
+            guard scene.number == 2, recallState.hasAnsweredCorrectly, newValue.count >= 2 else { return }
+            appModel.lessonStore.markScene(scene.id, mastery: .observedClosely)
+        }
+    }
+
+    private func completeStoryStep() {
+        storyStepComplete = true
+        LessonFeedback.fire(.success)
     }
 
     private func submitRecall() {
@@ -240,6 +250,7 @@ private struct StoryDeckCard: View {
     let lessonCards: [SceneCardContent]
     @Binding var cardIndex: Int
     let nextCardButtonTitle: String
+    let onFinishStory: () -> Void
 
     var body: some View {
         GBSurface(style: .plain) {
@@ -280,8 +291,12 @@ private struct StoryDeckCard: View {
                     }
 
                     Button(nextCardButtonTitle) {
-                        cardIndex = min(cardIndex + 1, lessonCards.count - 1)
-                        LessonFeedback.fire(.selection)
+                        if cardIndex == lessonCards.count - 1 {
+                            onFinishStory()
+                        } else {
+                            cardIndex = min(cardIndex + 1, lessonCards.count - 1)
+                            LessonFeedback.fire(.selection)
+                        }
                     }
                     .buttonStyle(.gbPrimary(.story))
                 }
@@ -372,7 +387,7 @@ private struct MapAnchorCard: View {
                     .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
                 }
 
-                Button(revealedMapAnchors == scene.mapAnchors.count ? "All place clues found" : "Reveal next place clue") {
+                Button(revealedMapAnchors == scene.mapAnchors.count ? "Continue to Chronicle" : "Reveal next place clue") {
                     let nextValue = min(revealedMapAnchors + 1, scene.mapAnchors.count)
                     if nextValue != revealedMapAnchors {
                         revealedMapAnchors = nextValue
@@ -380,50 +395,6 @@ private struct MapAnchorCard: View {
                     }
                 }
                 .buttonStyle(.gbSecondary)
-            }
-        }
-    }
-}
-
-private struct FortPlanningCard: View {
-    @Binding var chosenPlanSteps: Set<String>
-
-    var body: some View {
-        GBSurface(style: .plain) {
-            VStack(alignment: .leading, spacing: GBSpacing.small) {
-                GBSectionHeader(
-                    eyebrow: "Place Practice",
-                    title: "Choose smart fort planning steps",
-                    subtitle: "Pick two choices that would help a mountain base stay ready."
-                )
-
-                ForEach(LessonPlanStep.starterSet) { step in
-                    Button {
-                        if chosenPlanSteps.contains(step.id) {
-                            chosenPlanSteps.remove(step.id)
-                        } else {
-                            chosenPlanSteps.insert(step.id)
-                        }
-                        LessonFeedback.fire(.selection)
-                    } label: {
-                        HStack(spacing: GBSpacing.small) {
-                            Image(systemName: chosenPlanSteps.contains(step.id) ? GBIcon.success : step.symbol)
-                                .foregroundStyle(chosenPlanSteps.contains(step.id) ? GBColor.Accent.success : GBColor.Accent.place)
-                            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
-                                Text(step.title)
-                                    .font(.subheadline.weight(.semibold))
-                                    .foregroundStyle(GBColor.Content.primary)
-                                Text(step.detail)
-                                    .font(.caption)
-                                    .foregroundStyle(GBColor.Content.secondary)
-                            }
-                            Spacer()
-                        }
-                        .padding(GBSpacing.small)
-                        .background(GBColor.Background.elevated, in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
-                    }
-                    .buttonStyle(.plain)
-                }
             }
         }
     }
@@ -565,6 +536,11 @@ private struct CompletedSceneActions: View {
     let scene: StoryScene
     let places: [Place]
     let rewards: [ChronicleReward]
+    let recapVisible: Bool
+    let sceneRecap: String
+    @Binding var bonusPlanningVisible: Bool
+    let showsPlanningChallenge: Bool
+    let hasPlanningUpgrade: Bool
 
     var body: some View {
         GBSurface(style: .accented(.chronicle)) {
@@ -576,6 +552,12 @@ private struct CompletedSceneActions: View {
                     tone: .inverse,
                     trailing: AnyView(GBBadge(title: "Reward ready", symbol: GBIcon.chronicle, emphasis: .chronicle))
                 )
+
+                if recapVisible {
+                    Text(sceneRecap)
+                        .font(.subheadline)
+                        .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
+                }
 
                 NavigationLink {
                     ChronicleView(rewards: rewards, highlightRewardID: scene.rewardID)
@@ -592,6 +574,59 @@ private struct CompletedSceneActions: View {
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.gbSecondary)
+
+                if showsPlanningChallenge {
+                    Button(hasPlanningUpgrade ? "Bonus planning challenge complete" : (bonusPlanningVisible ? "Hide bonus planning challenge" : "Try the bonus planning challenge")) {
+                        bonusPlanningVisible.toggle()
+                        LessonFeedback.fire(.selection)
+                    }
+                    .buttonStyle(.gbSecondary)
+                    .disabled(hasPlanningUpgrade)
+                }
+            }
+        }
+    }
+}
+
+private struct BonusPlanningCard: View {
+    @Binding var chosenPlanSteps: Set<String>
+
+    var body: some View {
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Bonus Challenge",
+                    title: "Choose smart fort planning steps",
+                    subtitle: "Pick any two choices that would help a mountain base stay ready."
+                )
+
+                ForEach(LessonPlanStep.starterSet) { step in
+                    Button {
+                        if chosenPlanSteps.contains(step.id) {
+                            chosenPlanSteps.remove(step.id)
+                        } else {
+                            chosenPlanSteps.insert(step.id)
+                        }
+                        LessonFeedback.fire(.selection)
+                    } label: {
+                        HStack(spacing: GBSpacing.small) {
+                            Image(systemName: chosenPlanSteps.contains(step.id) ? GBIcon.success : step.symbol)
+                                .foregroundStyle(chosenPlanSteps.contains(step.id) ? GBColor.Accent.success : GBColor.Accent.place)
+                            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                                Text(step.title)
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(GBColor.Content.primary)
+                                Text(step.detail)
+                                    .font(.caption)
+                                    .foregroundStyle(GBColor.Content.secondary)
+                            }
+                            Spacer()
+                        }
+                        .padding(GBSpacing.small)
+                        .background(GBColor.Background.elevated, in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
     }

--- a/GreatsOfBharatha/Shared/Models/ShivajiLessonModels.swift
+++ b/GreatsOfBharatha/Shared/Models/ShivajiLessonModels.swift
@@ -12,6 +12,59 @@ struct LessonRecallState: Equatable {
     var hasAnsweredCorrectly = false
 }
 
+enum SceneLessonStage: Equatable {
+    case story
+    case place
+    case chronicle
+    case complete
+}
+
+struct SceneLessonFlow: Equatable {
+    let totalStoryCards: Int
+    let currentStoryCardIndex: Int
+    let storyStepComplete: Bool
+    let totalMapAnchors: Int
+    let revealedMapAnchors: Int
+    let hasAnsweredCorrectly: Bool
+
+    var activeStage: SceneLessonStage {
+        if hasAnsweredCorrectly {
+            return .complete
+        }
+        if placeStepComplete {
+            return .chronicle
+        }
+        if storyStepComplete {
+            return .place
+        }
+        return .story
+    }
+
+    var currentQuestStepID: String {
+        switch activeStage {
+        case .story:
+            return "story"
+        case .place:
+            return "place"
+        case .chronicle, .complete:
+            return "chronicle"
+        }
+    }
+
+    var placeStepComplete: Bool {
+        totalMapAnchors == 0 || revealedMapAnchors >= totalMapAnchors
+    }
+
+    var progressValue: Double {
+        let safeStoryCardCount = max(totalStoryCards, 1)
+        let safeMapAnchorCount = max(totalMapAnchors, 1)
+        let storyProgress = storyStepComplete ? 1.0 : min(Double(currentStoryCardIndex + 1) / Double(safeStoryCardCount + 1), 0.95)
+        let placeProgress = storyStepComplete ? (placeStepComplete ? 1.0 : Double(revealedMapAnchors) / Double(safeMapAnchorCount)) : 0.0
+        let chronicleProgress = hasAnsweredCorrectly ? 1.0 : 0.0
+        return min((storyProgress + placeProgress + chronicleProgress) / 3.0, 1.0)
+    }
+}
+
 struct LessonPlanStep: Identifiable, Hashable {
     let id: String
     let title: String

--- a/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
+++ b/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
@@ -17,6 +17,17 @@ final class ShivajiLessonStore: ObservableObject {
         masteryByScene[sceneID]
     }
 
+    func isSceneUnlocked(_ scene: StoryScene) -> Bool {
+        guard let sceneIndex = content.scenes.firstIndex(where: { $0.id == scene.id }) else {
+            return false
+        }
+        if sceneIndex == 0 {
+            return true
+        }
+        let previousScene = content.scenes[content.scenes.index(before: sceneIndex)]
+        return mastery(for: previousScene.id) != nil
+    }
+
     func markScene(_ sceneID: String, mastery: MasteryState) {
         let current = masteryByScene[sceneID] ?? .witnessed
         masteryByScene[sceneID] = higherMastery(current, mastery)

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -9,10 +9,70 @@ final class GreatsOfBharathaTests: XCTestCase {
     }
 
     func testLessonStoreTracksProgress() {
-        let store = ShivajiLessonStore()
+        let store = ShivajiLessonStore(defaults: UserDefaults(suiteName: #function)!)
         XCTAssertEqual(store.completedScenes, 0)
         store.markScene("scene-1-shivneri", mastery: .witnessed)
         XCTAssertEqual(store.completedScenes, 1)
         XCTAssertNotNil(store.nextSceneID)
+    }
+
+    func testLessonFlowAdvancesOneStageAtATime() {
+        let initial = SceneLessonFlow(
+            totalStoryCards: 3,
+            currentStoryCardIndex: 0,
+            storyStepComplete: false,
+            totalMapAnchors: 3,
+            revealedMapAnchors: 0,
+            hasAnsweredCorrectly: false
+        )
+        XCTAssertEqual(initial.activeStage, .story)
+        XCTAssertEqual(initial.currentQuestStepID, "story")
+
+        let afterStory = SceneLessonFlow(
+            totalStoryCards: 3,
+            currentStoryCardIndex: 2,
+            storyStepComplete: true,
+            totalMapAnchors: 3,
+            revealedMapAnchors: 1,
+            hasAnsweredCorrectly: false
+        )
+        XCTAssertEqual(afterStory.activeStage, .place)
+        XCTAssertEqual(afterStory.currentQuestStepID, "place")
+
+        let afterPlaces = SceneLessonFlow(
+            totalStoryCards: 3,
+            currentStoryCardIndex: 2,
+            storyStepComplete: true,
+            totalMapAnchors: 3,
+            revealedMapAnchors: 3,
+            hasAnsweredCorrectly: false
+        )
+        XCTAssertEqual(afterPlaces.activeStage, .chronicle)
+        XCTAssertEqual(afterPlaces.currentQuestStepID, "chronicle")
+
+        let completed = SceneLessonFlow(
+            totalStoryCards: 3,
+            currentStoryCardIndex: 2,
+            storyStepComplete: true,
+            totalMapAnchors: 3,
+            revealedMapAnchors: 3,
+            hasAnsweredCorrectly: true
+        )
+        XCTAssertEqual(completed.activeStage, .complete)
+        XCTAssertEqual(completed.currentQuestStepID, "chronicle")
+        XCTAssertEqual(completed.progressValue, 1.0)
+    }
+
+    func testLessonStoreUnlocksOnlyNextSceneByDefault() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let store = ShivajiLessonStore(defaults: defaults)
+
+        XCTAssertTrue(store.isSceneUnlocked(SampleContent.scene1))
+        XCTAssertFalse(store.isSceneUnlocked(SampleContent.scene2))
+
+        store.markScene(SampleContent.scene1.id, mastery: .understood)
+
+        XCTAssertTrue(store.isSceneUnlocked(SampleContent.scene2))
     }
 }


### PR DESCRIPTION
## Summary
- turn each scene into a single-step flow that only shows the active quest surface
- keep later scenes and the Chronicle entry point locked until earlier story progress exists
- move scene 2 planning practice into an optional post-success bonus challenge and add flow tests

## Testing
- git diff --check
- xcodebuild test on ganesh-mba (blocked: ssh route to mba was unavailable during this run)