### PR TITLE
feat: add card recall architecture foundation

### DIFF
--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0A4A9F8F0C1A4F32965E1011 /* GBSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F8E0C1A4F32965E1011 /* GBSpacing.swift */; };
 		0A4A9F910C1A4F32965E1011 /* GBLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A9F900C1A4F32965E1011 /* GBLayoutContext.swift */; };
 		16E40D4D9552B57A027D9FF5 /* StoryHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA3B33CD2FFC1A53263C40A /* StoryHomeView.swift */; };
+		1A7C4F102B8E4C1D9A001122 /* HeroArcModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7C4F0F2B8E4C1D9A001122 /* HeroArcModels.swift */; };
 		1F8C2F1A8E2D4A1B9C7D1234 /* DebugNavigationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C2F198E2D4A1B9C7D1234 /* DebugNavigationRoute.swift */; };
 		229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE540544C5E9622DB91B7EF8 /* ContentView.swift */; };
 		22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB428856E6E0B33ECEAA8E36 /* LessonHomeView.swift */; };
@@ -69,6 +70,7 @@
 		0A4A9F8C0C1A4F32965E1011 /* GBRadius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBRadius.swift; sourceTree = "<group>"; };
 		0A4A9F8E0C1A4F32965E1011 /* GBSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSpacing.swift; sourceTree = "<group>"; };
 		0A4A9F900C1A4F32965E1011 /* GBLayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBLayoutContext.swift; sourceTree = "<group>"; };
+		1A7C4F0F2B8E4C1D9A001122 /* HeroArcModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroArcModels.swift; sourceTree = "<group>"; };
 		1F8C2F198E2D4A1B9C7D1234 /* DebugNavigationRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugNavigationRoute.swift; sourceTree = "<group>"; };
 		2C6D8E0E1A2B3C4D5E6F7081 /* LessonFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonFeedback.swift; sourceTree = "<group>"; };
 		38AE753749107F40681898D3 /* GreatsOfBharathaTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = GreatsOfBharathaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -142,6 +144,7 @@
 			children = (
 				6413C33179A188AA0729938F /* AppModel.swift */,
 				842D0166597E3756A21D8739 /* ContentModels.swift */,
+				1A7C4F0F2B8E4C1D9A001122 /* HeroArcModels.swift */,
 				901C5A02CDD2D6DA5162F535 /* MasteryState.swift */,
 				71BEDED465CA437D09ADDCD5 /* SampleContent.swift */,
 				C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */,
@@ -348,6 +351,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1A7C4F102B8E4C1D9A001122 /* HeroArcModels.swift in Sources */,
 				0A4A9F7F0C1A4F32965E1011 /* GBBadge.swift in Sources */,
 				0A4A9F770C1A4F32965E1011 /* GBButtonStyle.swift in Sources */,
 				0A4A9F850C1A4F32965E1011 /* GBCardStyle.swift in Sources */,

--- a/GreatsOfBharatha/Shared/Models/ContentModels.swift
+++ b/GreatsOfBharatha/Shared/Models/ContentModels.swift
@@ -1,10 +1,47 @@
 import Foundation
 
 struct AppContent: Equatable {
-    let arcTitle: String
-    let scenes: [StoryScene]
-    let places: [Place]
-    let rewards: [ChronicleReward]
+    let heroArcs: [HeroArc]
+    let selectedHeroID: String
+
+    init(heroArc: HeroArc) {
+        self.heroArcs = [heroArc]
+        self.selectedHeroID = heroArc.id
+    }
+
+    init(heroArcs: [HeroArc], selectedHeroID: String) {
+        self.heroArcs = heroArcs
+        self.selectedHeroID = selectedHeroID
+    }
+
+    init(arcTitle: String, scenes: [StoryScene], places: [Place], rewards: [ChronicleReward]) {
+        self = LegacyAppContentAdapter.makeContent(
+            arcTitle: arcTitle,
+            scenes: scenes,
+            places: places,
+            rewards: rewards
+        )
+    }
+
+    var activeHeroArc: HeroArc {
+        heroArcs.first(where: { $0.id == selectedHeroID }) ?? heroArcs[0]
+    }
+
+    var arcTitle: String {
+        activeHeroArc.title
+    }
+
+    var scenes: [StoryScene] {
+        activeHeroArc.scenes.map { LegacySceneAdapter.makeStoryScene(from: $0) }
+    }
+
+    var places: [Place] {
+        activeHeroArc.locationNodes.map { LegacyPlaceAdapter.makePlace(from: $0) }
+    }
+
+    var rewards: [ChronicleReward] {
+        activeHeroArc.chronicleEntries.map { LegacyChronicleAdapter.makeReward(from: $0) }
+    }
 
     var corePlaces: [Place] {
         places.filter { $0.isCoreReleasePlace }
@@ -65,4 +102,183 @@ enum RewardCategory: String, CaseIterable, Equatable {
     case storyCard = "Story Card"
     case emblemFragment = "Emblem Fragment"
     case leadershipBadge = "Leadership Badge"
+}
+
+enum LegacySceneAdapter {
+    static func makeStoryScene(from scene: SceneCluster) -> StoryScene {
+        let recallChallenge = scene.primaryRecallChallenge
+        return StoryScene(
+            id: scene.id,
+            number: scene.sceneNumber,
+            title: scene.title,
+            narrativeObjective: scene.narrativeObjective,
+            keyFact: scene.keyFact,
+            childSafeSummary: scene.childSafeSummary,
+            mapAnchors: scene.mapAnchorIDs,
+            timelineMarker: scene.timelineEventID,
+            interactionSteps: [
+                "Reveal the opening story moment.",
+                "Hear why the moment matters.",
+                "Use the memory hook to anchor the place or event.",
+                "Answer the recall challenge before collecting the Chronicle keepsake."
+            ],
+            recallPrompt: RecallPrompt(
+                question: recallChallenge?.prompt ?? "Recall the key idea from this scene.",
+                answer: recallChallenge?.correctAnswers.first ?? "",
+                supportText: recallChallenge?.hintLadder.first?.body ?? scene.meaningStatement
+            ),
+            rewardID: scene.chronicleEntryIDs.first ?? scene.id + "-reward"
+        )
+    }
+}
+
+enum LegacyPlaceAdapter {
+    static func makePlace(from node: LocationNode) -> Place {
+        Place(
+            id: node.id,
+            name: node.name,
+            memoryHook: node.memoryHook,
+            primaryEvent: node.primaryEvent,
+            whyItMatters: node.primaryEvent,
+            regionLabel: node.regionLabel,
+            latitude: node.canonicalCoordinate.latitude,
+            longitude: node.canonicalCoordinate.longitude,
+            progress: .locked,
+            isCoreReleasePlace: node.isCoreReleasePlace
+        )
+    }
+}
+
+enum LegacyChronicleAdapter {
+    static func makeReward(from entry: ChronicleEntry) -> ChronicleReward {
+        ChronicleReward(
+            id: entry.id,
+            title: entry.title,
+            subtitle: entry.keepsakeTitle,
+            meaning: entry.meaningStatement,
+            unlockedBySceneID: entry.linkedSceneID,
+            mastery: entry.unlockRule.requiredMastery,
+            category: .storyCard
+        )
+    }
+}
+
+enum LegacyAppContentAdapter {
+    static func makeContent(arcTitle: String, scenes: [StoryScene], places: [Place], rewards: [ChronicleReward]) -> AppContent {
+        let sceneClusters = scenes.map { scene in
+            SceneCluster(
+                id: scene.id,
+                sceneNumber: scene.number,
+                title: scene.title,
+                narrativeObjective: scene.narrativeObjective,
+                keyFact: scene.keyFact,
+                meaningStatement: scene.recallPrompt.supportText,
+                childSafeSummary: scene.childSafeSummary,
+                mapAnchorIDs: scene.mapAnchors,
+                timelineEventID: scene.timelineMarker,
+                cards: [
+                    LearningCard(
+                        id: scene.id + "-story",
+                        type: .story,
+                        title: scene.title,
+                        text: scene.childSafeSummary,
+                        narration: scene.childSafeSummary,
+                        imageKey: scene.id,
+                        memoryHook: nil,
+                        difficultyBand: .standard
+                    )
+                ],
+                recallChallenges: [
+                    RecallChallenge(
+                        id: scene.id + "-recall",
+                        promptType: .openPrompt,
+                        prompt: scene.recallPrompt.question,
+                        correctAnswers: [scene.recallPrompt.answer],
+                        hintLadder: [RecallHint(level: 1, title: "Story clue", body: scene.recallPrompt.supportText)],
+                        feedback: RecallFeedback(success: scene.recallPrompt.supportText, recovery: scene.recallPrompt.supportText),
+                        masteryContribution: .understood
+                    )
+                ],
+                chronicleEntryIDs: [scene.rewardID]
+            )
+        }
+
+        let chronicleEntries = rewards.map { reward in
+            ChronicleEntry(
+                id: reward.id,
+                title: reward.title,
+                keepsakeTitle: reward.subtitle,
+                meaningStatement: reward.meaning,
+                linkedSceneID: reward.unlockedBySceneID,
+                linkedPlaceID: nil,
+                linkedTimelineEventID: nil,
+                unlockRule: UnlockRule(requiredMastery: reward.mastery, enhancedMastery: .chronicled)
+            )
+        }
+
+        let locationNodes = places.map { place in
+            let linkedSceneIDs = sceneClusters
+                .filter { scene in
+                    scene.mapAnchorIDs.contains(where: { $0.localizedCaseInsensitiveContains(place.name) })
+                }
+                .map { $0.id }
+
+            return LocationNode(
+                id: place.id,
+                name: place.name,
+                canonicalCoordinate: Coordinate(latitude: place.latitude, longitude: place.longitude),
+                memoryHook: place.memoryHook,
+                primaryEvent: place.primaryEvent,
+                regionLabel: place.regionLabel,
+                linkedSceneIDs: linkedSceneIDs,
+                linkedTimelineEventIDs: [],
+                unlockRule: UnlockRule(requiredMastery: .understood, enhancedMastery: .placed),
+                isCoreReleasePlace: place.isCoreReleasePlace
+            )
+        }
+
+        let timelineEvents = sceneClusters.enumerated().map { index, scene in
+            let linkedPlaceIDs = locationNodes
+                .filter { node in
+                    !Set(node.linkedSceneIDs).isDisjoint(with: [scene.id])
+                }
+                .map { $0.id }
+
+            return TimelineEvent(
+                id: scene.timelineEventID,
+                title: scene.timelineEventID,
+                orderIndex: index,
+                broadEraLabel: "Hero journey",
+                yearLabel: nil,
+                linkedPlaceIDs: linkedPlaceIDs,
+                recallPrompt: "Place \(scene.title) in the right sequence.",
+                unlockRule: UnlockRule(requiredMastery: .remembered, enhancedMastery: .placed)
+            )
+        }
+
+        let hero = Hero(
+            id: selectedHeroID(for: arcTitle),
+            name: arcTitle,
+            subtitle: arcTitle,
+            culturalFramingNotes: "Migrated from legacy content.",
+            ageBandCopyVariants: [.standard: arcTitle]
+        )
+
+        let heroArc = HeroArc(
+            id: hero.id,
+            hero: hero,
+            title: arcTitle,
+            scenes: sceneClusters,
+            chronicleEntries: chronicleEntries,
+            locationNodes: locationNodes,
+            timelineEvents: timelineEvents,
+            reviewBlueprints: []
+        )
+
+        return AppContent(heroArc: heroArc)
+    }
+
+    private static func selectedHeroID(for arcTitle: String) -> String {
+        arcTitle.lowercased().replacingOccurrences(of: " ", with: "-")
+    }
 }

--- a/GreatsOfBharatha/Shared/Models/HeroArcModels.swift
+++ b/GreatsOfBharatha/Shared/Models/HeroArcModels.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+struct HeroArc: Identifiable, Equatable {
+    let id: String
+    let hero: Hero
+    let title: String
+    let scenes: [SceneCluster]
+    let chronicleEntries: [ChronicleEntry]
+    let locationNodes: [LocationNode]
+    let timelineEvents: [TimelineEvent]
+    let reviewBlueprints: [ReviewSchedule]
+
+    var orderedSceneIDs: [String] {
+        scenes.map { $0.id }
+    }
+
+    func scene(withID sceneID: String) -> SceneCluster? {
+        scenes.first(where: { $0.id == sceneID })
+    }
+
+    func chronicleEntry(withID entryID: String) -> ChronicleEntry? {
+        chronicleEntries.first(where: { $0.id == entryID })
+    }
+
+    func locationNode(withID locationID: String) -> LocationNode? {
+        locationNodes.first(where: { $0.id == locationID })
+    }
+
+    func timelineEvent(withID eventID: String) -> TimelineEvent? {
+        timelineEvents.first(where: { $0.id == eventID })
+    }
+}
+
+struct Hero: Equatable {
+    let id: String
+    let name: String
+    let subtitle: String
+    let culturalFramingNotes: String
+    let ageBandCopyVariants: [AgeBand: String]
+}
+
+enum AgeBand: String, Codable, CaseIterable, Equatable {
+    case assist
+    case standard
+}
+
+struct SceneCluster: Identifiable, Equatable {
+    let id: String
+    let sceneNumber: Int
+    let title: String
+    let narrativeObjective: String
+    let keyFact: String
+    let meaningStatement: String
+    let childSafeSummary: String
+    let mapAnchorIDs: [String]
+    let timelineEventID: String
+    let cards: [LearningCard]
+    let recallChallenges: [RecallChallenge]
+    let chronicleEntryIDs: [String]
+
+    var primaryRecallChallenge: RecallChallenge? {
+        recallChallenges.first
+    }
+}
+
+enum LearningCardType: String, Codable, CaseIterable, Equatable {
+    case story
+    case meaning
+    case anchor
+    case recall
+    case compare
+    case reward
+    case review
+}
+
+struct LearningCard: Identifiable, Equatable {
+    let id: String
+    let type: LearningCardType
+    let title: String
+    let text: String
+    let narration: String
+    let imageKey: String
+    let memoryHook: String?
+    let difficultyBand: DifficultyBand
+}
+
+enum DifficultyBand: String, Codable, CaseIterable, Equatable {
+    case assist
+    case standard
+    case stretch
+}
+
+enum RecallPromptType: String, Codable, CaseIterable, Equatable {
+    case openPrompt
+    case mapPlacement
+    case sequenceSlot
+    case eventToPlaceMatch
+    case compareFromMemory
+}
+
+struct RecallChallenge: Identifiable, Equatable {
+    let id: String
+    let promptType: RecallPromptType
+    let prompt: String
+    let correctAnswers: [String]
+    let hintLadder: [RecallHint]
+    let feedback: RecallFeedback
+    let masteryContribution: MasteryState
+}
+
+struct RecallHint: Codable, Equatable {
+    let level: Int
+    let title: String
+    let body: String
+}
+
+struct RecallFeedback: Codable, Equatable {
+    let success: String
+    let recovery: String
+}
+
+enum MasterySubjectType: String, Codable, CaseIterable, Equatable {
+    case scene
+    case chronicle
+    case location
+    case timeline
+}
+
+enum MasteryEvidenceType: String, Codable, CaseIterable, Equatable {
+    case storyExposure
+    case recallAttempt
+    case recallSuccess
+    case mapPlacementSuccess
+    case timelinePlacementSuccess
+    case reviewSuccess
+    case chronicleReflection
+}
+
+struct MasteryEvidence: Codable, Equatable {
+    let type: MasteryEvidenceType
+    let recordedAt: Date
+    let detail: String
+}
+
+struct MasteryRecord: Codable, Equatable {
+    let subjectID: String
+    let subjectType: MasterySubjectType
+    var state: MasteryState
+    var exposureCount: Int
+    var successfulReviewCount: Int
+    var lastReviewedAt: Date?
+    var evidenceLog: [MasteryEvidence]
+}
+
+struct ChronicleEntry: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let keepsakeTitle: String
+    let meaningStatement: String
+    let linkedSceneID: String
+    let linkedPlaceID: String?
+    let linkedTimelineEventID: String?
+    let unlockRule: UnlockRule
+}
+
+struct UnlockRule: Codable, Equatable {
+    let requiredMastery: MasteryState
+    let enhancedMastery: MasteryState?
+}
+
+enum ChronicleUnlockState: String, Codable, CaseIterable, Equatable {
+    case silhouette
+    case unlocked
+    case enriched
+}
+
+struct LocationNode: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let canonicalCoordinate: Coordinate
+    let memoryHook: String
+    let primaryEvent: String
+    let regionLabel: String
+    let linkedSceneIDs: [String]
+    let linkedTimelineEventIDs: [String]
+    let unlockRule: UnlockRule
+    let isCoreReleasePlace: Bool
+}
+
+struct Coordinate: Codable, Equatable {
+    let latitude: Double
+    let longitude: Double
+}
+
+enum LocationUnlockState: String, Codable, CaseIterable, Equatable {
+    case hidden
+    case seenInStory
+    case learnable
+    case remembered
+    case placedAccurately
+    case masteredInReview
+}
+
+struct TimelineEvent: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let orderIndex: Int
+    let broadEraLabel: String
+    let yearLabel: String?
+    let linkedPlaceIDs: [String]
+    let recallPrompt: String
+    let unlockRule: UnlockRule
+}
+
+struct ReviewSchedule: Codable, Equatable {
+    let subjectID: String
+    let subjectType: MasterySubjectType
+    var nextDueAt: Date
+    var intervalIndex: Int
+    var stabilityBand: ReviewStabilityBand
+    var difficultyAdjustment: Int
+    let cadenceDays: [Int]
+}
+
+enum ReviewStabilityBand: String, Codable, CaseIterable, Equatable {
+    case new
+    case warming
+    case steady
+    case durable
+}

--- a/GreatsOfBharatha/Shared/Models/MasteryState.swift
+++ b/GreatsOfBharatha/Shared/Models/MasteryState.swift
@@ -1,7 +1,31 @@
 import Foundation
 
-enum MasteryState: String, CaseIterable, Equatable {
+enum MasteryState: String, CaseIterable, Codable, Equatable, Comparable {
     case witnessed = "Witnessed"
     case understood = "Understood"
     case observedClosely = "Observed Closely"
+    case remembered = "Remembered"
+    case placed = "Placed"
+    case chronicled = "Chronicled"
+
+    var rank: Int {
+        switch self {
+        case .witnessed:
+            return 0
+        case .understood:
+            return 1
+        case .observedClosely:
+            return 2
+        case .remembered:
+            return 3
+        case .placed:
+            return 4
+        case .chronicled:
+            return 5
+        }
+    }
+
+    static func < (lhs: MasteryState, rhs: MasteryState) -> Bool {
+        lhs.rank < rhs.rank
+    }
 }

--- a/GreatsOfBharatha/Shared/Models/SampleContent.swift
+++ b/GreatsOfBharatha/Shared/Models/SampleContent.swift
@@ -1,174 +1,488 @@
 import Foundation
 
 enum SampleContent {
-    static let shivajiVerticalSlice = AppContent(
-        arcTitle: "Shivaji Arc",
-        scenes: [scene1, scene2],
-        places: [shivneri, torna, rajgad, pratapgad, raigad, purandar],
-        rewards: [birthFortCard, firstBigFortCard, mountainSealFragment, planningBadge]
+    private enum IDs {
+        static let heroArc = "hero-shivaji"
+
+        static let scene1 = "scene-1-shivneri"
+        static let scene2 = "scene-2-torna-rajgad"
+        static let scene3 = "scene-3-rajgad-planning"
+        static let scene4 = "scene-4-pratapgad"
+        static let scene5 = "scene-5-comeback"
+        static let scene6 = "scene-6-raigad"
+
+        static let placeShivneri = "place-shivneri"
+        static let placeTorna = "place-torna"
+        static let placeRajgad = "place-rajgad"
+        static let placePratapgad = "place-pratapgad"
+        static let placeRaigad = "place-raigad"
+        static let placePurandar = "place-purandar"
+        static let placeSinhagad = "place-sinhagad"
+
+        static let eventBirth = "event-birth-fort"
+        static let eventFirstFort = "event-first-fort"
+        static let eventEarlyCapital = "event-early-capital"
+        static let eventTurningPoint = "event-turning-point"
+        static let eventComeback = "event-comeback"
+        static let eventCoronation = "event-coronation"
+
+        static let chronicleBirth = "chronicle-birth-fort"
+        static let chronicleFirstFort = "chronicle-first-fort"
+        static let chronicleStrategy = "chronicle-mountain-strategy"
+        static let chronicleTurningPoint = "chronicle-turning-point"
+        static let chronicleComeback = "chronicle-comeback"
+        static let chronicleCoronation = "chronicle-coronation"
+    }
+
+    static let shivajiHeroArc = HeroArc(
+        id: IDs.heroArc,
+        hero: Hero(
+            id: "shivaji-maharaj",
+            name: "Shivaji Maharaj",
+            subtitle: "Build Swarajya through remembered places, events, and meaning",
+            culturalFramingNotes: "Use respectful, child-safe framing grounded in curated canon.",
+            ageBandCopyVariants: [
+                .assist: "Hear the story, remember the fort, and collect one keepsake at a time.",
+                .standard: "Remember the place, the turning point, and why it mattered."
+            ]
+        ),
+        title: "Shivaji Arc",
+        scenes: [scene1, scene2, scene3, scene4, scene5, scene6],
+        chronicleEntries: [birthFortEntry, firstFortEntry, mountainStrategyEntry, turningPointEntry, comebackEntry, coronationEntry],
+        locationNodes: [shivneri, torna, rajgad, pratapgad, raigad, purandar, sinhagad],
+        timelineEvents: [timelineBirth, timelineTorna, timelineRajgad, timelinePratapgad, timelineComeback, timelineCoronation],
+        reviewBlueprints: ReviewSchedule.defaultBlueprints(for: [
+            IDs.scene1,
+            IDs.scene2,
+            IDs.scene3,
+            IDs.scene4,
+            IDs.scene5,
+            IDs.scene6
+        ])
     )
 
-    static let scene1 = StoryScene(
-        id: "scene-1-shivneri",
+    static let shivajiVerticalSlice = AppContent(heroArc: shivajiHeroArc)
+
+    static let scene1 = makeScene(
+        id: IDs.scene1,
         number: 1,
         title: "Shivneri, where Shivaji Maharaj's story begins",
-        narrativeObjective: "Meet Shivaji Maharaj as a child, guided by place, courage, and Jijabai.",
+        objective: "Meet Shivaji Maharaj as a child and tie the journey to one memorable birthplace.",
         keyFact: "Shivaji Maharaj was born at Shivneri Fort, and Jijabai shaped his early values.",
-        childSafeSummary: "At Shivneri Fort, young Shivaji began his journey. Jijabai helped him grow brave, caring, and ready to lead.",
+        meaning: "The journey begins with place, family guidance, and a clear memory hook: Birth Fort.",
+        summary: "At Shivneri Fort, young Shivaji began his journey. Jijabai helped him grow brave, caring, and ready to lead.",
         mapAnchors: ["Shivneri Fort", "Junnar", "Hill-fort country north of Pune"],
-        timelineMarker: "Born at Shivneri",
-        interactionSteps: [
-            "Reveal the opening story moment.",
-            "Hear the short story beat.",
-            "Mark the first Chronicle moment: Born at Shivneri.",
-            "Answer the recall question to unlock the Chronicle card."
-        ],
-        recallPrompt: RecallPrompt(
-            question: "Which fort is Shivaji Maharaj’s birth place?",
-            answer: "Shivneri Fort",
-            supportText: "The story begins at Shivneri, the Birth Fort."
-        ),
-        rewardID: "reward-birth-fort-card"
+        timelineEventID: IDs.eventBirth,
+        memoryHook: "Birth Fort",
+        answer: "Shivneri Fort",
+        chronicleEntryID: IDs.chronicleBirth
     )
 
-    static let scene2 = StoryScene(
-        id: "scene-2-torna-rajgad",
+    static let scene2 = makeScene(
+        id: IDs.scene2,
         number: 2,
         title: "Torna and Rajgad, the first steps of Swarajya",
-        narrativeObjective: "Show how early fort victories turned into careful planning and state-building.",
+        objective: "Show how early fort victories turned into careful planning and state-building.",
         keyFact: "Torna was an early breakthrough, and Rajgad became an early capital and planning base.",
-        childSafeSummary: "Shivaji Maharaj began building Swarajya by winning key forts and planning from the mountains.",
+        meaning: "A remembered breakthrough helps the child connect courage with strategic place-making.",
+        summary: "Torna shows the first big mountain breakthrough, and Rajgad turns the journey into careful planning.",
         mapAnchors: ["Torna", "Rajgad", "Mountain routes of western Maharashtra"],
-        timelineMarker: "Early forts",
-        interactionSteps: [
-            "Follow the story from Shivneri to Torna and Rajgad.",
-            "Notice why Torna mattered first and Rajgad mattered next.",
-            "Pick smart fort-planning choices.",
-            "Answer a short recall prompt before collecting the reward."
-        ],
-        recallPrompt: RecallPrompt(
-            question: "Which fort became an early capital?",
-            answer: "Rajgad",
-            supportText: "Torna is the First Big Fort, and Rajgad is the Early Capital."
-        ),
-        rewardID: "reward-first-big-fort-card"
+        timelineEventID: IDs.eventFirstFort,
+        memoryHook: "Early Capital",
+        answer: "Rajgad",
+        chronicleEntryID: IDs.chronicleFirstFort
     )
 
-    static let shivneri = Place(
-        id: "place-shivneri",
+    static let scene3 = makeScene(
+        id: IDs.scene3,
+        number: 3,
+        title: "Rajgad, the planning capital",
+        objective: "Link planning, state-building, and place memory through Rajgad.",
+        keyFact: "Rajgad became an early capital and planning base for growing Swarajya.",
+        meaning: "Children should remember that leadership also means careful planning from the right place.",
+        summary: "Rajgad becomes the fort for planning, storing strength, and thinking ahead.",
+        mapAnchors: ["Rajgad", "Near Torna", "Mountain planning base"],
+        timelineEventID: IDs.eventEarlyCapital,
+        memoryHook: "Early Capital",
+        answer: "Rajgad",
+        chronicleEntryID: IDs.chronicleStrategy
+    )
+
+    static let scene4 = makeScene(
+        id: IDs.scene4,
+        number: 4,
+        title: "Pratapgad, the turning point",
+        objective: "Teach a decisive turning point through terrain, strategy, and confidence.",
+        keyFact: "Pratapgad became a major turning point that showed how terrain and preparation matter.",
+        meaning: "The child should remember Pratapgad as the turning-point fort, not just a dramatic battle name.",
+        summary: "At Pratapgad, strategy and terrain change the story. A turning point becomes unforgettable.",
+        mapAnchors: ["Pratapgad", "Near Mahabaleshwar", "Hill country"],
+        timelineEventID: IDs.eventTurningPoint,
+        memoryHook: "Turning Point",
+        answer: "Pratapgad",
+        chronicleEntryID: IDs.chronicleTurningPoint
+    )
+
+    static let scene5 = makeScene(
+        id: IDs.scene5,
+        number: 5,
+        title: "Purandar to Sinhagad, pressure and comeback",
+        objective: "Hold two related places in memory while teaching pressure, loss, and return.",
+        keyFact: "Purandar marks pressure and compromise, while Sinhagad helps children remember comeback and courage.",
+        meaning: "History includes setbacks, and remembered places help children see how the story recovers.",
+        summary: "The journey faces pressure, then regains confidence. The child learns that courage includes comeback.",
+        mapAnchors: ["Purandar", "Sinhagad", "Forts around Pune"],
+        timelineEventID: IDs.eventComeback,
+        memoryHook: "Pressure to Comeback",
+        answer: "Sinhagad",
+        chronicleEntryID: IDs.chronicleComeback
+    )
+
+    static let scene6 = makeScene(
+        id: IDs.scene6,
+        number: 6,
+        title: "Raigad, the coronation capital",
+        objective: "Close the arc with a place, title, and sequence moment that feels ceremonial.",
+        keyFact: "Raigad is remembered as the coronation capital where Shivaji Maharaj became Chhatrapati.",
+        meaning: "The final scene should tie sovereignty, sequence, and Chronicle completion into one earned moment.",
+        summary: "Raigad brings the story to its sovereign climax. The child remembers the coronation capital with pride.",
+        mapAnchors: ["Raigad", "Konkan edge of the Sahyadris", "Coronation capital"],
+        timelineEventID: IDs.eventCoronation,
+        memoryHook: "Coronation Capital",
+        answer: "Raigad",
+        chronicleEntryID: IDs.chronicleCoronation
+    )
+
+    static let shivneri = makeLocation(
+        id: IDs.placeShivneri,
         name: "Shivneri",
-        memoryHook: "Birth Fort",
-        primaryEvent: "Birth of Shivaji Maharaj",
-        whyItMatters: "This is where the story begins.",
-        regionLabel: "Near Junnar, north of Pune",
+        hook: "Birth Fort",
+        event: "Birth of Shivaji Maharaj",
+        region: "Near Junnar, north of Pune",
         latitude: 19.1990,
         longitude: 73.8595,
-        progress: .readyToLearn,
-        isCoreReleasePlace: true
+        linkedSceneIDs: [IDs.scene1],
+        linkedTimelineEventIDs: [IDs.eventBirth],
+        isCore: true
     )
 
-    static let torna = Place(
-        id: "place-torna",
+    static let torna = makeLocation(
+        id: IDs.placeTorna,
         name: "Torna",
-        memoryHook: "First Big Fort",
-        primaryEvent: "Early breakthrough in the start of Swarajya",
-        whyItMatters: "It marks one of the first major fort successes.",
-        regionLabel: "Sahyadri range, southwest of Pune",
+        hook: "First Big Fort",
+        event: "Early breakthrough in the start of Swarajya",
+        region: "Sahyadri range, southwest of Pune",
         latitude: 18.2761,
         longitude: 73.6227,
-        progress: .readyToLearn,
-        isCoreReleasePlace: true
+        linkedSceneIDs: [IDs.scene2],
+        linkedTimelineEventIDs: [IDs.eventFirstFort],
+        isCore: true
     )
 
-    static let rajgad = Place(
-        id: "place-rajgad",
+    static let rajgad = makeLocation(
+        id: IDs.placeRajgad,
         name: "Rajgad",
-        memoryHook: "Early Capital",
-        primaryEvent: "Early power center and planning base",
-        whyItMatters: "It supported growth and consolidation.",
-        regionLabel: "Sahyadri range, near Torna",
+        hook: "Early Capital",
+        event: "Early power center and planning base",
+        region: "Sahyadri range, near Torna",
         latitude: 18.2460,
         longitude: 73.6822,
-        progress: .readyToLearn,
-        isCoreReleasePlace: true
+        linkedSceneIDs: [IDs.scene2, IDs.scene3],
+        linkedTimelineEventIDs: [IDs.eventFirstFort, IDs.eventEarlyCapital],
+        isCore: true
     )
 
-    static let pratapgad = Place(
-        id: "place-pratapgad",
+    static let pratapgad = makeLocation(
+        id: IDs.placePratapgad,
         name: "Pratapgad",
-        memoryHook: "Turning Point",
-        primaryEvent: "Major turning point in Shivaji Maharaj’s rise",
-        whyItMatters: "It teaches strategy and terrain.",
-        regionLabel: "Hill country near Mahabaleshwar",
+        hook: "Turning Point",
+        event: "Major turning point in Shivaji Maharaj's rise",
+        region: "Hill country near Mahabaleshwar",
         latitude: 17.9362,
         longitude: 73.5776,
-        progress: .locked,
-        isCoreReleasePlace: true
+        linkedSceneIDs: [IDs.scene4],
+        linkedTimelineEventIDs: [IDs.eventTurningPoint],
+        isCore: true
     )
 
-    static let raigad = Place(
-        id: "place-raigad",
+    static let raigad = makeLocation(
+        id: IDs.placeRaigad,
         name: "Raigad",
-        memoryHook: "Coronation Capital",
-        primaryEvent: "Coronation as Chhatrapati",
-        whyItMatters: "It is the sovereign climax of the arc.",
-        regionLabel: "Konkan edge of the Sahyadris",
+        hook: "Coronation Capital",
+        event: "Coronation as Chhatrapati",
+        region: "Konkan edge of the Sahyadris",
         latitude: 18.2335,
         longitude: 73.4406,
-        progress: .locked,
-        isCoreReleasePlace: true
+        linkedSceneIDs: [IDs.scene6],
+        linkedTimelineEventIDs: [IDs.eventCoronation],
+        isCore: true
     )
 
-    static let purandar = Place(
-        id: "place-purandar",
+    static let purandar = makeLocation(
+        id: IDs.placePurandar,
         name: "Purandar",
-        memoryHook: "Pressure Fort",
-        primaryEvent: "Context for later pressure and compromise",
-        whyItMatters: "Useful story support, but not required for first-release pinning.",
-        regionLabel: "Southeast of Pune",
+        hook: "Pressure Fort",
+        event: "Context for later pressure and compromise",
+        region: "Southeast of Pune",
         latitude: 18.2808,
         longitude: 73.9736,
-        progress: .locked,
-        isCoreReleasePlace: false
+        linkedSceneIDs: [IDs.scene5],
+        linkedTimelineEventIDs: [IDs.eventComeback],
+        isCore: false
     )
 
-    static let birthFortCard = ChronicleReward(
-        id: "reward-birth-fort-card",
+    static let sinhagad = makeLocation(
+        id: IDs.placeSinhagad,
+        name: "Sinhagad",
+        hook: "Comeback Fort",
+        event: "Remembered comeback and courage",
+        region: "Southwest of Pune",
+        latitude: 18.3662,
+        longitude: 73.7559,
+        linkedSceneIDs: [IDs.scene5],
+        linkedTimelineEventIDs: [IDs.eventComeback],
+        isCore: false
+    )
+
+    static let birthFortEntry = makeChronicle(
+        id: IDs.chronicleBirth,
         title: "Birth Fort",
-        subtitle: "Journey keepsake card",
-        meaning: "The Chronicle keeps the memory of Shivneri Fort, where Shivaji Maharaj’s journey begins.",
-        unlockedBySceneID: "scene-1-shivneri",
-        mastery: .witnessed,
-        category: .storyCard
+        keepsakeTitle: "Journey keepsake",
+        meaning: "The Chronicle keeps Shivneri as the place where Shivaji Maharaj's journey begins.",
+        sceneID: IDs.scene1,
+        placeID: IDs.placeShivneri,
+        timelineEventID: IDs.eventBirth
     )
 
-    static let firstBigFortCard = ChronicleReward(
-        id: "reward-first-big-fort-card",
+    static let firstFortEntry = makeChronicle(
+        id: IDs.chronicleFirstFort,
         title: "First Big Fort",
-        subtitle: "Journey keepsake card",
-        meaning: "This keepsake remembers Torna as an early breakthrough in building Swarajya.",
-        unlockedBySceneID: "scene-2-torna-rajgad",
-        mastery: .witnessed,
-        category: .storyCard
+        keepsakeTitle: "Mountain keepsake",
+        meaning: "This keepsake remembers the first fort step and why Rajgad mattered next.",
+        sceneID: IDs.scene2,
+        placeID: IDs.placeRajgad,
+        timelineEventID: IDs.eventFirstFort
     )
 
-    static let mountainSealFragment = ChronicleReward(
-        id: "reward-mountain-seal-fragment",
-        title: "Mountain Seal Fragment",
-        subtitle: "Mountain emblem fragment",
-        meaning: "A mountain emblem fragment earned by learning the first forts and how they sit in the Sahyadris.",
-        unlockedBySceneID: "scene-2-torna-rajgad",
-        mastery: .understood,
-        category: .emblemFragment
+    static let mountainStrategyEntry = makeChronicle(
+        id: IDs.chronicleStrategy,
+        title: "Mountain Strategy",
+        keepsakeTitle: "Planning seal",
+        meaning: "Rajgad becomes a keepsake about planning well, not just winning quickly.",
+        sceneID: IDs.scene3,
+        placeID: IDs.placeRajgad,
+        timelineEventID: IDs.eventEarlyCapital
     )
 
-    static let planningBadge = ChronicleReward(
-        id: "reward-planning-badge",
-        title: "Planning Badge",
-        subtitle: "Planner’s badge",
-        meaning: "A keepsake badge for noticing that careful planning helps the Shivaji journey grow strong.",
-        unlockedBySceneID: "scene-2-torna-rajgad",
-        mastery: .observedClosely,
-        category: .leadershipBadge
+    static let turningPointEntry = makeChronicle(
+        id: IDs.chronicleTurningPoint,
+        title: "Turning Point Seal",
+        keepsakeTitle: "Turning-point keepsake",
+        meaning: "Pratapgad earns a Chronicle seal only after the child remembers why the turning point mattered.",
+        sceneID: IDs.scene4,
+        placeID: IDs.placePratapgad,
+        timelineEventID: IDs.eventTurningPoint
     )
+
+    static let comebackEntry = makeChronicle(
+        id: IDs.chronicleComeback,
+        title: "Comeback Crest",
+        keepsakeTitle: "Resilience keepsake",
+        meaning: "This keepsake marks the journey through pressure and comeback, not a simple straight climb.",
+        sceneID: IDs.scene5,
+        placeID: IDs.placeSinhagad,
+        timelineEventID: IDs.eventComeback
+    )
+
+    static let coronationEntry = makeChronicle(
+        id: IDs.chronicleCoronation,
+        title: "Coronation Seal",
+        keepsakeTitle: "Hero page reward",
+        meaning: "Raigad becomes the ceremonial final keepsake when the child remembers the coronation capital.",
+        sceneID: IDs.scene6,
+        placeID: IDs.placeRaigad,
+        timelineEventID: IDs.eventCoronation
+    )
+
+    static let timelineBirth = makeTimelineEvent(
+        id: IDs.eventBirth,
+        title: "Birth at Shivneri",
+        order: 0,
+        era: "Beginning",
+        linkedPlaces: [IDs.placeShivneri]
+    )
+
+    static let timelineTorna = makeTimelineEvent(
+        id: IDs.eventFirstFort,
+        title: "Early fort breakthrough at Torna and Rajgad",
+        order: 1,
+        era: "Early rise",
+        linkedPlaces: [IDs.placeTorna, IDs.placeRajgad]
+    )
+
+    static let timelineRajgad = makeTimelineEvent(
+        id: IDs.eventEarlyCapital,
+        title: "Rajgad becomes the planning capital",
+        order: 2,
+        era: "State-building",
+        linkedPlaces: [IDs.placeRajgad]
+    )
+
+    static let timelinePratapgad = makeTimelineEvent(
+        id: IDs.eventTurningPoint,
+        title: "Pratapgad turns the story",
+        order: 3,
+        era: "Turning point",
+        linkedPlaces: [IDs.placePratapgad]
+    )
+
+    static let timelineComeback = makeTimelineEvent(
+        id: IDs.eventComeback,
+        title: "Pressure, recovery, and comeback",
+        order: 4,
+        era: "Comeback",
+        linkedPlaces: [IDs.placePurandar, IDs.placeSinhagad]
+    )
+
+    static let timelineCoronation = makeTimelineEvent(
+        id: IDs.eventCoronation,
+        title: "Coronation at Raigad",
+        order: 5,
+        era: "Coronation",
+        linkedPlaces: [IDs.placeRaigad]
+    )
+
+    private static func makeScene(
+        id: String,
+        number: Int,
+        title: String,
+        objective: String,
+        keyFact: String,
+        meaning: String,
+        summary: String,
+        mapAnchors: [String],
+        timelineEventID: String,
+        memoryHook: String,
+        answer: String,
+        chronicleEntryID: String
+    ) -> SceneCluster {
+        let challenge = RecallChallenge(
+            id: id + "-recall",
+            promptType: number == 6 ? .sequenceSlot : .openPrompt,
+            prompt: number == 6 ? "Which fort is remembered as the coronation capital at the end of the arc?" : "Which place matches this memory hook: \(memoryHook)?",
+            correctAnswers: [answer],
+            hintLadder: [
+                RecallHint(level: 1, title: "Anchor hint", body: "Remember this hook: \(memoryHook)."),
+                RecallHint(level: 2, title: "Story hint", body: meaning),
+                RecallHint(level: 3, title: "Recognition rescue", body: "Look for the fort tied to \(answer).")
+            ],
+            feedback: RecallFeedback(
+                success: "You got it. \(meaning)",
+                recovery: "Good try. \(meaning)"
+            ),
+            masteryContribution: .understood
+        )
+
+        return SceneCluster(
+            id: id,
+            sceneNumber: number,
+            title: title,
+            narrativeObjective: objective,
+            keyFact: keyFact,
+            meaningStatement: meaning,
+            childSafeSummary: summary,
+            mapAnchorIDs: mapAnchors,
+            timelineEventID: timelineEventID,
+            cards: [
+                LearningCard(id: id + "-story", type: .story, title: title, text: summary, narration: summary, imageKey: id, memoryHook: nil, difficultyBand: .standard),
+                LearningCard(id: id + "-meaning", type: .meaning, title: "Why it matters", text: meaning, narration: meaning, imageKey: id + "-meaning", memoryHook: nil, difficultyBand: .standard),
+                LearningCard(id: id + "-anchor", type: .anchor, title: memoryHook, text: keyFact, narration: keyFact, imageKey: id + "-anchor", memoryHook: memoryHook, difficultyBand: .standard),
+                LearningCard(id: id + "-reward", type: .reward, title: "Chronicle reward", text: "Earn the keepsake by remembering the scene.", narration: "Earn the keepsake by remembering the scene.", imageKey: id + "-reward", memoryHook: memoryHook, difficultyBand: .standard)
+            ],
+            recallChallenges: [challenge],
+            chronicleEntryIDs: [chronicleEntryID]
+        )
+    }
+
+    private static func makeLocation(
+        id: String,
+        name: String,
+        hook: String,
+        event: String,
+        region: String,
+        latitude: Double,
+        longitude: Double,
+        linkedSceneIDs: [String],
+        linkedTimelineEventIDs: [String],
+        isCore: Bool
+    ) -> LocationNode {
+        LocationNode(
+            id: id,
+            name: name,
+            canonicalCoordinate: Coordinate(latitude: latitude, longitude: longitude),
+            memoryHook: hook,
+            primaryEvent: event,
+            regionLabel: region,
+            linkedSceneIDs: linkedSceneIDs,
+            linkedTimelineEventIDs: linkedTimelineEventIDs,
+            unlockRule: UnlockRule(requiredMastery: .understood, enhancedMastery: .placed),
+            isCoreReleasePlace: isCore
+        )
+    }
+
+    private static func makeChronicle(
+        id: String,
+        title: String,
+        keepsakeTitle: String,
+        meaning: String,
+        sceneID: String,
+        placeID: String?,
+        timelineEventID: String?
+    ) -> ChronicleEntry {
+        ChronicleEntry(
+            id: id,
+            title: title,
+            keepsakeTitle: keepsakeTitle,
+            meaningStatement: meaning,
+            linkedSceneID: sceneID,
+            linkedPlaceID: placeID,
+            linkedTimelineEventID: timelineEventID,
+            unlockRule: UnlockRule(requiredMastery: .understood, enhancedMastery: .remembered)
+        )
+    }
+
+    private static func makeTimelineEvent(
+        id: String,
+        title: String,
+        order: Int,
+        era: String,
+        linkedPlaces: [String]
+    ) -> TimelineEvent {
+        TimelineEvent(
+            id: id,
+            title: title,
+            orderIndex: order,
+            broadEraLabel: era,
+            yearLabel: nil,
+            linkedPlaceIDs: linkedPlaces,
+            recallPrompt: "Place \(title) in the correct sequence slot.",
+            unlockRule: UnlockRule(requiredMastery: .remembered, enhancedMastery: .placed)
+        )
+    }
+}
+
+private extension ReviewSchedule {
+    static func defaultBlueprints(for subjectIDs: [String]) -> [ReviewSchedule] {
+        subjectIDs.map { subjectID in
+            ReviewSchedule(
+                subjectID: subjectID,
+                subjectType: .scene,
+                nextDueAt: .distantFuture,
+                intervalIndex: 0,
+                stabilityBand: .new,
+                difficultyAdjustment: 0,
+                cadenceDays: [0, 1, 3, 7, 14]
+            )
+        }
+    }
 }

--- a/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
+++ b/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
@@ -1,20 +1,67 @@
+import Combine
 import Foundation
 
 final class ShivajiLessonStore: ObservableObject {
     @Published private(set) var masteryByScene: [String: MasteryState] = [:]
+    @Published private(set) var masteryRecordsBySubject: [String: MasteryRecord] = [:]
+    @Published private(set) var reviewSchedulesBySubject: [String: ReviewSchedule] = [:]
 
     private let content: AppContent
     private let defaults: UserDefaults
-    private let storageKey = "shivajiLessonStore.masteryByScene"
+    private let recordsStorageKey = "shivajiLessonStore.masteryRecords"
+    private let reviewStorageKey = "shivajiLessonStore.reviewSchedules"
+    private let legacyMasteryStorageKey = "shivajiLessonStore.masteryByScene"
 
     init(content: AppContent = SampleContent.shivajiVerticalSlice, defaults: UserDefaults = .standard) {
         self.content = content
         self.defaults = defaults
-        self.masteryByScene = Self.loadMastery(from: defaults, key: storageKey)
+        self.masteryRecordsBySubject = Self.loadRecords(from: defaults, key: recordsStorageKey)
+        self.reviewSchedulesBySubject = Self.loadSchedules(from: defaults, key: reviewStorageKey)
+
+        if masteryRecordsBySubject.isEmpty {
+            let migratedMastery = Self.loadLegacyMastery(from: defaults, key: legacyMasteryStorageKey)
+            masteryRecordsBySubject = migratedMastery.reduce(into: [:]) { partialResult, pair in
+                partialResult[pair.key] = MasteryRecord(
+                    subjectID: pair.key,
+                    subjectType: .scene,
+                    state: pair.value,
+                    exposureCount: 1,
+                    successfulReviewCount: pair.value >= .understood ? 1 : 0,
+                    lastReviewedAt: nil,
+                    evidenceLog: []
+                )
+            }
+        }
+
+        if reviewSchedulesBySubject.isEmpty {
+            reviewSchedulesBySubject = Dictionary(uniqueKeysWithValues: content.activeHeroArc.reviewBlueprints.map { ($0.subjectID, $0) })
+        }
+
+        syncLegacySceneMastery()
     }
 
     func mastery(for sceneID: String) -> MasteryState? {
         masteryByScene[sceneID]
+    }
+
+    func masteryRecord(for subjectID: String) -> MasteryRecord? {
+        masteryRecordsBySubject[subjectID]
+    }
+
+    func recordStoryExposure(for sceneID: String, detail: String = "Scene viewed") {
+        updateRecord(subjectID: sceneID, subjectType: .scene, newState: .witnessed, evidenceType: .storyExposure, detail: detail)
+    }
+
+    func markScene(_ sceneID: String, mastery: MasteryState) {
+        let evidenceType: MasteryEvidenceType = mastery >= .remembered ? .reviewSuccess : (mastery >= .understood ? .recallSuccess : .recallAttempt)
+        updateRecord(subjectID: sceneID, subjectType: .scene, newState: mastery, evidenceType: evidenceType, detail: "Scene mastery updated")
+    }
+
+    func resetScene(_ sceneID: String) {
+        masteryRecordsBySubject.removeValue(forKey: sceneID)
+        reviewSchedulesBySubject.removeValue(forKey: sceneID)
+        ensureReviewBlueprint(for: sceneID, subjectType: .scene)
+        persist()
     }
 
     func isSceneUnlocked(_ scene: StoryScene) -> Bool {
@@ -24,46 +71,101 @@ final class ShivajiLessonStore: ObservableObject {
         if sceneIndex == 0 {
             return true
         }
+
         let previousScene = content.scenes[content.scenes.index(before: sceneIndex)]
-        return mastery(for: previousScene.id) != nil
-    }
-
-    func markScene(_ sceneID: String, mastery: MasteryState) {
-        let current = masteryByScene[sceneID] ?? .witnessed
-        masteryByScene[sceneID] = higherMastery(current, mastery)
-        persist()
-    }
-
-    func resetScene(_ sceneID: String) {
-        masteryByScene.removeValue(forKey: sceneID)
-        persist()
+        return (mastery(for: previousScene.id) ?? .witnessed) >= .understood
     }
 
     func isUnlocked(_ reward: ChronicleReward) -> Bool {
-        guard let mastery = masteryByScene[reward.unlockedBySceneID] else { return false }
-        return masteryRank(mastery) >= masteryRank(.understood)
+        guard let entry = content.activeHeroArc.chronicleEntries.first(where: { $0.id == reward.id }) else {
+            return (mastery(for: reward.unlockedBySceneID) ?? .witnessed) >= reward.mastery
+        }
+        return chronicleUnlockState(for: entry) != .silhouette
     }
 
     func unlockedRewards(from rewards: [ChronicleReward]) -> [ChronicleReward] {
-        rewards.filter(isUnlocked)
+        rewards.filter { isUnlocked($0) }
     }
 
     func progress(for place: Place) -> PlaceProgress {
-        switch place.id {
-        case "place-shivneri":
-            return mastery(for: "scene-1-shivneri") == nil ? .readyToLearn : .reviewed
-        case "place-torna", "place-rajgad":
-            if let mastery = mastery(for: "scene-2-torna-rajgad") {
-                return mastery == .observedClosely ? .masteredLightly : .reviewed
-            }
-            return .readyToLearn
-        default:
+        guard let node = content.activeHeroArc.locationNodes.first(where: { $0.id == place.id }) else {
             return place.progress
+        }
+
+        switch locationUnlockState(for: node) {
+        case .hidden:
+            return .locked
+        case .seenInStory, .learnable:
+            return .readyToLearn
+        case .remembered:
+            return .reviewed
+        case .placedAccurately, .masteredInReview:
+            return .masteredLightly
         }
     }
 
+    func chronicleUnlockState(for entry: ChronicleEntry) -> ChronicleUnlockState {
+        let sceneMastery = mastery(for: entry.linkedSceneID) ?? .witnessed
+        guard sceneMastery >= entry.unlockRule.requiredMastery else {
+            return .silhouette
+        }
+
+        if let enhanced = entry.unlockRule.enhancedMastery, sceneMastery >= enhanced {
+            return .enriched
+        }
+
+        return .unlocked
+    }
+
+    func locationUnlockState(for node: LocationNode) -> LocationUnlockState {
+        let linkedSceneMasteries = node.linkedSceneIDs.compactMap { mastery(for: $0) }
+        let strongestSceneMastery = linkedSceneMasteries.max() ?? .witnessed
+
+        if strongestSceneMastery < .understood {
+            let hasUnlockedLinkedScene = node.linkedSceneIDs.contains { sceneID in
+                content.scenes.first(where: { $0.id == sceneID }).map(isSceneUnlocked) ?? false
+            }
+            return hasUnlockedLinkedScene ? .learnable : .hidden
+        }
+
+        let record = masteryRecord(for: node.id)
+        let locationMastery = record?.state ?? strongestSceneMastery
+
+        if locationMastery >= .placed {
+            return .placedAccurately
+        }
+        if locationMastery >= .remembered || strongestSceneMastery >= .remembered {
+            return .remembered
+        }
+        if strongestSceneMastery >= .understood {
+            return .learnable
+        }
+        return .seenInStory
+    }
+
+    func timelineUnlockState(for event: TimelineEvent) -> LocationUnlockState {
+        let linkedSceneMasteries = content.activeHeroArc.scenes
+            .filter { $0.timelineEventID == event.id }
+            .compactMap { mastery(for: $0.id) }
+        let strongestMastery = linkedSceneMasteries.max() ?? .witnessed
+
+        if strongestMastery < event.unlockRule.requiredMastery {
+            return .hidden
+        }
+        if let enhanced = event.unlockRule.enhancedMastery, strongestMastery >= enhanced {
+            return .placedAccurately
+        }
+        return .remembered
+    }
+
+    func dueReviews(referenceDate: Date = Date()) -> [ReviewSchedule] {
+        reviewSchedulesBySubject.values
+            .filter { $0.nextDueAt <= referenceDate }
+            .sorted { lhs, rhs in lhs.nextDueAt < rhs.nextDueAt }
+    }
+
     var completedScenes: Int {
-        masteryByScene.count
+        content.scenes.filter { (mastery(for: $0.id) ?? .witnessed) >= .understood }.count
     }
 
     var totalScenes: Int {
@@ -77,56 +179,169 @@ final class ShivajiLessonStore: ObservableObject {
 
     var chronicleHeadline: String {
         switch completedScenes {
-        case 0: return "Begin the Chronicle"
-        case totalScenes: return "The first Chronicle page is complete"
-        default: return "Your Chronicle is taking shape"
+        case 0:
+            return "Begin the Chronicle"
+        case totalScenes:
+            return "The first Chronicle page is complete"
+        default:
+            return "Your Chronicle is taking shape"
         }
     }
 
     var nextSceneID: String? {
-        content.scenes.first(where: { mastery(for: $0.id) == nil })?.id
-    }
-
-    private func higherMastery(_ lhs: MasteryState, _ rhs: MasteryState) -> MasteryState {
-        masteryRank(lhs) >= masteryRank(rhs) ? lhs : rhs
-    }
-
-    private func masteryRank(_ mastery: MasteryState) -> Int {
-        switch mastery {
-        case .witnessed:
-            return 0
-        case .understood:
-            return 1
-        case .observedClosely:
-            return 2
-        }
-    }
-
-    private func persist() {
-        let encoded = masteryByScene.mapValues(\ .rawValue)
-        defaults.set(encoded, forKey: storageKey)
+        content.scenes.first(where: { (mastery(for: $0.id) ?? .witnessed) < .understood })?.id
     }
 
     func applyCaptureSeed(_ profile: CaptureSeedProfile) {
         switch profile {
         case .pristine:
-            masteryByScene = [:]
+            masteryRecordsBySubject = [:]
+            reviewSchedulesBySubject = Dictionary(uniqueKeysWithValues: content.activeHeroArc.reviewBlueprints.map { ($0.subjectID, $0) })
         case .chronicleUnlocked:
-            masteryByScene = [
-                "scene-1-shivneri": .understood,
-                "scene-2-torna-rajgad": .observedClosely
+            let now = Date()
+            masteryRecordsBySubject = [
+                "scene-1-shivneri": MasteryRecord(
+                    subjectID: "scene-1-shivneri",
+                    subjectType: .scene,
+                    state: .understood,
+                    exposureCount: 1,
+                    successfulReviewCount: 1,
+                    lastReviewedAt: now,
+                    evidenceLog: [MasteryEvidence(type: .recallSuccess, recordedAt: now, detail: "Capture seed")]
+                ),
+                "scene-2-torna-rajgad": MasteryRecord(
+                    subjectID: "scene-2-torna-rajgad",
+                    subjectType: .scene,
+                    state: .observedClosely,
+                    exposureCount: 1,
+                    successfulReviewCount: 1,
+                    lastReviewedAt: now,
+                    evidenceLog: [MasteryEvidence(type: .reviewSuccess, recordedAt: now, detail: "Capture seed")]
+                )
             ]
+            reviewSchedulesBySubject = Dictionary(uniqueKeysWithValues: content.activeHeroArc.reviewBlueprints.map { ($0.subjectID, $0) })
+            if var scene1 = reviewSchedulesBySubject["scene-1-shivneri"] {
+                scene1.nextDueAt = now.addingTimeInterval(24 * 60 * 60)
+                scene1.intervalIndex = 1
+                scene1.stabilityBand = .warming
+                reviewSchedulesBySubject[scene1.subjectID] = scene1
+            }
+        }
+        persist()
+    }
+
+    private func updateRecord(subjectID: String, subjectType: MasterySubjectType, newState: MasteryState, evidenceType: MasteryEvidenceType, detail: String) {
+        let now = Date()
+        var record = masteryRecordsBySubject[subjectID] ?? MasteryRecord(
+            subjectID: subjectID,
+            subjectType: subjectType,
+            state: .witnessed,
+            exposureCount: 0,
+            successfulReviewCount: 0,
+            lastReviewedAt: nil,
+            evidenceLog: []
+        )
+
+        record.state = max(record.state, newState)
+        record.exposureCount += 1
+        if newState >= .understood {
+            record.successfulReviewCount += 1
+            record.lastReviewedAt = now
+            advanceReviewSchedule(for: subjectID, subjectType: subjectType, referenceDate: now, success: true)
+        } else {
+            ensureReviewBlueprint(for: subjectID, subjectType: subjectType)
+        }
+        record.evidenceLog.append(MasteryEvidence(type: evidenceType, recordedAt: now, detail: detail))
+        masteryRecordsBySubject[subjectID] = record
+        persist()
+    }
+
+    private func advanceReviewSchedule(for subjectID: String, subjectType: MasterySubjectType, referenceDate: Date, success: Bool) {
+        ensureReviewBlueprint(for: subjectID, subjectType: subjectType)
+        guard var schedule = reviewSchedulesBySubject[subjectID] else { return }
+
+        let nextIndex = success ? min(schedule.intervalIndex + 1, max(schedule.cadenceDays.count - 1, 0)) : 0
+        schedule.intervalIndex = nextIndex
+        let cadenceDay = schedule.cadenceDays.isEmpty ? 0 : schedule.cadenceDays[nextIndex]
+        schedule.nextDueAt = Calendar.current.date(byAdding: .day, value: cadenceDay, to: referenceDate) ?? referenceDate
+        schedule.stabilityBand = stabilityBand(for: nextIndex)
+        reviewSchedulesBySubject[subjectID] = schedule
+    }
+
+    private func ensureReviewBlueprint(for subjectID: String, subjectType: MasterySubjectType) {
+        if reviewSchedulesBySubject[subjectID] != nil {
+            return
+        }
+
+        let blueprint = content.activeHeroArc.reviewBlueprints.first(where: { $0.subjectID == subjectID }) ?? ReviewSchedule(
+            subjectID: subjectID,
+            subjectType: subjectType,
+            nextDueAt: .distantFuture,
+            intervalIndex: 0,
+            stabilityBand: .new,
+            difficultyAdjustment: 0,
+            cadenceDays: [0, 1, 3, 7, 14]
+        )
+        reviewSchedulesBySubject[subjectID] = blueprint
+    }
+
+    private func stabilityBand(for intervalIndex: Int) -> ReviewStabilityBand {
+        switch intervalIndex {
+        case 0:
+            return .new
+        case 1:
+            return .warming
+        case 2...3:
+            return .steady
+        default:
+            return .durable
         }
     }
 
-    private static func loadMastery(from defaults: UserDefaults, key: String) -> [String: MasteryState] {
+    private func syncLegacySceneMastery() {
+        masteryByScene = masteryRecordsBySubject.reduce(into: [:]) { partialResult, pair in
+            guard pair.value.subjectType == .scene else { return }
+            partialResult[pair.key] = pair.value.state
+        }
+    }
+
+    private func persist() {
+        syncLegacySceneMastery()
+        defaults.set(masteryByScene.mapValues { $0.rawValue }, forKey: legacyMasteryStorageKey)
+
+        let encoder = JSONEncoder()
+        if let recordsData = try? encoder.encode(masteryRecordsBySubject) {
+            defaults.set(recordsData, forKey: recordsStorageKey)
+        }
+        if let scheduleData = try? encoder.encode(reviewSchedulesBySubject) {
+            defaults.set(scheduleData, forKey: reviewStorageKey)
+        }
+    }
+
+    private static func loadRecords(from defaults: UserDefaults, key: String) -> [String: MasteryRecord] {
+        guard let data = defaults.data(forKey: key),
+              let records = try? JSONDecoder().decode([String: MasteryRecord].self, from: data) else {
+            return [:]
+        }
+        return records
+    }
+
+    private static func loadSchedules(from defaults: UserDefaults, key: String) -> [String: ReviewSchedule] {
+        guard let data = defaults.data(forKey: key),
+              let schedules = try? JSONDecoder().decode([String: ReviewSchedule].self, from: data) else {
+            return [:]
+        }
+        return schedules
+    }
+
+    private static func loadLegacyMastery(from defaults: UserDefaults, key: String) -> [String: MasteryState] {
         guard let stored = defaults.dictionary(forKey: key) as? [String: String] else {
             return [:]
         }
 
-        return stored.reduce(into: [:]) { result, item in
-            guard let mastery = MasteryState(rawValue: item.value) else { return }
-            result[item.key] = mastery
+        return stored.reduce(into: [:]) { partialResult, pair in
+            guard let mastery = MasteryState(rawValue: pair.value) else { return }
+            partialResult[pair.key] = mastery
         }
     }
 }

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -6,14 +6,20 @@ final class GreatsOfBharathaTests: XCTestCase {
         let model = AppModel()
         XCTAssertFalse(model.content.scenes.isEmpty)
         XCTAssertEqual(model.content.scenes.first?.title, "Shivneri, where Shivaji Maharaj's story begins")
+        XCTAssertEqual(model.content.activeHeroArc.scenes.count, 6)
     }
 
     func testLessonStoreTracksProgress() {
-        let store = ShivajiLessonStore(defaults: UserDefaults(suiteName: #function)!)
+        let defaults = makeDefaults(testName: #function)
+        let store = ShivajiLessonStore(defaults: defaults)
+
         XCTAssertEqual(store.completedScenes, 0)
         store.markScene("scene-1-shivneri", mastery: .witnessed)
+        XCTAssertEqual(store.completedScenes, 0)
+
+        store.markScene("scene-1-shivneri", mastery: .understood)
         XCTAssertEqual(store.completedScenes, 1)
-        XCTAssertNotNil(store.nextSceneID)
+        XCTAssertEqual(store.nextSceneID, "scene-2-torna-rajgad")
     }
 
     func testLessonFlowAdvancesOneStageAtATime() {
@@ -63,16 +69,71 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertEqual(completed.progressValue, 1.0)
     }
 
-    func testLessonStoreUnlocksOnlyNextSceneByDefault() {
-        let defaults = UserDefaults(suiteName: #function)!
-        defaults.removePersistentDomain(forName: #function)
+    func testLessonStoreUnlocksOnlyNextSceneAfterUnderstanding() {
+        let defaults = makeDefaults(testName: #function)
         let store = ShivajiLessonStore(defaults: defaults)
 
-        XCTAssertTrue(store.isSceneUnlocked(SampleContent.scene1))
-        XCTAssertFalse(store.isSceneUnlocked(SampleContent.scene2))
+        let firstScene = SampleContent.shivajiVerticalSlice.scenes[0]
+        let secondScene = SampleContent.shivajiVerticalSlice.scenes[1]
 
-        store.markScene(SampleContent.scene1.id, mastery: .understood)
+        XCTAssertTrue(store.isSceneUnlocked(firstScene))
+        XCTAssertFalse(store.isSceneUnlocked(secondScene))
 
-        XCTAssertTrue(store.isSceneUnlocked(SampleContent.scene2))
+        store.markScene(firstScene.id, mastery: .witnessed)
+        XCTAssertFalse(store.isSceneUnlocked(secondScene))
+
+        store.markScene(firstScene.id, mastery: .understood)
+        XCTAssertTrue(store.isSceneUnlocked(secondScene))
+    }
+
+    func testChronicleUnlockRespectsEvidenceBasedMastery() {
+        let defaults = makeDefaults(testName: #function)
+        let store = ShivajiLessonStore(defaults: defaults)
+        let reward = SampleContent.shivajiVerticalSlice.rewards.first { $0.id == "chronicle-birth-fort" }
+
+        XCTAssertNotNil(reward)
+        XCTAssertFalse(store.isUnlocked(reward!))
+
+        store.markScene("scene-1-shivneri", mastery: .witnessed)
+        XCTAssertFalse(store.isUnlocked(reward!))
+
+        store.markScene("scene-1-shivneri", mastery: .understood)
+        XCTAssertTrue(store.isUnlocked(reward!))
+    }
+
+    func testReviewScheduleAdvancesAfterSuccessfulRecall() {
+        let defaults = makeDefaults(testName: #function)
+        let store = ShivajiLessonStore(defaults: defaults)
+
+        store.markScene("scene-1-shivneri", mastery: .understood)
+
+        let record = store.masteryRecord(for: "scene-1-shivneri")
+        let schedule = store.reviewSchedulesBySubject["scene-1-shivneri"]
+
+        XCTAssertEqual(record?.state, .understood)
+        XCTAssertEqual(record?.successfulReviewCount, 1)
+        XCTAssertEqual(schedule?.intervalIndex, 1)
+        XCTAssertEqual(schedule?.stabilityBand, .warming)
+    }
+
+    func testLocationAndTimelineStateProgressionUsesNewContracts() {
+        let defaults = makeDefaults(testName: #function)
+        let store = ShivajiLessonStore(defaults: defaults)
+        let firstPlace = SampleContent.shivajiHeroArc.locationNodes.first { $0.id == "place-shivneri" }
+        let firstEvent = SampleContent.timelineBirth
+
+        XCTAssertEqual(store.locationUnlockState(for: firstPlace!), .learnable)
+        XCTAssertEqual(store.timelineUnlockState(for: firstEvent), .hidden)
+
+        store.markScene("scene-1-shivneri", mastery: .remembered)
+
+        XCTAssertEqual(store.locationUnlockState(for: firstPlace!), .remembered)
+        XCTAssertEqual(store.timelineUnlockState(for: firstEvent), .remembered)
+    }
+
+    private func makeDefaults(testName: String) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: testName)!
+        defaults.removePersistentDomain(forName: testName)
+        return defaults
     }
 }


### PR DESCRIPTION
## Summary
- add additive hero-arc, card, recall, mastery, chronicle, location, timeline, and review-schedule contracts in shared models
- keep the current SwiftUI slice consuming legacy `AppContent` / `StoryScene` / `Place` / `ChronicleReward` surfaces through pragmatic adapters
- rework `ShivajiLessonStore` around evidence-based mastery records and review schedules while preserving existing UI entry points
- expand Shivaji sample content to a six-scene MVP foundation and add focused tests for unlock rules, progression, and review scheduling

## Validation
- `git diff --cached --check`
- targeted grep/sed sanity checks for malformed keypaths and compatibility-sensitive IDs/usages

## Blocked validation
- remote Xcode validation on `ganesh-mba` is currently blocked because SSH reachability is down (`No route to host`)
- local `swift` / `swiftc` / `xcodebuild` tooling is not available on this host

Closes #49.
