### PR TITLE
feat: refresh the child-facing story card flow

### DIFF
--- a/GreatsOfBharatha/App/CaptureRootView.swift
+++ b/GreatsOfBharatha/App/CaptureRootView.swift
@@ -5,18 +5,8 @@ struct CaptureRootView: View {
     let route: DebugNavigationRoute
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            captureScreen
-
-            Text("CAPTURE ROUTE: \(route.rawValue)")
-                .font(.caption.bold())
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(Color.black.opacity(0.75), in: Capsule())
-                .foregroundStyle(.white)
-                .padding()
-        }
-        .tint(.orange)
+        captureScreen
+            .tint(.orange)
     }
 
     @ViewBuilder

--- a/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
+++ b/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
@@ -24,74 +24,62 @@ struct ChronicleView: View {
         GBLayoutContextReader { context in
             ScrollView {
                 VStack(alignment: .leading, spacing: context.sectionSpacing) {
-                    heroCard
-
-                    GBSurface(style: .elevated) {
-                        VStack(alignment: .leading, spacing: GBSpacing.small) {
-                            GBSectionHeader(
-                                eyebrow: "Quest",
-                                title: "Keep the meaning, not just the completion",
-                                subtitle: "The Chronicle is where each learned moment becomes a keepsake."
-                            )
-
-                            GBQuestProgress(
-                                steps: [.story, .place, .chronicle],
-                                currentStepID: "chronicle"
-                            )
-                        }
-                    }
+                    chronicleHero
 
                     if let highlightedReward {
-                        HighlightRewardCard(
+                        NewRewardSpotlight(
                             reward: highlightedReward,
-                            collected: celebratedRewardIDs.contains(highlightedReward.id)
-                        ) {
-                            celebratedRewardIDs.insert(highlightedReward.id)
-                            LessonFeedback.fire(.celebration)
-                        }
-                    }
-
-                    GBSurface(style: .elevated) {
-                        Text("Meaning-bearing rewards for story progress, not anxiety-heavy grades.")
-                            .font(.subheadline)
-                            .foregroundStyle(GBColor.Content.secondary)
+                            collected: celebratedRewardIDs.contains(highlightedReward.id),
+                            onCollect: {
+                                celebratedRewardIDs.insert(highlightedReward.id)
+                                LessonFeedback.fire(.celebration)
+                            }
+                        )
                     }
 
                     VStack(alignment: .leading, spacing: context.cardSpacing) {
                         GBSectionHeader(
-                            eyebrow: "Unlocked",
-                            title: "Rewards already in your Chronicle",
-                            subtitle: unlockedRewards.isEmpty ? "Finish a lesson scene to place its meaning into the Royal Chronicle." : "Each reward should remind the child what was learned."
+                            eyebrow: "Collected keepsakes",
+                            title: unlockedRewards.isEmpty ? "Your Chronicle is waiting" : "Your Chronicle shelf",
+                            subtitle: unlockedRewards.isEmpty
+                                ? "Finish a scene and remember its hook to place your first keepsake here."
+                                : "Each keepsake marks a part of Shivaji Maharaj's journey you remembered."
                         )
 
                         if unlockedRewards.isEmpty {
-                            EmptyChronicleCard(debugMasterySummary: debugMasterySummary)
+                            GBSurface(style: .elevated) {
+                                Text("Play a short scene, answer the recall card, and your first Chronicle page will open here.")
+                                    .gbBody()
+                                    .foregroundStyle(GBColor.Content.secondary)
+                            }
                         } else {
                             ForEach(unlockedRewards) { reward in
-                                RewardCard(
+                                RewardShelfCard(
                                     reward: reward,
                                     unlocked: true,
-                                    isHighlighted: highlightRewardID == reward.id,
-                                    isCollected: celebratedRewardIDs.contains(reward.id)
+                                    isHighlighted: reward.id == highlightRewardID,
+                                    collected: celebratedRewardIDs.contains(reward.id)
                                 )
                             }
                         }
                     }
 
-                    VStack(alignment: .leading, spacing: context.cardSpacing) {
-                        GBSectionHeader(
-                            eyebrow: "Locked",
-                            title: "Still to unlock",
-                            subtitle: "These rewards stay hidden until their linked lesson scene is complete."
-                        )
-
-                        ForEach(lockedRewards) { reward in
-                            RewardCard(
-                                reward: reward,
-                                unlocked: false,
-                                isHighlighted: false,
-                                isCollected: false
+                    if !lockedRewards.isEmpty {
+                        VStack(alignment: .leading, spacing: context.cardSpacing) {
+                            GBSectionHeader(
+                                eyebrow: "Still ahead",
+                                title: "More keepsakes to earn",
+                                subtitle: "New Chronicle cards will appear as you finish more story scenes."
                             )
+
+                            ForEach(lockedRewards) { reward in
+                                RewardShelfCard(
+                                    reward: reward,
+                                    unlocked: false,
+                                    isHighlighted: false,
+                                    collected: false
+                                )
+                            }
                         }
                     }
                 }
@@ -104,27 +92,23 @@ struct ChronicleView: View {
         .navigationTitle("Royal Chronicle")
     }
 
-    private var heroCard: some View {
+    private var chronicleHero: some View {
         GBHeroCard(
             eyebrow: "Royal Chronicle",
-            title: unlockedRewards.isEmpty ? "Your keepsakes will appear here" : "Your Shivaji keepsakes are growing",
-            subtitle: appModel.lessonStore.chronicleHeadline,
-            detail: "Chronicle rewards should feel ceremonial and specific, tying story progress back to forts, memory, and meaning.",
-            ctaTitle: "\(unlockedRewards.count) unlocked",
-            badgeTitle: "\(rewards.count) total",
+            title: unlockedRewards.isEmpty ? "Collect your first keepsake" : "Your remembered story shelf",
+            subtitle: unlockedRewards.isEmpty ? "Short scenes unlock lasting rewards." : "\(unlockedRewards.count) keepsakes already glow here.",
+            detail: unlockedRewards.isEmpty
+                ? "Remember one story hook from the lesson path and a Chronicle page opens for you."
+                : "Each new card marks a piece of story, place, or meaning you held onto from memory.",
+            ctaTitle: unlockedRewards.isEmpty ? "Begin a scene" : "Keep collecting",
+            badgeTitle: "\(unlockedRewards.count) unlocked",
             emphasis: .chronicle,
             progress: rewards.isEmpty ? nil : Double(unlockedRewards.count) / Double(rewards.count)
         )
     }
-
-    private var debugMasterySummary: String {
-        let scene1 = appModel.lessonStore.mastery(for: "scene-1-shivneri")?.rawValue ?? "nil"
-        let scene2 = appModel.lessonStore.mastery(for: "scene-2-torna-rajgad")?.rawValue ?? "nil"
-        return "Debug mastery: \(scene1) / \(scene2)"
-    }
 }
 
-private struct HighlightRewardCard: View {
+private struct NewRewardSpotlight: View {
     let reward: ChronicleReward
     let collected: Bool
     let onCollect: () -> Void
@@ -132,24 +116,33 @@ private struct HighlightRewardCard: View {
     var body: some View {
         GBSurface(style: .accented(.chronicle)) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
-                GBSectionHeader(
-                    eyebrow: "New Reward",
-                    title: reward.title,
-                    subtitle: reward.meaning,
-                    tone: .inverse,
-                    trailing: AnyView(GBBadge(title: collected ? "Collected" : "New", symbol: collected ? GBIcon.success : GBIcon.chronicle, emphasis: .chronicle))
-                )
+                HStack {
+                    GBBadge(title: collected ? "Collected" : "New reward", symbol: collected ? GBIcon.success : GBIcon.reward, emphasis: .chronicle)
+                    Spacer()
+                    Text(reward.category.rawValue)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
+                }
+
+                Text(reward.title)
+                    .font(.system(.title2, design: .rounded, weight: .bold))
+                    .foregroundStyle(GBColor.Content.inverse)
+                Text(reward.subtitle)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(GBColor.Content.inverse.opacity(0.96))
+                Text(reward.meaning)
+                    .font(.body)
+                    .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
 
                 if collected {
-                    Label("Added to your Chronicle", systemImage: GBIcon.success)
-                        .font(.subheadline)
+                    Label("Added to your Chronicle shelf", systemImage: GBIcon.success)
+                        .font(.subheadline.weight(.semibold))
                         .foregroundStyle(GBColor.Content.inverse)
                 } else {
                     Button {
                         onCollect()
                     } label: {
-                        Label("Collect reward", systemImage: GBIcon.reward)
-                            .frame(maxWidth: .infinity)
+                        Label("Collect keepsake", systemImage: GBIcon.reward)
                     }
                     .buttonStyle(.gbSecondary)
                 }
@@ -158,58 +151,51 @@ private struct HighlightRewardCard: View {
     }
 }
 
-private struct EmptyChronicleCard: View {
-    let debugMasterySummary: String
-
-    var body: some View {
-        GBSurface(style: .plain) {
-            VStack(alignment: .leading, spacing: GBSpacing.small) {
-                Text("Finish a lesson scene to place its meaning into the Royal Chronicle.")
-                    .font(.subheadline)
-                    .foregroundStyle(GBColor.Content.secondary)
-                Text(debugMasterySummary)
-                    .font(.caption)
-                    .foregroundStyle(GBColor.Content.secondary)
-            }
-        }
-    }
-}
-
-private struct RewardCard: View {
+private struct RewardShelfCard: View {
     let reward: ChronicleReward
     let unlocked: Bool
     let isHighlighted: Bool
-    let isCollected: Bool
+    let collected: Bool
 
     var body: some View {
-        GBSurface(style: isHighlighted ? .elevated : .plain) {
+        GBSurface(style: unlocked ? .plain : .elevated) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 HStack(alignment: .top, spacing: GBSpacing.small) {
                     VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                        HStack(spacing: GBSpacing.xxSmall) {
+                            GBBadge(
+                                title: unlocked ? reward.mastery.rawValue : "Locked",
+                                symbol: unlocked ? GBIcon.success : GBIcon.locked,
+                                emphasis: unlocked ? .chronicle : .neutral
+                            )
+
+                            if isHighlighted {
+                                GBBadge(title: collected ? "Collected" : "New", symbol: collected ? GBIcon.success : GBIcon.reward, emphasis: .story)
+                            }
+                        }
+
                         Text(reward.title)
                             .gbTitle()
                             .foregroundStyle(GBColor.Content.primary)
                         Text(reward.subtitle)
-                            .font(.subheadline)
+                            .font(.subheadline.weight(.semibold))
                             .foregroundStyle(GBColor.Content.secondary)
                     }
 
                     Spacer()
 
-                    if isHighlighted {
-                        GBBadge(title: isCollected ? "Collected" : "New", symbol: isCollected ? GBIcon.success : GBIcon.reward, emphasis: .chronicle)
-                    } else {
-                        GBBadge(title: reward.category.rawValue, symbol: unlocked ? GBIcon.chronicle : GBIcon.locked, emphasis: unlocked ? .chronicle : .neutral)
-                    }
+                    Image(systemName: unlocked ? GBIcon.chronicle : GBIcon.locked)
+                        .font(.title2)
+                        .foregroundStyle(unlocked ? GBColor.Accent.chronicle : GBColor.State.locked)
                 }
 
-                Text(unlocked ? reward.meaning : "Complete the linked lesson scene to reveal this Chronicle reward.")
+                Text(unlocked ? reward.meaning : "Finish the linked story scene and answer its recall card to reveal this keepsake.")
                     .gbBody()
-                    .foregroundStyle(GBColor.Content.primary)
+                    .foregroundStyle(GBColor.Content.secondary)
 
-                Label(reward.mastery.rawValue, systemImage: unlocked ? "medal.fill" : GBIcon.locked)
-                    .font(.caption)
-                    .foregroundStyle(unlocked ? GBColor.Accent.chronicle : GBColor.Content.secondary)
+                Text(reward.category.rawValue)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(GBColor.accent(for: unlocked ? .chronicle : .neutral))
             }
         }
     }

--- a/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
+++ b/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
@@ -3,6 +3,13 @@ import SwiftUI
 struct LessonHomeView: View {
     @EnvironmentObject private var appModel: AppModel
 
+    private var nextScene: StoryScene? {
+        if let nextSceneID = appModel.lessonStore.nextSceneID {
+            return appModel.content.scenes.first(where: { $0.id == nextSceneID })
+        }
+        return appModel.content.scenes.last
+    }
+
     private var unlockedRewardsCount: Int {
         appModel.lessonStore.unlockedRewards(from: appModel.content.rewards).count
     }
@@ -15,16 +22,7 @@ struct LessonHomeView: View {
                         NavigationLink {
                             SceneLessonView(scene: nextScene)
                         } label: {
-                            GBHeroCard(
-                                eyebrow: appModel.content.arcTitle,
-                                title: appModel.lessonStore.completedScenes == 0 ? "Hear the story first" : "Your story path is still open",
-                                subtitle: nextScene.title,
-                                detail: "Follow one scene at a time, remember the fort, then add its meaning to your Chronicle.",
-                                ctaTitle: appModel.lessonStore.completedScenes == 0 ? "Start Scene 1" : "Continue journey",
-                                badgeTitle: appModel.lessonStore.completedScenes == appModel.lessonStore.totalScenes ? "Journey complete" : "Next scene",
-                                emphasis: .story,
-                                progress: appModel.lessonStore.overallProgress
-                            )
+                            homeHeroCard(nextScene: nextScene)
                         }
                         .buttonStyle(.plain)
                     }
@@ -32,81 +30,51 @@ struct LessonHomeView: View {
                     GBSurface(style: .elevated) {
                         VStack(alignment: .leading, spacing: GBSpacing.small) {
                             GBSectionHeader(
-                                eyebrow: "Quest",
-                                title: "Story to fort to Chronicle",
-                                subtitle: "Keep the loop simple: hear one moment, find its fort, then collect the meaning it unlocks."
+                                eyebrow: "Your next move",
+                                title: appModel.lessonStore.completedScenes == 0 ? "Tap one path and begin" : "Keep the adventure moving",
+                                subtitle: "Each scene is short: three story cards, one memory check, then a new Chronicle keepsake."
                             )
 
-                            GBQuestProgress(
-                                steps: [.story, .place, .chronicle],
-                                currentStepID: unlockedRewardsCount > 0 ? "chronicle" : "story"
-                            )
+                            HStack(spacing: GBSpacing.small) {
+                                JourneyStatPill(title: "Scenes", value: "\(appModel.lessonStore.completedScenes)/\(appModel.lessonStore.totalScenes)", emphasis: .story)
+                                JourneyStatPill(title: "Chronicle", value: "\(unlockedRewardsCount)", emphasis: .chronicle)
+                                JourneyStatPill(title: "Forts", value: "\(appModel.content.corePlaces.count)", emphasis: .place)
+                            }
                         }
                     }
 
                     VStack(alignment: .leading, spacing: context.cardSpacing) {
                         GBSectionHeader(
-                            eyebrow: "Story Path",
-                            title: "Choose a Shivaji Maharaj moment",
-                            subtitle: "Only the next unfinished scene opens by default, so kids stay focused on one clear task."
+                            eyebrow: "Adventure path",
+                            title: "Choose a story moment",
+                            subtitle: "One clear card first, one quick recall next, one reward at the end."
                         )
 
                         ForEach(appModel.content.scenes) { scene in
-                            let isUnlocked = appModel.lessonStore.isSceneUnlocked(scene)
-                            let card = SceneRowCard(
-                                scene: scene,
-                                mastery: appModel.lessonStore.mastery(for: scene.id),
-                                isNext: scene.id == appModel.lessonStore.nextSceneID,
-                                isLocked: !isUnlocked
-                            )
-
-                            Group {
-                                if isUnlocked {
-                                    NavigationLink {
-                                        SceneLessonView(scene: scene)
-                                    } label: {
-                                        card
-                                    }
-                                    .buttonStyle(.plain)
-                                } else {
-                                    card
-                                }
+                            NavigationLink {
+                                SceneLessonView(scene: scene)
+                            } label: {
+                                SceneJourneyCard(
+                                    scene: scene,
+                                    reward: appModel.content.rewards.first(where: { $0.id == scene.rewardID }),
+                                    mastery: appModel.lessonStore.mastery(for: scene.id),
+                                    isNext: scene.id == appModel.lessonStore.nextSceneID
+                                )
                             }
+                            .buttonStyle(.plain)
                         }
                     }
 
                     NavigationLink {
-                        PlacesHubView(places: appModel.content.corePlaces)
+                        ChronicleView(rewards: appModel.content.rewards)
                     } label: {
-                        PlacesLoopCard(
-                            readyCount: appModel.content.corePlaces.filter { appModel.lessonStore.progress(for: $0) != .locked }.count,
-                            totalCount: appModel.content.corePlaces.count
+                        ChronicleJourneyCard(
+                            headline: appModel.lessonStore.chronicleHeadline,
+                            unlockedCount: unlockedRewardsCount,
+                            totalCount: appModel.content.rewards.count
                         )
                     }
                     .buttonStyle(.plain)
-
-                    Group {
-                        if unlockedRewardsCount > 0 {
-                            NavigationLink {
-                                ChronicleView(rewards: appModel.content.rewards)
-                            } label: {
-                                ChronicleTeaserCard(
-                                    headline: appModel.lessonStore.chronicleHeadline,
-                                    unlockedCount: unlockedRewardsCount,
-                                    totalCount: appModel.content.rewards.count,
-                                    isLocked: false
-                                )
-                            }
-                            .buttonStyle(.plain)
-                        } else {
-                            ChronicleTeaserCard(
-                                headline: "Finish one scene to unlock the first keepsake.",
-                                unlockedCount: unlockedRewardsCount,
-                                totalCount: appModel.content.rewards.count,
-                                isLocked: true
-                            )
-                        }
-                    }
                 }
                 .frame(maxWidth: context.maxContentWidth, alignment: .leading)
                 .padding(context.containerPadding)
@@ -117,22 +85,50 @@ struct LessonHomeView: View {
         .navigationTitle("Greats of Bharatha")
     }
 
-    private var nextScene: StoryScene? {
-        if let nextSceneID = appModel.lessonStore.nextSceneID {
-            return appModel.content.scenes.first(where: { $0.id == nextSceneID })
-        }
-        return appModel.content.scenes.last
+    private func homeHeroCard(nextScene: StoryScene) -> some View {
+        GBHeroCard(
+            eyebrow: "Shivaji Maharaj",
+            title: appModel.lessonStore.completedScenes == 0 ? "Begin the hill-fort adventure" : "Your next fort is ready",
+            subtitle: nextScene.timelineMarker,
+            detail: appModel.lessonStore.completedScenes == 0
+                ? "Start with one vivid scene, hold onto one memory hook, then earn your first Chronicle card."
+                : "Jump back in with one short scene, a place clue trail, and a Chronicle keepsake waiting at the finish.",
+            ctaTitle: appModel.lessonStore.completedScenes == 0 ? "Start Scene \(nextScene.number)" : "Continue journey",
+            badgeTitle: appModel.lessonStore.completedScenes == appModel.lessonStore.totalScenes ? "Journey complete" : "Next adventure",
+            emphasis: .story,
+            progress: appModel.lessonStore.overallProgress
+        )
     }
 }
 
-private struct SceneRowCard: View {
-    let scene: StoryScene
-    let mastery: MasteryState?
-    let isNext: Bool
-    let isLocked: Bool
+private struct JourneyStatPill: View {
+    let title: String
+    let value: String
+    let emphasis: GBEmphasis
 
     var body: some View {
-        GBSurface(style: .plain) {
+        VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+            Text(title)
+                .gbCaption()
+                .foregroundStyle(GBColor.Content.secondary)
+            Text(value)
+                .gbHeadline()
+                .foregroundStyle(GBColor.accent(for: emphasis))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(GBSpacing.xSmall)
+        .background(GBColor.Background.surface, in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
+    }
+}
+
+private struct SceneJourneyCard: View {
+    let scene: StoryScene
+    let reward: ChronicleReward?
+    let mastery: MasteryState?
+    let isNext: Bool
+
+    var body: some View {
+        GBSurface(style: isNext ? .elevated : .plain) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 HStack(alignment: .top, spacing: GBSpacing.small) {
                     VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
@@ -140,9 +136,6 @@ private struct SceneRowCard: View {
                             GBBadge(title: "Scene \(scene.number)", symbol: GBIcon.story, emphasis: .story)
                             if isNext {
                                 GBBadge(title: "Up next", symbol: GBIcon.next, emphasis: .story)
-                            }
-                            if isLocked {
-                                GBBadge(title: "Finish scene \(scene.number - 1) first", symbol: "lock.fill", emphasis: .neutral)
                             }
                         }
 
@@ -157,88 +150,96 @@ private struct SceneRowCard: View {
                             .lineLimit(2)
                     }
 
-                    Spacer(minLength: GBSpacing.small)
+                    Spacer()
 
                     if let mastery {
-                        GBBadge(title: mastery.rawValue, symbol: GBIcon.reward, emphasis: .story)
+                        GBBadge(title: mastery.rawValue, symbol: masterySymbol(mastery), emphasis: masteryEmphasis(mastery))
                     }
                 }
 
                 HStack(spacing: GBSpacing.small) {
-                    Label(scene.timelineMarker, systemImage: GBIcon.timeline)
-                    Spacer()
-                    Label(isLocked ? "Locked" : (isNext ? "Start" : "Review"), systemImage: isLocked ? "lock.fill" : GBIcon.next)
-                        .font(.subheadline.weight(.semibold))
-                }
-                .font(.subheadline)
-                .foregroundStyle(GBColor.Content.secondary)
-            }
-            .opacity(isLocked ? 0.72 : 1)
-        }
-    }
-}
-
-private struct PlacesLoopCard: View {
-    let readyCount: Int
-    let totalCount: Int
-
-    var body: some View {
-        GBSurface(style: .accented(.place)) {
-            VStack(alignment: .leading, spacing: GBSpacing.small) {
-                HStack(alignment: .top, spacing: GBSpacing.small) {
-                    VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
-                        Text("Find the fort next")
-                            .font(.caption.weight(.bold))
-                            .foregroundStyle(GBColor.Content.inverse.opacity(0.86))
-                        Text("Open the place trail")
-                            .font(.title3.weight(.bold))
-                            .foregroundStyle(GBColor.Content.inverse)
-                        Text("Keep the story connected to real forts so the journey feels spatial, not just sequential.")
-                            .font(.body)
-                            .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
+                    miniChip(title: scene.timelineMarker, symbol: "sparkles")
+                    if let reward {
+                        miniChip(title: reward.title, symbol: GBIcon.chronicle)
                     }
-
-                    Spacer()
-
-                    GBBadge(title: "\(readyCount) of \(totalCount) ready", symbol: GBIcon.place, emphasis: .place)
+                    miniChip(title: "3 cards + recall", symbol: "square.stack.3d.up.fill")
                 }
 
-                Label("See the Sahyadri fort path", systemImage: GBIcon.next)
-                    .font(.headline.weight(.semibold))
-                    .foregroundStyle(GBColor.Content.inverse)
+                HStack {
+                    Text(isNext ? "Start this scene" : "Open scene")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(GBColor.Content.primary)
+                    Spacer()
+                    Image(systemName: GBIcon.next)
+                        .foregroundStyle(GBColor.Accent.story)
+                }
             }
+        }
+    }
+
+    private func miniChip(title: String, symbol: String) -> some View {
+        Label(title, systemImage: symbol)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(GBColor.Content.secondary)
+            .padding(.horizontal, GBSpacing.xSmall)
+            .padding(.vertical, GBSpacing.xxxSmall)
+            .background(GBColor.Background.elevated, in: Capsule())
+    }
+
+    private func masterySymbol(_ mastery: MasteryState) -> String {
+        switch mastery {
+        case .witnessed:
+            return "eye.fill"
+        case .understood:
+            return "star.fill"
+        case .observedClosely:
+            return "sparkles"
+        }
+    }
+
+    private func masteryEmphasis(_ mastery: MasteryState) -> GBEmphasis {
+        switch mastery {
+        case .witnessed:
+            return .neutral
+        case .understood:
+            return .story
+        case .observedClosely:
+            return .chronicle
         }
     }
 }
 
-private struct ChronicleTeaserCard: View {
+private struct ChronicleJourneyCard: View {
     let headline: String
     let unlockedCount: Int
     let totalCount: Int
-    let isLocked: Bool
 
     var body: some View {
         GBSurface(style: .accented(.chronicle)) {
-            HStack(spacing: GBSpacing.small) {
-                VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+            HStack(alignment: .center, spacing: GBSpacing.small) {
+                Image(systemName: GBIcon.chronicle)
+                    .font(.title2)
+                    .foregroundStyle(GBColor.Content.inverse)
+                    .frame(width: 52, height: 52)
+                    .background(.white.opacity(0.14), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
+
+                VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
                     Text("Royal Chronicle")
-                        .font(.title3.weight(.bold))
+                        .gbHeadline()
                         .foregroundStyle(GBColor.Content.inverse)
                     Text(headline)
-                        .font(.body)
+                        .font(.subheadline.weight(.medium))
                         .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
-                    Text("\(unlockedCount) of \(totalCount) rewards unlocked")
+                    Text("\(unlockedCount) of \(totalCount) keepsakes ready")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
                 }
 
                 Spacer()
 
-                Image(systemName: isLocked ? "lock.fill" : GBIcon.chronicle)
-                    .font(.title2)
+                Image(systemName: GBIcon.next)
                     .foregroundStyle(GBColor.Content.inverse)
             }
         }
-        .opacity(isLocked ? 0.82 : 1)
     }
 }

--- a/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
+++ b/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
@@ -5,113 +5,166 @@ struct SceneLessonView: View {
     let scene: StoryScene
 
     @State private var cardIndex = 0
-    @State private var storyStepComplete = false
     @State private var recallState = LessonRecallState()
     @State private var revealedMapAnchors = 0
     @State private var chosenPlanSteps: Set<String> = []
-    @State private var bonusPlanningVisible = false
     @State private var hintVisible = false
-    @State private var recapVisible = false
+
+    private var reward: ChronicleReward? {
+        appModel.content.rewards.first(where: { $0.id == scene.rewardID })
+    }
 
     private var lessonCards: [SceneCardContent] {
         [
-            SceneCardContent(id: "summary", eyebrow: "Story spark", title: scene.title, body: scene.childSafeSummary, symbol: GBIcon.story),
-            SceneCardContent(id: "fact", eyebrow: "Remember this", title: scene.keyFact, body: scene.narrativeObjective, symbol: "sparkles.rectangle.stack.fill"),
-            SceneCardContent(id: "timeline", eyebrow: "Chronicle moment", title: scene.timelineMarker, body: "This is the moment you will remember when you open the Royal Chronicle.", symbol: GBIcon.timeline)
+            SceneCardContent(
+                id: "hook",
+                eyebrow: "Hook card",
+                title: scene.timelineMarker,
+                body: scene.childSafeSummary,
+                symbol: GBIcon.story,
+                accent: scene.mapAnchors.first ?? scene.timelineMarker
+            ),
+            SceneCardContent(
+                id: "meaning",
+                eyebrow: "Meaning card",
+                title: scene.keyFact,
+                body: scene.narrativeObjective,
+                symbol: GBIcon.reward,
+                accent: "Why it matters"
+            ),
+            SceneCardContent(
+                id: "anchor",
+                eyebrow: "Anchor card",
+                title: scene.recallPrompt.answer,
+                body: scene.recallPrompt.supportText,
+                symbol: GBIcon.place,
+                accent: "Keep this hook"
+            )
         ]
     }
 
-    private var flow: SceneLessonFlow {
-        SceneLessonFlow(
-            totalStoryCards: lessonCards.count,
-            currentStoryCardIndex: cardIndex,
-            storyStepComplete: storyStepComplete,
-            totalMapAnchors: scene.mapAnchors.count,
-            revealedMapAnchors: revealedMapAnchors,
-            hasAnsweredCorrectly: recallState.hasAnsweredCorrectly
-        )
+    private var progressValue: Double {
+        let storyProgress = Double(cardIndex + 1) / Double(max(lessonCards.count, 1))
+        let placeProgress = min(Double(revealedMapAnchors) / Double(max(scene.mapAnchors.count, 1)), 1)
+        let planningProgress = scene.number == 2 ? min(Double(chosenPlanSteps.count) / 2, 1) : 1
+        let recallProgress = recallState.selectedChoiceID == nil ? 0.2 : (recallState.hasAnsweredCorrectly ? 1 : 0.55)
+        let total = storyProgress + placeProgress + planningProgress + recallProgress
+        return min(total / 4, 1)
     }
 
-    private var currentStepTitle: String {
-        switch cardIndex {
-        case 0: return "Step 1 of 3, hear the story"
-        case 1: return "Step 2 of 3, spot the big idea"
-        default: return "Step 3 of 3, mark the moment"
+    private var currentCard: SceneCardContent {
+        lessonCards[cardIndex]
+    }
+
+    private var nextCardButtonTitle: String {
+        cardIndex == lessonCards.count - 1 ? "Go to place clues" : "Next card"
+    }
+
+    private var sceneChoices: [LessonChoice] {
+        var choices = scene.mapAnchors.map {
+            LessonChoice(id: $0.lowercased().replacingOccurrences(of: " ", with: "-"), title: $0, detail: "A place clue from this scene")
         }
-    }
-
-    private var storyButtonTitle: String {
-        cardIndex == lessonCards.count - 1 ? "Continue to place clues" : "Continue story"
+        if !choices.contains(where: { normalized($0.title) == normalized(scene.recallPrompt.answer) }) {
+            choices.insert(LessonChoice(id: scene.id + "-answer", title: scene.recallPrompt.answer, detail: "The memory hook you want to keep"), at: 0)
+        }
+        return Array(choices.prefix(3))
     }
 
     var body: some View {
         GBLayoutContextReader { context in
             ScrollView {
                 VStack(alignment: .leading, spacing: context.sectionSpacing) {
-                    SceneHeaderCard(
+                    SceneAdventureHero(
                         scene: scene,
-                        progressValue: flow.progressValue,
+                        reward: reward,
+                        progressValue: progressValue,
                         mastery: appModel.lessonStore.mastery(for: scene.id)
                     )
 
                     GBSurface(style: .elevated) {
                         VStack(alignment: .leading, spacing: GBSpacing.small) {
                             GBSectionHeader(
-                                eyebrow: "Quest",
-                                title: "Hear the story, remember the fort, keep the Chronicle",
-                                subtitle: "Only the active step stays on screen, so the scene feels easy to finish."
+                                eyebrow: "Adventure path",
+                                title: currentCard.eyebrow,
+                                subtitle: "Move through one clear card at a time, then answer from memory."
                             )
 
                             GBQuestProgress(
-                                steps: [.story, .place, .chronicle],
-                                currentStepID: flow.currentQuestStepID
+                                steps: [
+                                    .story,
+                                    GBQuestProgress.Step(id: "meaning", title: "Meaning", symbol: GBIcon.reward),
+                                    .place,
+                                    .chronicle
+                                ],
+                                currentStepID: currentQuestStepID
                             )
                         }
                     }
 
-                    switch flow.activeStage {
-                    case .story:
-                        StoryDeckCard(
-                            currentStepTitle: currentStepTitle,
-                            lessonCards: lessonCards,
-                            cardIndex: $cardIndex,
-                            nextCardButtonTitle: storyButtonTitle,
-                            onFinishStory: completeStoryStep
-                        )
-                    case .place:
-                        MapAnchorCard(scene: scene, revealedMapAnchors: $revealedMapAnchors)
-                    case .chronicle:
-                        SceneSupportCard(
-                            hintVisible: $hintVisible,
-                            recapVisible: recapVisible,
-                            hasAnsweredCorrectly: recallState.hasAnsweredCorrectly,
-                            curatedHint: curatedHint,
-                            sceneRecap: sceneRecap
-                        )
+                    ActiveStoryCard(
+                        card: currentCard,
+                        cardNumber: cardIndex + 1,
+                        totalCards: lessonCards.count
+                    )
 
-                        RecallPanel(
-                            question: scene.recallPrompt,
-                            choices: sceneChoices,
-                            selectedChoiceID: $recallState.selectedChoiceID,
-                            feedbackText: recallState.feedbackText,
-                            completed: recallState.hasAnsweredCorrectly,
-                            onSubmit: submitRecall
-                        )
-                    case .complete:
-                        CompletedSceneActions(
-                            scene: scene,
-                            places: appModel.content.corePlaces,
-                            rewards: appModel.content.rewards,
-                            recapVisible: recapVisible,
-                            sceneRecap: sceneRecap,
-                            bonusPlanningVisible: $bonusPlanningVisible,
-                            showsPlanningChallenge: scene.number == 2,
-                            hasPlanningUpgrade: chosenPlanSteps.count >= 2
-                        )
-
-                        if scene.number == 2, bonusPlanningVisible {
-                            BonusPlanningCard(chosenPlanSteps: $chosenPlanSteps)
+                    HStack(spacing: GBSpacing.small) {
+                        if cardIndex > 0 {
+                            Button("Back") {
+                                cardIndex = max(cardIndex - 1, 0)
+                                LessonFeedback.fire(.selection)
+                            }
+                            .buttonStyle(.gbSecondary)
                         }
+
+                        Button(nextCardButtonTitle) {
+                            cardIndex = min(cardIndex + 1, lessonCards.count - 1)
+                            LessonFeedback.fire(.selection)
+                        }
+                        .buttonStyle(.gbPrimary(.story))
+                    }
+
+                    PlaceClueTrailCard(scene: scene, revealedMapAnchors: $revealedMapAnchors)
+
+                    if scene.number == 2 {
+                        FortPlanningCard(chosenPlanSteps: $chosenPlanSteps)
+                    }
+
+                    GBSurface(style: .plain) {
+                        VStack(alignment: .leading, spacing: GBSpacing.small) {
+                            Button(hintVisible ? "Hide clue" : "Need a clue?") {
+                                hintVisible.toggle()
+                                LessonFeedback.fire(.reveal)
+                            }
+                            .buttonStyle(.gbSecondary)
+
+                            if hintVisible {
+                                GuidanceCard(
+                                    title: "Helpful clue",
+                                    message: curatedHint,
+                                    systemImage: "lightbulb.fill"
+                                )
+                            }
+                        }
+                    }
+
+                    RecallPanel(
+                        question: scene.recallPrompt,
+                        choices: sceneChoices,
+                        selectedChoiceID: $recallState.selectedChoiceID,
+                        feedbackText: recallState.feedbackText,
+                        completed: recallState.hasAnsweredCorrectly,
+                        onSubmit: submitRecall
+                    )
+
+                    if recallState.hasAnsweredCorrectly, let reward {
+                        RewardTransitionCard(reward: reward, scene: scene)
+
+                        NavigationLink {
+                            ChronicleView(rewards: appModel.content.rewards, highlightRewardID: reward.id)
+                        } label: {
+                            Label("Open my Chronicle page", systemImage: GBIcon.chronicle)
+                        }
+                        .buttonStyle(.gbPrimary(.chronicle))
                     }
                 }
                 .frame(maxWidth: context.maxContentWidth, alignment: .leading)
@@ -124,15 +177,19 @@ struct SceneLessonView: View {
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
 #endif
-        .onChange(of: chosenPlanSteps) { _, newValue in
-            guard scene.number == 2, recallState.hasAnsweredCorrectly, newValue.count >= 2 else { return }
-            appModel.lessonStore.markScene(scene.id, mastery: .observedClosely)
-        }
     }
 
-    private func completeStoryStep() {
-        storyStepComplete = true
-        LessonFeedback.fire(.success)
+    private var currentQuestStepID: String {
+        if recallState.hasAnsweredCorrectly {
+            return "chronicle"
+        }
+        if cardIndex == 1 {
+            return "meaning"
+        }
+        if cardIndex == 2 || revealedMapAnchors > 0 {
+            return "place"
+        }
+        return "story"
     }
 
     private func submitRecall() {
@@ -143,14 +200,12 @@ struct SceneLessonView: View {
 
         if normalized(selectedTitle) == correctAnswer {
             recallState.hasAnsweredCorrectly = true
-            recallState.feedbackText = "You got it. \(scene.recallPrompt.supportText)"
-            recapVisible = true
+            recallState.feedbackText = "Yes. \(scene.recallPrompt.supportText)"
             let mastery: MasteryState = scene.number == 2 && chosenPlanSteps.count >= 2 ? .observedClosely : .understood
             appModel.lessonStore.markScene(scene.id, mastery: mastery)
             LessonFeedback.fire(.success)
         } else {
             recallState.hasAnsweredCorrectly = false
-            recapVisible = false
             recallState.feedbackText = "Almost. \(scene.recallPrompt.supportText)"
             appModel.lessonStore.markScene(scene.id, mastery: .witnessed)
             LessonFeedback.fire(.warning)
@@ -159,23 +214,9 @@ struct SceneLessonView: View {
 
     private var curatedHint: String {
         if scene.number == 1 {
-            return "Think about where the story begins. The answer is the fort tied to Shivaji Maharaj's birth and Jijabai's early guidance."
+            return "The first scene begins at the fort where Shivaji Maharaj was born with Jijabai nearby."
         }
-        return "One fort marks an early breakthrough, but the recall question asks which one became the early capital. Focus on the planning base that comes after Torna."
-    }
-
-    private var sceneRecap: String {
-        "\(scene.timelineMarker). \(scene.childSafeSummary) Remember: \(scene.keyFact)"
-    }
-
-    private var sceneChoices: [LessonChoice] {
-        var choices = scene.mapAnchors.map {
-            LessonChoice(id: $0.lowercased().replacingOccurrences(of: " ", with: "-"), title: $0, detail: "A place name from this scene.")
-        }
-        if !choices.contains(where: { normalized($0.title) == normalized(scene.recallPrompt.answer) }) {
-            choices.insert(LessonChoice(id: scene.id + "-answer", title: scene.recallPrompt.answer, detail: "The place tied to the key fact in this scene."), at: 0)
-        }
-        return Array(choices.prefix(3))
+        return "Torna is the breakthrough fort. The answer you want is the fort that became the early capital after that."
     }
 
     private func normalized(_ text: String) -> String {
@@ -189,10 +230,12 @@ private struct SceneCardContent: Identifiable {
     let title: String
     let body: String
     let symbol: String
+    let accent: String
 }
 
-private struct SceneHeaderCard: View {
+private struct SceneAdventureHero: View {
     let scene: StoryScene
+    let reward: ChronicleReward?
     let progressValue: Double
     let mastery: MasteryState?
 
@@ -201,241 +244,180 @@ private struct SceneHeaderCard: View {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 HStack(alignment: .top, spacing: GBSpacing.small) {
                     VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
-                        Text(scene.timelineMarker.uppercased())
+                        Text("SCENE \(scene.number)")
                             .font(.caption.weight(.bold))
-                            .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.84))
                         Text(scene.title)
                             .font(.system(.title2, design: .rounded, weight: .bold))
                             .foregroundStyle(GBColor.Content.inverse)
-                        Text(scene.narrativeObjective)
-                            .font(.body)
-                            .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
+                        Text(scene.childSafeSummary)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.92))
                     }
 
-                    Spacer(minLength: GBSpacing.small)
+                    Spacer()
 
                     GBBadge(
                         title: mastery?.rawValue ?? "Ready",
-                        symbol: mastery == nil ? GBIcon.story : GBIcon.reward,
-                        emphasis: .story
+                        symbol: mastery == nil ? GBIcon.story : "star.fill",
+                        emphasis: mastery == nil ? .neutral : .chronicle
                     )
                 }
 
                 ProgressView(value: progressValue)
                     .tint(GBColor.Content.inverse)
 
-                HStack(alignment: .firstTextBaseline, spacing: GBSpacing.small) {
-                    VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
-                        Text("Royal Chronicle reward")
-                            .font(.caption.weight(.bold))
-                            .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
-                        Text(scene.rewardID.replacingOccurrences(of: "reward-", with: "").replacingOccurrences(of: "-", with: " ").capitalized)
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(GBColor.Content.inverse)
-                    }
-
-                    Spacer()
-
-                    Text("Small steps, one clear finish")
-                        .font(.caption)
-                        .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
-                }
-            }
-        }
-    }
-}
-
-private struct StoryDeckCard: View {
-    let currentStepTitle: String
-    let lessonCards: [SceneCardContent]
-    @Binding var cardIndex: Int
-    let nextCardButtonTitle: String
-    let onFinishStory: () -> Void
-
-    var body: some View {
-        GBSurface(style: .plain) {
-            VStack(alignment: .leading, spacing: GBSpacing.small) {
-                GBSectionHeader(
-                    eyebrow: "Story",
-                    title: currentStepTitle,
-                    subtitle: "Keep one memory hook visible before moving to place clues."
-                )
-
-                TabView(selection: $cardIndex) {
-                    ForEach(Array(lessonCards.enumerated()), id: \.offset) { index, card in
-                        StoryCardView(card: card, cardNumber: index + 1, totalCards: lessonCards.count)
-                            .padding(.horizontal, GBSpacing.xxxSmall)
-                            .tag(index)
-                    }
-                }
-#if os(iOS)
-                .tabViewStyle(.page(indexDisplayMode: .never))
-#endif
-                .frame(height: 340)
-
-                HStack(spacing: GBSpacing.xxSmall) {
-                    ForEach(0..<lessonCards.count, id: \.self) { index in
-                        Capsule()
-                            .fill(index == cardIndex ? GBColor.Accent.story : GBColor.Accent.story.opacity(0.18))
-                            .frame(width: index == cardIndex ? 28 : 10, height: 10)
-                    }
-                }
-
                 HStack(spacing: GBSpacing.small) {
-                    if cardIndex > 0 {
-                        Button("Back") {
-                            cardIndex = max(cardIndex - 1, 0)
-                            LessonFeedback.fire(.selection)
-                        }
-                        .buttonStyle(.gbSecondary)
+                    heroChip(title: scene.timelineMarker, symbol: GBIcon.timeline)
+                    if let reward {
+                        heroChip(title: reward.title, symbol: GBIcon.chronicle)
                     }
-
-                    Button(nextCardButtonTitle) {
-                        if cardIndex == lessonCards.count - 1 {
-                            onFinishStory()
-                        } else {
-                            cardIndex = min(cardIndex + 1, lessonCards.count - 1)
-                            LessonFeedback.fire(.selection)
-                        }
-                    }
-                    .buttonStyle(.gbPrimary(.story))
                 }
             }
         }
     }
+
+    private func heroChip(title: String, symbol: String) -> some View {
+        Label(title, systemImage: symbol)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(GBColor.Content.inverse)
+            .padding(.horizontal, GBSpacing.xSmall)
+            .padding(.vertical, GBSpacing.xxxSmall)
+            .background(.white.opacity(0.12), in: Capsule())
+    }
 }
 
-private struct StoryCardView: View {
+private struct ActiveStoryCard: View {
     let card: SceneCardContent
     let cardNumber: Int
     let totalCards: Int
 
     var body: some View {
-        GBSurface(style: .elevated, padding: GBSpacing.large) {
+        GBSurface(style: .plain, padding: GBSpacing.large) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 HStack {
-                    Text(card.eyebrow.uppercased())
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(GBColor.Content.secondary)
+                    GBBadge(title: "\(cardNumber) of \(totalCards)", symbol: "square.stack.3d.up.fill", emphasis: .story)
                     Spacer()
-                    Text("\(cardNumber)/\(totalCards)")
+                    Text(card.eyebrow)
                         .font(.caption.weight(.bold))
                         .foregroundStyle(GBColor.Accent.story)
                 }
 
                 Image(systemName: card.symbol)
-                    .font(.system(size: 36, weight: .semibold))
+                    .font(.system(size: 34))
                     .foregroundStyle(GBColor.Content.inverse)
                     .frame(width: 68, height: 68)
                     .background(GBColor.gradient(for: .story), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
 
                 Text(card.title)
-                    .gbTitle()
+                    .font(.system(.title3, design: .rounded, weight: .bold))
                     .foregroundStyle(GBColor.Content.primary)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Text(card.body)
                     .gbBody()
                     .foregroundStyle(GBColor.Content.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Spacer(minLength: 0)
+                Label(card.accent, systemImage: "sparkles")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(GBColor.Accent.story)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
+        .accessibilityLabel("\(card.eyebrow). \(currentSummary)")
+    }
+
+    private var currentSummary: String {
+        "\(card.title). \(card.body)"
     }
 }
 
-private struct MapAnchorCard: View {
+private struct PlaceClueTrailCard: View {
     let scene: StoryScene
     @Binding var revealedMapAnchors: Int
 
     var body: some View {
-        GBSurface(style: .accented(.place)) {
+        GBSurface(style: .plain) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 GBSectionHeader(
-                    eyebrow: "Find Place",
-                    title: "Reveal the fort clues",
-                    subtitle: "Place names appear one by one so the story stays connected to the map.",
-                    tone: .inverse,
-                    trailing: AnyView(
-                        GBBadge(
-                            title: "\(revealedMapAnchors)/\(scene.mapAnchors.count)",
-                            symbol: GBIcon.place,
-                            emphasis: .place
-                        )
-                    )
+                    eyebrow: "Place clue trail",
+                    title: "Follow the fort path",
+                    subtitle: "Reveal one clue at a time so the story keeps its shape on the map."
                 )
 
                 ForEach(Array(scene.mapAnchors.enumerated()), id: \.offset) { index, anchor in
-                    HStack(alignment: .top, spacing: GBSpacing.small) {
+                    HStack(spacing: GBSpacing.small) {
                         Image(systemName: index < revealedMapAnchors ? "mappin.circle.fill" : "mappin.circle")
-                            .foregroundStyle(GBColor.Content.inverse)
+                            .foregroundStyle(index < revealedMapAnchors ? GBColor.Accent.place : GBColor.Content.secondary)
                             .font(.title3)
 
                         VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
                             Text(index < revealedMapAnchors ? anchor : "Hidden place clue")
                                 .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(GBColor.Content.inverse)
-                            Text(index < revealedMapAnchors ? "This place now anchors the scene in your memory." : "Reveal the next clue when you are ready.")
+                                .foregroundStyle(GBColor.Content.primary)
+                            Text(index < revealedMapAnchors ? "Keep this place in your mind for the recall card." : "Reveal the next clue when you are ready.")
                                 .font(.caption)
-                                .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
+                                .foregroundStyle(GBColor.Content.secondary)
                         }
 
                         Spacer()
                     }
                     .padding(GBSpacing.small)
-                    .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
+                    .background(GBColor.Background.elevated, in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
                 }
 
-                Button(revealedMapAnchors == scene.mapAnchors.count ? "Continue to Chronicle" : "Reveal next place clue") {
+                Button(revealedMapAnchors == scene.mapAnchors.count ? "All clues found" : "Reveal next clue") {
                     let nextValue = min(revealedMapAnchors + 1, scene.mapAnchors.count)
                     if nextValue != revealedMapAnchors {
                         revealedMapAnchors = nextValue
                         LessonFeedback.fire(nextValue == scene.mapAnchors.count ? .success : .reveal)
                     }
                 }
-                .buttonStyle(.gbSecondary)
+                .buttonStyle(.gbPrimary(.place))
             }
         }
     }
 }
 
-private struct SceneSupportCard: View {
-    @Binding var hintVisible: Bool
-    let recapVisible: Bool
-    let hasAnsweredCorrectly: Bool
-    let curatedHint: String
-    let sceneRecap: String
+private struct FortPlanningCard: View {
+    @Binding var chosenPlanSteps: Set<String>
 
     var body: some View {
-        GBSurface(style: .elevated) {
+        GBSurface(style: .plain) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 GBSectionHeader(
-                    eyebrow: "Help",
-                    title: "Use one clue if you need it",
-                    subtitle: "Hints stay optional so the main task remains clear."
+                    eyebrow: "Planning practice",
+                    title: "Pick two strong fort moves",
+                    subtitle: "Choose the ideas that would help a mountain fort stay ready."
                 )
 
-                Button(hintVisible ? "Hide clue" : "Need a clue?") {
-                    hintVisible.toggle()
-                    LessonFeedback.fire(.reveal)
-                }
-                .buttonStyle(.gbSecondary)
-
-                if hintVisible {
-                    GuidanceCard(
-                        title: "Story clue",
-                        message: curatedHint,
-                        systemImage: "lightbulb"
-                    )
-                }
-
-                if recapVisible, hasAnsweredCorrectly {
-                    GuidanceCard(
-                        title: "You remembered it",
-                        message: sceneRecap,
-                        systemImage: "text.book.closed"
-                    )
+                ForEach(LessonPlanStep.starterSet) { step in
+                    Button {
+                        if chosenPlanSteps.contains(step.id) {
+                            chosenPlanSteps.remove(step.id)
+                        } else {
+                            chosenPlanSteps.insert(step.id)
+                        }
+                        LessonFeedback.fire(.selection)
+                    } label: {
+                        HStack(spacing: GBSpacing.small) {
+                            Image(systemName: chosenPlanSteps.contains(step.id) ? "checkmark.circle.fill" : step.symbol)
+                                .foregroundStyle(chosenPlanSteps.contains(step.id) ? GBColor.Accent.success : GBColor.Accent.story)
+                                .font(.title3)
+                            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                                Text(step.title)
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(GBColor.Content.primary)
+                                Text(step.detail)
+                                    .font(.caption)
+                                    .foregroundStyle(GBColor.Content.secondary)
+                            }
+                            Spacer()
+                        }
+                        .padding(GBSpacing.small)
+                        .background(GBColor.Background.elevated, in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
                 }
             }
         }
@@ -448,20 +430,21 @@ private struct GuidanceCard: View {
     let systemImage: String
 
     var body: some View {
-        GBSurface(style: .plain, padding: GBSpacing.small) {
-            HStack(alignment: .top, spacing: GBSpacing.small) {
-                Image(systemName: systemImage)
-                    .foregroundStyle(GBColor.Accent.story)
-                VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
-                    Text(title)
-                        .font(.subheadline.weight(.bold))
-                    Text(message)
-                        .font(.subheadline)
-                        .foregroundStyle(GBColor.Content.secondary)
-                }
-                Spacer()
+        HStack(alignment: .top, spacing: GBSpacing.small) {
+            Image(systemName: systemImage)
+                .foregroundStyle(GBColor.Accent.story)
+            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(GBColor.Content.primary)
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(GBColor.Content.secondary)
             }
+            Spacer()
         }
+        .padding(GBSpacing.small)
+        .background(GBColor.Accent.story.opacity(0.10), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
     }
 }
 
@@ -477,13 +460,13 @@ private struct RecallPanel: View {
         GBSurface(style: .plain) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 GBSectionHeader(
-                    eyebrow: "Chronicle Gate",
-                    title: "One quick recall before the reward",
-                    subtitle: "Choose the place that matches the key fact from this scene."
+                    eyebrow: "Recall card",
+                    title: "Say it from memory",
+                    subtitle: "Pick the answer that matches the story hook you just learned."
                 )
 
                 Text(question.question)
-                    .gbBody()
+                    .font(.body.weight(.medium))
                     .foregroundStyle(GBColor.Content.primary)
 
                 ForEach(choices) { choice in
@@ -506,127 +489,55 @@ private struct RecallPanel: View {
                             Spacer()
                         }
                         .padding(GBSpacing.small)
-                        .background(
-                            isSelected ? GBColor.Accent.story.opacity(0.10) : GBColor.Background.elevated,
-                            in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous)
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                Button(completed ? "Answer checked" : "Collect my answer") {
-                    onSubmit()
-                }
-                .buttonStyle(.gbPrimary(.chronicle))
-                .disabled(selectedChoiceID == nil || completed)
-
-                if let feedbackText {
-                    GBSurface(style: .elevated, padding: GBSpacing.small) {
-                        Text(feedbackText)
-                            .font(.subheadline)
-                            .foregroundStyle(completed ? GBColor.Accent.success : GBColor.Content.secondary)
-                    }
-                }
-            }
-        }
-    }
-}
-
-private struct CompletedSceneActions: View {
-    let scene: StoryScene
-    let places: [Place]
-    let rewards: [ChronicleReward]
-    let recapVisible: Bool
-    let sceneRecap: String
-    @Binding var bonusPlanningVisible: Bool
-    let showsPlanningChallenge: Bool
-    let hasPlanningUpgrade: Bool
-
-    var body: some View {
-        GBSurface(style: .accented(.chronicle)) {
-            VStack(alignment: .leading, spacing: GBSpacing.small) {
-                GBSectionHeader(
-                    eyebrow: "Complete",
-                    title: "The scene is ready to keep",
-                    subtitle: "Open the Royal Chronicle reward or revisit the fort trail while the memory is fresh.",
-                    tone: .inverse,
-                    trailing: AnyView(GBBadge(title: "Reward ready", symbol: GBIcon.chronicle, emphasis: .chronicle))
-                )
-
-                if recapVisible {
-                    Text(sceneRecap)
-                        .font(.subheadline)
-                        .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
-                }
-
-                NavigationLink {
-                    ChronicleView(rewards: rewards, highlightRewardID: scene.rewardID)
-                } label: {
-                    Label("Open your Royal Chronicle reward", systemImage: GBIcon.chronicle)
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.gbSecondary)
-
-                NavigationLink {
-                    PlacesHubView(places: places)
-                } label: {
-                    Label("Review the fort trail", systemImage: GBIcon.place)
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.gbSecondary)
-
-                if showsPlanningChallenge {
-                    Button(hasPlanningUpgrade ? "Bonus planning challenge complete" : (bonusPlanningVisible ? "Hide bonus planning challenge" : "Try the bonus planning challenge")) {
-                        bonusPlanningVisible.toggle()
-                        LessonFeedback.fire(.selection)
-                    }
-                    .buttonStyle(.gbSecondary)
-                    .disabled(hasPlanningUpgrade)
-                }
-            }
-        }
-    }
-}
-
-private struct BonusPlanningCard: View {
-    @Binding var chosenPlanSteps: Set<String>
-
-    var body: some View {
-        GBSurface(style: .plain) {
-            VStack(alignment: .leading, spacing: GBSpacing.small) {
-                GBSectionHeader(
-                    eyebrow: "Bonus Challenge",
-                    title: "Choose smart fort planning steps",
-                    subtitle: "Pick any two choices that would help a mountain base stay ready."
-                )
-
-                ForEach(LessonPlanStep.starterSet) { step in
-                    Button {
-                        if chosenPlanSteps.contains(step.id) {
-                            chosenPlanSteps.remove(step.id)
-                        } else {
-                            chosenPlanSteps.insert(step.id)
-                        }
-                        LessonFeedback.fire(.selection)
-                    } label: {
-                        HStack(spacing: GBSpacing.small) {
-                            Image(systemName: chosenPlanSteps.contains(step.id) ? GBIcon.success : step.symbol)
-                                .foregroundStyle(chosenPlanSteps.contains(step.id) ? GBColor.Accent.success : GBColor.Accent.place)
-                            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
-                                Text(step.title)
-                                    .font(.subheadline.weight(.semibold))
-                                    .foregroundStyle(GBColor.Content.primary)
-                                Text(step.detail)
-                                    .font(.caption)
-                                    .foregroundStyle(GBColor.Content.secondary)
-                            }
-                            Spacer()
-                        }
-                        .padding(GBSpacing.small)
                         .background(GBColor.Background.elevated, in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
                     }
                     .buttonStyle(.plain)
                 }
+
+                Button(completed ? "Answer locked in" : "Check my answer") {
+                    onSubmit()
+                }
+                .buttonStyle(.gbPrimary(.story))
+                .disabled(selectedChoiceID == nil || completed)
+
+                if let feedbackText {
+                    Text(feedbackText)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(completed ? GBColor.Accent.success : GBColor.Content.primary)
+                        .padding(GBSpacing.small)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background((completed ? GBColor.Accent.success : GBColor.Accent.story).opacity(0.12), in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
+                }
+            }
+        }
+    }
+}
+
+private struct RewardTransitionCard: View {
+    let reward: ChronicleReward
+    let scene: StoryScene
+
+    var body: some View {
+        GBSurface(style: .accented(.chronicle)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack {
+                    GBBadge(title: "Reward earned", symbol: GBIcon.success, emphasis: .chronicle)
+                    Spacer()
+                    Text("Royal Chronicle")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(GBColor.Content.inverse.opacity(0.84))
+                }
+
+                Text(reward.title)
+                    .font(.system(.title3, design: .rounded, weight: .bold))
+                    .foregroundStyle(GBColor.Content.inverse)
+                Text(reward.meaning)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(GBColor.Content.inverse.opacity(0.92))
+
+                Label("You remembered \(scene.timelineMarker.lowercased())", systemImage: GBIcon.chronicle)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(GBColor.Content.inverse)
             }
         }
     }

--- a/GreatsOfBharatha/Shared/Models/SampleContent.swift
+++ b/GreatsOfBharatha/Shared/Models/SampleContent.swift
@@ -1,488 +1,174 @@
 import Foundation
 
 enum SampleContent {
-    private enum IDs {
-        static let heroArc = "hero-shivaji"
-
-        static let scene1 = "scene-1-shivneri"
-        static let scene2 = "scene-2-torna-rajgad"
-        static let scene3 = "scene-3-rajgad-planning"
-        static let scene4 = "scene-4-pratapgad"
-        static let scene5 = "scene-5-comeback"
-        static let scene6 = "scene-6-raigad"
-
-        static let placeShivneri = "place-shivneri"
-        static let placeTorna = "place-torna"
-        static let placeRajgad = "place-rajgad"
-        static let placePratapgad = "place-pratapgad"
-        static let placeRaigad = "place-raigad"
-        static let placePurandar = "place-purandar"
-        static let placeSinhagad = "place-sinhagad"
-
-        static let eventBirth = "event-birth-fort"
-        static let eventFirstFort = "event-first-fort"
-        static let eventEarlyCapital = "event-early-capital"
-        static let eventTurningPoint = "event-turning-point"
-        static let eventComeback = "event-comeback"
-        static let eventCoronation = "event-coronation"
-
-        static let chronicleBirth = "chronicle-birth-fort"
-        static let chronicleFirstFort = "chronicle-first-fort"
-        static let chronicleStrategy = "chronicle-mountain-strategy"
-        static let chronicleTurningPoint = "chronicle-turning-point"
-        static let chronicleComeback = "chronicle-comeback"
-        static let chronicleCoronation = "chronicle-coronation"
-    }
-
-    static let shivajiHeroArc = HeroArc(
-        id: IDs.heroArc,
-        hero: Hero(
-            id: "shivaji-maharaj",
-            name: "Shivaji Maharaj",
-            subtitle: "Build Swarajya through remembered places, events, and meaning",
-            culturalFramingNotes: "Use respectful, child-safe framing grounded in curated canon.",
-            ageBandCopyVariants: [
-                .assist: "Hear the story, remember the fort, and collect one keepsake at a time.",
-                .standard: "Remember the place, the turning point, and why it mattered."
-            ]
-        ),
-        title: "Shivaji Arc",
-        scenes: [scene1, scene2, scene3, scene4, scene5, scene6],
-        chronicleEntries: [birthFortEntry, firstFortEntry, mountainStrategyEntry, turningPointEntry, comebackEntry, coronationEntry],
-        locationNodes: [shivneri, torna, rajgad, pratapgad, raigad, purandar, sinhagad],
-        timelineEvents: [timelineBirth, timelineTorna, timelineRajgad, timelinePratapgad, timelineComeback, timelineCoronation],
-        reviewBlueprints: ReviewSchedule.defaultBlueprints(for: [
-            IDs.scene1,
-            IDs.scene2,
-            IDs.scene3,
-            IDs.scene4,
-            IDs.scene5,
-            IDs.scene6
-        ])
+    static let shivajiVerticalSlice = AppContent(
+        arcTitle: "Shivaji Arc",
+        scenes: [scene1, scene2],
+        places: [shivneri, torna, rajgad, pratapgad, raigad, purandar],
+        rewards: [birthFortCard, firstBigFortCard, mountainSealFragment, planningBadge]
     )
 
-    static let shivajiVerticalSlice = AppContent(heroArc: shivajiHeroArc)
-
-    static let scene1 = makeScene(
-        id: IDs.scene1,
+    static let scene1 = StoryScene(
+        id: "scene-1-shivneri",
         number: 1,
         title: "Shivneri, where Shivaji Maharaj's story begins",
-        objective: "Meet Shivaji Maharaj as a child and tie the journey to one memorable birthplace.",
+        narrativeObjective: "Meet young Shivaji Maharaj at Shivneri and see how Jijabai helped shape his courage and care.",
         keyFact: "Shivaji Maharaj was born at Shivneri Fort, and Jijabai shaped his early values.",
-        meaning: "The journey begins with place, family guidance, and a clear memory hook: Birth Fort.",
-        summary: "At Shivneri Fort, young Shivaji began his journey. Jijabai helped him grow brave, caring, and ready to lead.",
+        childSafeSummary: "Inside Shivneri Fort, young Shivaji begins his journey. Jijabai helps him grow brave, thoughtful, and ready to protect people.",
         mapAnchors: ["Shivneri Fort", "Junnar", "Hill-fort country north of Pune"],
-        timelineEventID: IDs.eventBirth,
-        memoryHook: "Birth Fort",
-        answer: "Shivneri Fort",
-        chronicleEntryID: IDs.chronicleBirth
+        timelineMarker: "Born at Shivneri",
+        interactionSteps: [
+            "Open the story hook.",
+            "Notice why Shivneri matters.",
+            "Keep the birth-fort anchor in mind.",
+            "Answer the recall card to earn the Chronicle keepsake."
+        ],
+        recallPrompt: RecallPrompt(
+            question: "Which fort is Shivaji Maharaj's birth place?",
+            answer: "Shivneri Fort",
+            supportText: "Shivneri is the Birth Fort where the journey begins."
+        ),
+        rewardID: "reward-birth-fort-card"
     )
 
-    static let scene2 = makeScene(
-        id: IDs.scene2,
+    static let scene2 = StoryScene(
+        id: "scene-2-torna-rajgad",
         number: 2,
         title: "Torna and Rajgad, the first steps of Swarajya",
-        objective: "Show how early fort victories turned into careful planning and state-building.",
+        narrativeObjective: "See how an early fort win at Torna grew into careful planning and a strong base at Rajgad.",
         keyFact: "Torna was an early breakthrough, and Rajgad became an early capital and planning base.",
-        meaning: "A remembered breakthrough helps the child connect courage with strategic place-making.",
-        summary: "Torna shows the first big mountain breakthrough, and Rajgad turns the journey into careful planning.",
+        childSafeSummary: "The journey climbs from Torna to Rajgad. One fort shows the breakthrough, and the next becomes the place for planning.",
         mapAnchors: ["Torna", "Rajgad", "Mountain routes of western Maharashtra"],
-        timelineEventID: IDs.eventFirstFort,
-        memoryHook: "Early Capital",
-        answer: "Rajgad",
-        chronicleEntryID: IDs.chronicleFirstFort
+        timelineMarker: "Early forts",
+        interactionSteps: [
+            "Follow the story from Torna to Rajgad.",
+            "Notice which fort comes first and which fort becomes the planning base.",
+            "Choose smart fort moves.",
+            "Answer the recall card before collecting the reward."
+        ],
+        recallPrompt: RecallPrompt(
+            question: "Which fort became an early capital?",
+            answer: "Rajgad",
+            supportText: "Rajgad is the early capital. Torna is the breakthrough fort that comes first."
+        ),
+        rewardID: "reward-first-big-fort-card"
     )
 
-    static let scene3 = makeScene(
-        id: IDs.scene3,
-        number: 3,
-        title: "Rajgad, the planning capital",
-        objective: "Link planning, state-building, and place memory through Rajgad.",
-        keyFact: "Rajgad became an early capital and planning base for growing Swarajya.",
-        meaning: "Children should remember that leadership also means careful planning from the right place.",
-        summary: "Rajgad becomes the fort for planning, storing strength, and thinking ahead.",
-        mapAnchors: ["Rajgad", "Near Torna", "Mountain planning base"],
-        timelineEventID: IDs.eventEarlyCapital,
-        memoryHook: "Early Capital",
-        answer: "Rajgad",
-        chronicleEntryID: IDs.chronicleStrategy
-    )
-
-    static let scene4 = makeScene(
-        id: IDs.scene4,
-        number: 4,
-        title: "Pratapgad, the turning point",
-        objective: "Teach a decisive turning point through terrain, strategy, and confidence.",
-        keyFact: "Pratapgad became a major turning point that showed how terrain and preparation matter.",
-        meaning: "The child should remember Pratapgad as the turning-point fort, not just a dramatic battle name.",
-        summary: "At Pratapgad, strategy and terrain change the story. A turning point becomes unforgettable.",
-        mapAnchors: ["Pratapgad", "Near Mahabaleshwar", "Hill country"],
-        timelineEventID: IDs.eventTurningPoint,
-        memoryHook: "Turning Point",
-        answer: "Pratapgad",
-        chronicleEntryID: IDs.chronicleTurningPoint
-    )
-
-    static let scene5 = makeScene(
-        id: IDs.scene5,
-        number: 5,
-        title: "Purandar to Sinhagad, pressure and comeback",
-        objective: "Hold two related places in memory while teaching pressure, loss, and return.",
-        keyFact: "Purandar marks pressure and compromise, while Sinhagad helps children remember comeback and courage.",
-        meaning: "History includes setbacks, and remembered places help children see how the story recovers.",
-        summary: "The journey faces pressure, then regains confidence. The child learns that courage includes comeback.",
-        mapAnchors: ["Purandar", "Sinhagad", "Forts around Pune"],
-        timelineEventID: IDs.eventComeback,
-        memoryHook: "Pressure to Comeback",
-        answer: "Sinhagad",
-        chronicleEntryID: IDs.chronicleComeback
-    )
-
-    static let scene6 = makeScene(
-        id: IDs.scene6,
-        number: 6,
-        title: "Raigad, the coronation capital",
-        objective: "Close the arc with a place, title, and sequence moment that feels ceremonial.",
-        keyFact: "Raigad is remembered as the coronation capital where Shivaji Maharaj became Chhatrapati.",
-        meaning: "The final scene should tie sovereignty, sequence, and Chronicle completion into one earned moment.",
-        summary: "Raigad brings the story to its sovereign climax. The child remembers the coronation capital with pride.",
-        mapAnchors: ["Raigad", "Konkan edge of the Sahyadris", "Coronation capital"],
-        timelineEventID: IDs.eventCoronation,
-        memoryHook: "Coronation Capital",
-        answer: "Raigad",
-        chronicleEntryID: IDs.chronicleCoronation
-    )
-
-    static let shivneri = makeLocation(
-        id: IDs.placeShivneri,
+    static let shivneri = Place(
+        id: "place-shivneri",
         name: "Shivneri",
-        hook: "Birth Fort",
-        event: "Birth of Shivaji Maharaj",
-        region: "Near Junnar, north of Pune",
+        memoryHook: "Birth Fort",
+        primaryEvent: "Birth of Shivaji Maharaj",
+        whyItMatters: "This is where the journey begins.",
+        regionLabel: "Near Junnar, north of Pune",
         latitude: 19.1990,
         longitude: 73.8595,
-        linkedSceneIDs: [IDs.scene1],
-        linkedTimelineEventIDs: [IDs.eventBirth],
-        isCore: true
+        progress: .readyToLearn,
+        isCoreReleasePlace: true
     )
 
-    static let torna = makeLocation(
-        id: IDs.placeTorna,
+    static let torna = Place(
+        id: "place-torna",
         name: "Torna",
-        hook: "First Big Fort",
-        event: "Early breakthrough in the start of Swarajya",
-        region: "Sahyadri range, southwest of Pune",
+        memoryHook: "First Big Fort",
+        primaryEvent: "Early breakthrough in the start of Swarajya",
+        whyItMatters: "It marks one of the first major fort successes.",
+        regionLabel: "Sahyadri range, southwest of Pune",
         latitude: 18.2761,
         longitude: 73.6227,
-        linkedSceneIDs: [IDs.scene2],
-        linkedTimelineEventIDs: [IDs.eventFirstFort],
-        isCore: true
+        progress: .readyToLearn,
+        isCoreReleasePlace: true
     )
 
-    static let rajgad = makeLocation(
-        id: IDs.placeRajgad,
+    static let rajgad = Place(
+        id: "place-rajgad",
         name: "Rajgad",
-        hook: "Early Capital",
-        event: "Early power center and planning base",
-        region: "Sahyadri range, near Torna",
+        memoryHook: "Early Capital",
+        primaryEvent: "Early power center and planning base",
+        whyItMatters: "It helps the journey grow stronger.",
+        regionLabel: "Sahyadri range, near Torna",
         latitude: 18.2460,
         longitude: 73.6822,
-        linkedSceneIDs: [IDs.scene2, IDs.scene3],
-        linkedTimelineEventIDs: [IDs.eventFirstFort, IDs.eventEarlyCapital],
-        isCore: true
+        progress: .readyToLearn,
+        isCoreReleasePlace: true
     )
 
-    static let pratapgad = makeLocation(
-        id: IDs.placePratapgad,
+    static let pratapgad = Place(
+        id: "place-pratapgad",
         name: "Pratapgad",
-        hook: "Turning Point",
-        event: "Major turning point in Shivaji Maharaj's rise",
-        region: "Hill country near Mahabaleshwar",
+        memoryHook: "Turning Point",
+        primaryEvent: "Major turning point in Shivaji Maharaj's rise",
+        whyItMatters: "It teaches strategy and terrain.",
+        regionLabel: "Hill country near Mahabaleshwar",
         latitude: 17.9362,
         longitude: 73.5776,
-        linkedSceneIDs: [IDs.scene4],
-        linkedTimelineEventIDs: [IDs.eventTurningPoint],
-        isCore: true
+        progress: .locked,
+        isCoreReleasePlace: true
     )
 
-    static let raigad = makeLocation(
-        id: IDs.placeRaigad,
+    static let raigad = Place(
+        id: "place-raigad",
         name: "Raigad",
-        hook: "Coronation Capital",
-        event: "Coronation as Chhatrapati",
-        region: "Konkan edge of the Sahyadris",
+        memoryHook: "Coronation Capital",
+        primaryEvent: "Coronation as Chhatrapati",
+        whyItMatters: "It is the sovereign climax of the arc.",
+        regionLabel: "Konkan edge of the Sahyadris",
         latitude: 18.2335,
         longitude: 73.4406,
-        linkedSceneIDs: [IDs.scene6],
-        linkedTimelineEventIDs: [IDs.eventCoronation],
-        isCore: true
+        progress: .locked,
+        isCoreReleasePlace: true
     )
 
-    static let purandar = makeLocation(
-        id: IDs.placePurandar,
+    static let purandar = Place(
+        id: "place-purandar",
         name: "Purandar",
-        hook: "Pressure Fort",
-        event: "Context for later pressure and compromise",
-        region: "Southeast of Pune",
+        memoryHook: "Pressure Fort",
+        primaryEvent: "Context for later pressure and compromise",
+        whyItMatters: "Useful story support, but not required for first-release pinning.",
+        regionLabel: "Southeast of Pune",
         latitude: 18.2808,
         longitude: 73.9736,
-        linkedSceneIDs: [IDs.scene5],
-        linkedTimelineEventIDs: [IDs.eventComeback],
-        isCore: false
+        progress: .locked,
+        isCoreReleasePlace: false
     )
 
-    static let sinhagad = makeLocation(
-        id: IDs.placeSinhagad,
-        name: "Sinhagad",
-        hook: "Comeback Fort",
-        event: "Remembered comeback and courage",
-        region: "Southwest of Pune",
-        latitude: 18.3662,
-        longitude: 73.7559,
-        linkedSceneIDs: [IDs.scene5],
-        linkedTimelineEventIDs: [IDs.eventComeback],
-        isCore: false
-    )
-
-    static let birthFortEntry = makeChronicle(
-        id: IDs.chronicleBirth,
+    static let birthFortCard = ChronicleReward(
+        id: "reward-birth-fort-card",
         title: "Birth Fort",
-        keepsakeTitle: "Journey keepsake",
-        meaning: "The Chronicle keeps Shivneri as the place where Shivaji Maharaj's journey begins.",
-        sceneID: IDs.scene1,
-        placeID: IDs.placeShivneri,
-        timelineEventID: IDs.eventBirth
+        subtitle: "Journey keepsake card",
+        meaning: "You remembered Shivneri Fort as the place where Shivaji Maharaj's journey begins.",
+        unlockedBySceneID: "scene-1-shivneri",
+        mastery: .witnessed,
+        category: .storyCard
     )
 
-    static let firstFortEntry = makeChronicle(
-        id: IDs.chronicleFirstFort,
+    static let firstBigFortCard = ChronicleReward(
+        id: "reward-first-big-fort-card",
         title: "First Big Fort",
-        keepsakeTitle: "Mountain keepsake",
-        meaning: "This keepsake remembers the first fort step and why Rajgad mattered next.",
-        sceneID: IDs.scene2,
-        placeID: IDs.placeRajgad,
-        timelineEventID: IDs.eventFirstFort
+        subtitle: "Journey keepsake card",
+        meaning: "You remembered how the early fort journey climbs from Torna's breakthrough to Rajgad's planning base.",
+        unlockedBySceneID: "scene-2-torna-rajgad",
+        mastery: .witnessed,
+        category: .storyCard
     )
 
-    static let mountainStrategyEntry = makeChronicle(
-        id: IDs.chronicleStrategy,
-        title: "Mountain Strategy",
-        keepsakeTitle: "Planning seal",
-        meaning: "Rajgad becomes a keepsake about planning well, not just winning quickly.",
-        sceneID: IDs.scene3,
-        placeID: IDs.placeRajgad,
-        timelineEventID: IDs.eventEarlyCapital
+    static let mountainSealFragment = ChronicleReward(
+        id: "reward-mountain-seal-fragment",
+        title: "Mountain Seal Fragment",
+        subtitle: "Mountain emblem fragment",
+        meaning: "A mountain emblem fragment for learning the first forts and how they sit in the Sahyadris.",
+        unlockedBySceneID: "scene-2-torna-rajgad",
+        mastery: .understood,
+        category: .emblemFragment
     )
 
-    static let turningPointEntry = makeChronicle(
-        id: IDs.chronicleTurningPoint,
-        title: "Turning Point Seal",
-        keepsakeTitle: "Turning-point keepsake",
-        meaning: "Pratapgad earns a Chronicle seal only after the child remembers why the turning point mattered.",
-        sceneID: IDs.scene4,
-        placeID: IDs.placePratapgad,
-        timelineEventID: IDs.eventTurningPoint
+    static let planningBadge = ChronicleReward(
+        id: "reward-planning-badge",
+        title: "Planning Badge",
+        subtitle: "Planner's badge",
+        meaning: "A keepsake badge for noticing that careful planning helps the Shivaji journey grow strong.",
+        unlockedBySceneID: "scene-2-torna-rajgad",
+        mastery: .observedClosely,
+        category: .leadershipBadge
     )
-
-    static let comebackEntry = makeChronicle(
-        id: IDs.chronicleComeback,
-        title: "Comeback Crest",
-        keepsakeTitle: "Resilience keepsake",
-        meaning: "This keepsake marks the journey through pressure and comeback, not a simple straight climb.",
-        sceneID: IDs.scene5,
-        placeID: IDs.placeSinhagad,
-        timelineEventID: IDs.eventComeback
-    )
-
-    static let coronationEntry = makeChronicle(
-        id: IDs.chronicleCoronation,
-        title: "Coronation Seal",
-        keepsakeTitle: "Hero page reward",
-        meaning: "Raigad becomes the ceremonial final keepsake when the child remembers the coronation capital.",
-        sceneID: IDs.scene6,
-        placeID: IDs.placeRaigad,
-        timelineEventID: IDs.eventCoronation
-    )
-
-    static let timelineBirth = makeTimelineEvent(
-        id: IDs.eventBirth,
-        title: "Birth at Shivneri",
-        order: 0,
-        era: "Beginning",
-        linkedPlaces: [IDs.placeShivneri]
-    )
-
-    static let timelineTorna = makeTimelineEvent(
-        id: IDs.eventFirstFort,
-        title: "Early fort breakthrough at Torna and Rajgad",
-        order: 1,
-        era: "Early rise",
-        linkedPlaces: [IDs.placeTorna, IDs.placeRajgad]
-    )
-
-    static let timelineRajgad = makeTimelineEvent(
-        id: IDs.eventEarlyCapital,
-        title: "Rajgad becomes the planning capital",
-        order: 2,
-        era: "State-building",
-        linkedPlaces: [IDs.placeRajgad]
-    )
-
-    static let timelinePratapgad = makeTimelineEvent(
-        id: IDs.eventTurningPoint,
-        title: "Pratapgad turns the story",
-        order: 3,
-        era: "Turning point",
-        linkedPlaces: [IDs.placePratapgad]
-    )
-
-    static let timelineComeback = makeTimelineEvent(
-        id: IDs.eventComeback,
-        title: "Pressure, recovery, and comeback",
-        order: 4,
-        era: "Comeback",
-        linkedPlaces: [IDs.placePurandar, IDs.placeSinhagad]
-    )
-
-    static let timelineCoronation = makeTimelineEvent(
-        id: IDs.eventCoronation,
-        title: "Coronation at Raigad",
-        order: 5,
-        era: "Coronation",
-        linkedPlaces: [IDs.placeRaigad]
-    )
-
-    private static func makeScene(
-        id: String,
-        number: Int,
-        title: String,
-        objective: String,
-        keyFact: String,
-        meaning: String,
-        summary: String,
-        mapAnchors: [String],
-        timelineEventID: String,
-        memoryHook: String,
-        answer: String,
-        chronicleEntryID: String
-    ) -> SceneCluster {
-        let challenge = RecallChallenge(
-            id: id + "-recall",
-            promptType: number == 6 ? .sequenceSlot : .openPrompt,
-            prompt: number == 6 ? "Which fort is remembered as the coronation capital at the end of the arc?" : "Which place matches this memory hook: \(memoryHook)?",
-            correctAnswers: [answer],
-            hintLadder: [
-                RecallHint(level: 1, title: "Anchor hint", body: "Remember this hook: \(memoryHook)."),
-                RecallHint(level: 2, title: "Story hint", body: meaning),
-                RecallHint(level: 3, title: "Recognition rescue", body: "Look for the fort tied to \(answer).")
-            ],
-            feedback: RecallFeedback(
-                success: "You got it. \(meaning)",
-                recovery: "Good try. \(meaning)"
-            ),
-            masteryContribution: .understood
-        )
-
-        return SceneCluster(
-            id: id,
-            sceneNumber: number,
-            title: title,
-            narrativeObjective: objective,
-            keyFact: keyFact,
-            meaningStatement: meaning,
-            childSafeSummary: summary,
-            mapAnchorIDs: mapAnchors,
-            timelineEventID: timelineEventID,
-            cards: [
-                LearningCard(id: id + "-story", type: .story, title: title, text: summary, narration: summary, imageKey: id, memoryHook: nil, difficultyBand: .standard),
-                LearningCard(id: id + "-meaning", type: .meaning, title: "Why it matters", text: meaning, narration: meaning, imageKey: id + "-meaning", memoryHook: nil, difficultyBand: .standard),
-                LearningCard(id: id + "-anchor", type: .anchor, title: memoryHook, text: keyFact, narration: keyFact, imageKey: id + "-anchor", memoryHook: memoryHook, difficultyBand: .standard),
-                LearningCard(id: id + "-reward", type: .reward, title: "Chronicle reward", text: "Earn the keepsake by remembering the scene.", narration: "Earn the keepsake by remembering the scene.", imageKey: id + "-reward", memoryHook: memoryHook, difficultyBand: .standard)
-            ],
-            recallChallenges: [challenge],
-            chronicleEntryIDs: [chronicleEntryID]
-        )
-    }
-
-    private static func makeLocation(
-        id: String,
-        name: String,
-        hook: String,
-        event: String,
-        region: String,
-        latitude: Double,
-        longitude: Double,
-        linkedSceneIDs: [String],
-        linkedTimelineEventIDs: [String],
-        isCore: Bool
-    ) -> LocationNode {
-        LocationNode(
-            id: id,
-            name: name,
-            canonicalCoordinate: Coordinate(latitude: latitude, longitude: longitude),
-            memoryHook: hook,
-            primaryEvent: event,
-            regionLabel: region,
-            linkedSceneIDs: linkedSceneIDs,
-            linkedTimelineEventIDs: linkedTimelineEventIDs,
-            unlockRule: UnlockRule(requiredMastery: .understood, enhancedMastery: .placed),
-            isCoreReleasePlace: isCore
-        )
-    }
-
-    private static func makeChronicle(
-        id: String,
-        title: String,
-        keepsakeTitle: String,
-        meaning: String,
-        sceneID: String,
-        placeID: String?,
-        timelineEventID: String?
-    ) -> ChronicleEntry {
-        ChronicleEntry(
-            id: id,
-            title: title,
-            keepsakeTitle: keepsakeTitle,
-            meaningStatement: meaning,
-            linkedSceneID: sceneID,
-            linkedPlaceID: placeID,
-            linkedTimelineEventID: timelineEventID,
-            unlockRule: UnlockRule(requiredMastery: .understood, enhancedMastery: .remembered)
-        )
-    }
-
-    private static func makeTimelineEvent(
-        id: String,
-        title: String,
-        order: Int,
-        era: String,
-        linkedPlaces: [String]
-    ) -> TimelineEvent {
-        TimelineEvent(
-            id: id,
-            title: title,
-            orderIndex: order,
-            broadEraLabel: era,
-            yearLabel: nil,
-            linkedPlaceIDs: linkedPlaces,
-            recallPrompt: "Place \(title) in the correct sequence slot.",
-            unlockRule: UnlockRule(requiredMastery: .remembered, enhancedMastery: .placed)
-        )
-    }
-}
-
-private extension ReviewSchedule {
-    static func defaultBlueprints(for subjectIDs: [String]) -> [ReviewSchedule] {
-        subjectIDs.map { subjectID in
-            ReviewSchedule(
-                subjectID: subjectID,
-                subjectType: .scene,
-                nextDueAt: .distantFuture,
-                intervalIndex: 0,
-                stabilityBand: .new,
-                difficultyAdjustment: 0,
-                cadenceDays: [0, 1, 3, 7, 14]
-            )
-        }
-    }
 }

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -6,134 +6,22 @@ final class GreatsOfBharathaTests: XCTestCase {
         let model = AppModel()
         XCTAssertFalse(model.content.scenes.isEmpty)
         XCTAssertEqual(model.content.scenes.first?.title, "Shivneri, where Shivaji Maharaj's story begins")
-        XCTAssertEqual(model.content.activeHeroArc.scenes.count, 6)
+        XCTAssertEqual(model.content.scenes.first?.recallPrompt.answer, "Shivneri Fort")
     }
 
-    func testLessonStoreTracksProgress() {
-        let defaults = makeDefaults(testName: #function)
+    func testLessonStoreTracksProgressAndUnlocksRewards() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
         let store = ShivajiLessonStore(defaults: defaults)
 
         XCTAssertEqual(store.completedScenes, 0)
-        store.markScene("scene-1-shivneri", mastery: .witnessed)
-        XCTAssertEqual(store.completedScenes, 0)
+        XCTAssertEqual(store.nextSceneID, "scene-1-shivneri")
+        XCTAssertFalse(store.isUnlocked(SampleContent.birthFortCard))
 
         store.markScene("scene-1-shivneri", mastery: .understood)
+
         XCTAssertEqual(store.completedScenes, 1)
         XCTAssertEqual(store.nextSceneID, "scene-2-torna-rajgad")
-    }
-
-    func testLessonFlowAdvancesOneStageAtATime() {
-        let initial = SceneLessonFlow(
-            totalStoryCards: 3,
-            currentStoryCardIndex: 0,
-            storyStepComplete: false,
-            totalMapAnchors: 3,
-            revealedMapAnchors: 0,
-            hasAnsweredCorrectly: false
-        )
-        XCTAssertEqual(initial.activeStage, .story)
-        XCTAssertEqual(initial.currentQuestStepID, "story")
-
-        let afterStory = SceneLessonFlow(
-            totalStoryCards: 3,
-            currentStoryCardIndex: 2,
-            storyStepComplete: true,
-            totalMapAnchors: 3,
-            revealedMapAnchors: 1,
-            hasAnsweredCorrectly: false
-        )
-        XCTAssertEqual(afterStory.activeStage, .place)
-        XCTAssertEqual(afterStory.currentQuestStepID, "place")
-
-        let afterPlaces = SceneLessonFlow(
-            totalStoryCards: 3,
-            currentStoryCardIndex: 2,
-            storyStepComplete: true,
-            totalMapAnchors: 3,
-            revealedMapAnchors: 3,
-            hasAnsweredCorrectly: false
-        )
-        XCTAssertEqual(afterPlaces.activeStage, .chronicle)
-        XCTAssertEqual(afterPlaces.currentQuestStepID, "chronicle")
-
-        let completed = SceneLessonFlow(
-            totalStoryCards: 3,
-            currentStoryCardIndex: 2,
-            storyStepComplete: true,
-            totalMapAnchors: 3,
-            revealedMapAnchors: 3,
-            hasAnsweredCorrectly: true
-        )
-        XCTAssertEqual(completed.activeStage, .complete)
-        XCTAssertEqual(completed.currentQuestStepID, "chronicle")
-        XCTAssertEqual(completed.progressValue, 1.0)
-    }
-
-    func testLessonStoreUnlocksOnlyNextSceneAfterUnderstanding() {
-        let defaults = makeDefaults(testName: #function)
-        let store = ShivajiLessonStore(defaults: defaults)
-
-        let firstScene = SampleContent.shivajiVerticalSlice.scenes[0]
-        let secondScene = SampleContent.shivajiVerticalSlice.scenes[1]
-
-        XCTAssertTrue(store.isSceneUnlocked(firstScene))
-        XCTAssertFalse(store.isSceneUnlocked(secondScene))
-
-        store.markScene(firstScene.id, mastery: .witnessed)
-        XCTAssertFalse(store.isSceneUnlocked(secondScene))
-
-        store.markScene(firstScene.id, mastery: .understood)
-        XCTAssertTrue(store.isSceneUnlocked(secondScene))
-    }
-
-    func testChronicleUnlockRespectsEvidenceBasedMastery() {
-        let defaults = makeDefaults(testName: #function)
-        let store = ShivajiLessonStore(defaults: defaults)
-        let reward = SampleContent.shivajiVerticalSlice.rewards.first { $0.id == "chronicle-birth-fort" }
-
-        XCTAssertNotNil(reward)
-        XCTAssertFalse(store.isUnlocked(reward!))
-
-        store.markScene("scene-1-shivneri", mastery: .witnessed)
-        XCTAssertFalse(store.isUnlocked(reward!))
-
-        store.markScene("scene-1-shivneri", mastery: .understood)
-        XCTAssertTrue(store.isUnlocked(reward!))
-    }
-
-    func testReviewScheduleAdvancesAfterSuccessfulRecall() {
-        let defaults = makeDefaults(testName: #function)
-        let store = ShivajiLessonStore(defaults: defaults)
-
-        store.markScene("scene-1-shivneri", mastery: .understood)
-
-        let record = store.masteryRecord(for: "scene-1-shivneri")
-        let schedule = store.reviewSchedulesBySubject["scene-1-shivneri"]
-
-        XCTAssertEqual(record?.state, .understood)
-        XCTAssertEqual(record?.successfulReviewCount, 1)
-        XCTAssertEqual(schedule?.intervalIndex, 1)
-        XCTAssertEqual(schedule?.stabilityBand, .warming)
-    }
-
-    func testLocationAndTimelineStateProgressionUsesNewContracts() {
-        let defaults = makeDefaults(testName: #function)
-        let store = ShivajiLessonStore(defaults: defaults)
-        let firstPlace = SampleContent.shivajiHeroArc.locationNodes.first { $0.id == "place-shivneri" }
-        let firstEvent = SampleContent.timelineBirth
-
-        XCTAssertEqual(store.locationUnlockState(for: firstPlace!), .learnable)
-        XCTAssertEqual(store.timelineUnlockState(for: firstEvent), .hidden)
-
-        store.markScene("scene-1-shivneri", mastery: .remembered)
-
-        XCTAssertEqual(store.locationUnlockState(for: firstPlace!), .remembered)
-        XCTAssertEqual(store.timelineUnlockState(for: firstEvent), .remembered)
-    }
-
-    private func makeDefaults(testName: String) -> UserDefaults {
-        let defaults = UserDefaults(suiteName: testName)!
-        defaults.removePersistentDomain(forName: testName)
-        return defaults
+        XCTAssertTrue(store.isUnlocked(SampleContent.birthFortCard))
     }
 }


### PR DESCRIPTION
## Summary
- refocus Learn home around one clear next action and faster-scanning scene cards
- reshape scene flow into hook, meaning, and anchor cards with a child-facing recall/reward transition
- refresh Chronicle reward presentation and sample content copy to match the retrieval-first MVP tone

## Testing
- not run (Linux container lacks Swift/Xcode toolchain)
