### PR TITLE
fix: restore LessonHomeView CI after mastery enum expansion

### DIFF
--- a/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
+++ b/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
@@ -194,6 +194,12 @@ private struct SceneJourneyCard: View {
             return "star.fill"
         case .observedClosely:
             return "sparkles"
+        case .remembered:
+            return GBIcon.story
+        case .placed:
+            return GBIcon.place
+        case .chronicled:
+            return GBIcon.chronicle
         }
     }
 
@@ -201,10 +207,12 @@ private struct SceneJourneyCard: View {
         switch mastery {
         case .witnessed:
             return .neutral
-        case .understood:
+        case .understood, .remembered:
             return .story
-        case .observedClosely:
+        case .observedClosely, .chronicled:
             return .chronicle
+        case .placed:
+            return .place
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle the new `MasteryState` cases in `LessonHomeView` so the scene card badge helpers are exhaustive again
- map the added states to the existing story, place, and chronicle badge styling to preserve the PR #66 child-facing card flow
- keep the fix narrowly scoped to the post-merge CI regression

## Validation
- `git diff --check`
- `grep -RIn "switch mastery" GreatsOfBharatha --include='*.swift'`