### PR TITLE
fix: restore retrieval-first chronicle reward unlocks

### DIFF
--- a/GreatsOfBharatha/Shared/Models/SampleContent.swift
+++ b/GreatsOfBharatha/Shared/Models/SampleContent.swift
@@ -138,7 +138,7 @@ enum SampleContent {
         subtitle: "Journey keepsake card",
         meaning: "You remembered Shivneri Fort as the place where Shivaji Maharaj's journey begins.",
         unlockedBySceneID: "scene-1-shivneri",
-        mastery: .witnessed,
+        mastery: .understood,
         category: .storyCard
     )
 
@@ -148,7 +148,7 @@ enum SampleContent {
         subtitle: "Journey keepsake card",
         meaning: "You remembered how the early fort journey climbs from Torna's breakthrough to Rajgad's planning base.",
         unlockedBySceneID: "scene-2-torna-rajgad",
-        mastery: .witnessed,
+        mastery: .understood,
         category: .storyCard
     )
 


### PR DESCRIPTION
## Summary
- restore story-card chronicle rewards to unlock at `Understood` rather than `Witnessed`
- keep the current lesson store behavior, which already matches the intended recall-first flow
- align sample content with the existing alpha docs and failing unit test

## Validation
- `git diff --check`
- Unable to run Apple/Xcode tests in this Linux environment (`xcodebuild` is unavailable here)