### PR TITLE
test: fix chronicle unlock assertion for Shivaji content

### DIFF
--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -58,13 +58,18 @@ final class GreatsOfBharathaTests: XCTestCase {
 
         XCTAssertEqual(store.completedScenes, 0)
         XCTAssertEqual(store.nextSceneID, "scene-1-shivneri")
-        XCTAssertFalse(store.isUnlocked(SampleContent.birthFortCard))
+        XCTAssertTrue(store.isUnlocked(SampleContent.birthFortCard))
+
+        let guidanceEntry = SampleContent.shivajiHeroArc.chronicleEntry(withID: "reward-jijabai-guidance-badge")
+        XCTAssertNotNil(guidanceEntry)
+        XCTAssertEqual(store.chronicleUnlockState(for: guidanceEntry!), .silhouette)
 
         store.markScene("scene-1-shivneri", mastery: .understood)
 
         XCTAssertEqual(store.completedScenes, 1)
         XCTAssertEqual(store.nextSceneID, "scene-2-torna-rajgad")
         XCTAssertTrue(store.isUnlocked(SampleContent.birthFortCard))
+        XCTAssertEqual(store.chronicleUnlockState(for: guidanceEntry!), .unlocked)
     }
 
     func testRecallEngineRevealsHintLadderBeforeRecognitionRescue() {


### PR DESCRIPTION
## Summary
- fix the post-merge failing unit test introduced after #71 by aligning reward-unlock expectations with the new six-scene content contract
- assert that the birth-fort keepsake is visible at witnessed mastery while the higher-threshold guidance badge stays locked until scene mastery advances

## Why
The six-scene content pack changed the first Chronicle unlock rule so `reward-birth-fort-card` becomes visible at witnessed mastery. The old test still expected it to be locked before any mastery update, which made mainline CI fail after merge.

## Validation
- `git diff --check`
- local `swift` / `xcodebuild` unavailable in this environment
