### PR TITLE
feat: stage Chronicle rewards before unlock

### DIFF
--- a/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
+++ b/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
@@ -7,17 +7,28 @@ struct ChronicleView: View {
 
     @State private var celebratedRewardIDs: Set<String> = []
 
-    private var unlockedRewards: [ChronicleReward] {
-        appModel.lessonStore.unlockedRewards(from: rewards)
+    private var previewedRewards: [ChronicleReward] {
+        rewards.filter { appModel.lessonStore.isPreviewed($0) && !appModel.lessonStore.isUnlocked($0) }
+    }
+
+    private var earnedRewards: [ChronicleReward] {
+        rewards.filter { reward in
+            guard appModel.lessonStore.isUnlocked(reward) else { return false }
+            return !isEnriched(reward)
+        }
+    }
+
+    private var deepenedRewards: [ChronicleReward] {
+        rewards.filter(isEnriched)
+    }
+
+    private var hiddenRewards: [ChronicleReward] {
+        rewards.filter { !appModel.lessonStore.isPreviewed($0) && !appModel.lessonStore.isUnlocked($0) }
     }
 
     private var highlightedReward: ChronicleReward? {
         guard let highlightRewardID else { return nil }
-        return unlockedRewards.first(where: { $0.id == highlightRewardID })
-    }
-
-    private var lockedRewards: [ChronicleReward] {
-        rewards.filter { !appModel.lessonStore.isUnlocked($0) }
+        return rewards.first(where: { $0.id == highlightRewardID && appModel.lessonStore.isUnlocked($0) })
     }
 
     var body: some View {
@@ -29,6 +40,8 @@ struct ChronicleView: View {
                     if let highlightedReward {
                         NewRewardSpotlight(
                             reward: highlightedReward,
+                            state: shelfState(for: highlightedReward),
+                            linkedSceneTitle: linkedSceneTitle(for: highlightedReward),
                             collected: celebratedRewardIDs.contains(highlightedReward.id),
                             onCollect: {
                                 celebratedRewardIDs.insert(highlightedReward.id)
@@ -37,50 +50,44 @@ struct ChronicleView: View {
                         )
                     }
 
-                    VStack(alignment: .leading, spacing: context.cardSpacing) {
-                        GBSectionHeader(
-                            eyebrow: "Collected keepsakes",
-                            title: unlockedRewards.isEmpty ? "Your Chronicle is waiting" : "Your Chronicle shelf",
-                            subtitle: unlockedRewards.isEmpty
-                                ? "Finish a scene and remember its hook to place your first keepsake here."
-                                : "Each keepsake marks a part of Shivaji Maharaj's journey you remembered."
+                    if !previewedRewards.isEmpty {
+                        shelfSection(
+                            eyebrow: "Taking shape",
+                            title: "Previewed silhouettes",
+                            subtitle: "You have seen these moments in the story. Answer the recall card to reveal their meaning.",
+                            rewards: previewedRewards,
+                            state: .previewed
                         )
-
-                        if unlockedRewards.isEmpty {
-                            GBSurface(style: .elevated) {
-                                Text("Play a short scene, answer the recall card, and your first Chronicle page will open here.")
-                                    .gbBody()
-                                    .foregroundStyle(GBColor.Content.secondary)
-                            }
-                        } else {
-                            ForEach(unlockedRewards) { reward in
-                                RewardShelfCard(
-                                    reward: reward,
-                                    unlocked: true,
-                                    isHighlighted: reward.id == highlightRewardID,
-                                    collected: celebratedRewardIDs.contains(reward.id)
-                                )
-                            }
-                        }
                     }
 
-                    if !lockedRewards.isEmpty {
-                        VStack(alignment: .leading, spacing: context.cardSpacing) {
-                            GBSectionHeader(
-                                eyebrow: "Still ahead",
-                                title: "More keepsakes to earn",
-                                subtitle: "New Chronicle cards will appear as you finish more story scenes."
-                            )
+                    if !earnedRewards.isEmpty {
+                        shelfSection(
+                            eyebrow: "Kept from memory",
+                            title: "Earned keepsakes",
+                            subtitle: "These Chronicle cards opened because you remembered the scene, not just because you saw it.",
+                            rewards: earnedRewards,
+                            state: .earned
+                        )
+                    }
 
-                            ForEach(lockedRewards) { reward in
-                                RewardShelfCard(
-                                    reward: reward,
-                                    unlocked: false,
-                                    isHighlighted: false,
-                                    collected: false
-                                )
-                            }
-                        }
+                    if !deepenedRewards.isEmpty {
+                        shelfSection(
+                            eyebrow: "Held more deeply",
+                            title: "Deepened keepsakes",
+                            subtitle: "These entries now carry richer meaning because your mastery went beyond the first unlock.",
+                            rewards: deepenedRewards,
+                            state: .deepened
+                        )
+                    }
+
+                    if !hiddenRewards.isEmpty {
+                        shelfSection(
+                            eyebrow: "Still sealed",
+                            title: "More keepsakes ahead",
+                            subtitle: "These entries will appear after their story moments surface in the lesson journey.",
+                            rewards: hiddenRewards,
+                            state: .hidden
+                        )
                     }
                 }
                 .frame(maxWidth: context.maxContentWidth, alignment: .leading)
@@ -95,21 +102,77 @@ struct ChronicleView: View {
     private var chronicleHero: some View {
         GBHeroCard(
             eyebrow: "Royal Chronicle",
-            title: unlockedRewards.isEmpty ? "Collect your first keepsake" : "Your remembered story shelf",
-            subtitle: unlockedRewards.isEmpty ? "Short scenes unlock lasting rewards." : "\(unlockedRewards.count) keepsakes already glow here.",
-            detail: unlockedRewards.isEmpty
-                ? "Remember one story hook from the lesson path and a Chronicle page opens for you."
-                : "Each new card marks a piece of story, place, or meaning you held onto from memory.",
-            ctaTitle: unlockedRewards.isEmpty ? "Begin a scene" : "Keep collecting",
-            badgeTitle: "\(unlockedRewards.count) unlocked",
+            title: appModel.lessonStore.unlockedChronicleCount == 0 ? "Your keepsakes are taking shape" : "A shelf of remembered meaning",
+            subtitle: "Previewed: \(appModel.lessonStore.previewedChronicleCount)  •  Earned: \(appModel.lessonStore.unlockedChronicleCount)  •  Deepened: \(appModel.lessonStore.enrichedChronicleCount)",
+            detail: appModel.lessonStore.unlockedChronicleCount == 0
+                ? "Story exposure lets a keepsake silhouette appear. Real Chronicle unlocks begin when you answer from memory."
+                : "The Chronicle now tracks what you have merely seen, what you have truly earned, and what you understand more deeply.",
+            ctaTitle: appModel.lessonStore.unlockedChronicleCount == 0 ? "Earn a keepsake" : "Keep deepening",
+            badgeTitle: "\(appModel.lessonStore.unlockedChronicleCount)/\(max(appModel.lessonStore.totalChronicleEntries, 1)) earned",
             emphasis: .chronicle,
-            progress: rewards.isEmpty ? nil : Double(unlockedRewards.count) / Double(rewards.count)
+            progress: appModel.lessonStore.totalChronicleEntries == 0 ? nil : Double(appModel.lessonStore.unlockedChronicleCount) / Double(appModel.lessonStore.totalChronicleEntries)
         )
     }
+
+    @ViewBuilder
+    private func shelfSection(
+        eyebrow: String,
+        title: String,
+        subtitle: String,
+        rewards: [ChronicleReward],
+        state: ChronicleShelfState
+    ) -> some View {
+        VStack(alignment: .leading, spacing: GBSpacing.small) {
+            GBSectionHeader(eyebrow: eyebrow, title: title, subtitle: subtitle)
+
+            ForEach(rewards) { reward in
+                ChronicleShelfCard(
+                    reward: reward,
+                    state: state,
+                    linkedSceneTitle: linkedSceneTitle(for: reward),
+                    isHighlighted: reward.id == highlightRewardID,
+                    collected: celebratedRewardIDs.contains(reward.id)
+                )
+            }
+        }
+    }
+
+    private func linkedSceneTitle(for reward: ChronicleReward) -> String {
+        appModel.content.scenes.first(where: { $0.id == reward.unlockedBySceneID })?.title ?? "A story moment"
+    }
+
+    private func isEnriched(_ reward: ChronicleReward) -> Bool {
+        guard let entry = appModel.content.activeHeroArc.chronicleEntry(withID: reward.id) else {
+            return false
+        }
+        return appModel.lessonStore.chronicleUnlockState(for: entry) == .enriched
+    }
+
+    private func shelfState(for reward: ChronicleReward) -> ChronicleShelfState {
+        if isEnriched(reward) {
+            return .deepened
+        }
+        if appModel.lessonStore.isUnlocked(reward) {
+            return .earned
+        }
+        if appModel.lessonStore.isPreviewed(reward) {
+            return .previewed
+        }
+        return .hidden
+    }
+}
+
+private enum ChronicleShelfState {
+    case hidden
+    case previewed
+    case earned
+    case deepened
 }
 
 private struct NewRewardSpotlight: View {
     let reward: ChronicleReward
+    let state: ChronicleShelfState
+    let linkedSceneTitle: String
     let collected: Bool
     let onCollect: () -> Void
 
@@ -117,7 +180,7 @@ private struct NewRewardSpotlight: View {
         GBSurface(style: .accented(.chronicle)) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 HStack {
-                    GBBadge(title: collected ? "Collected" : "New reward", symbol: collected ? GBIcon.success : GBIcon.reward, emphasis: .chronicle)
+                    GBBadge(title: spotlightTitle, symbol: collected ? GBIcon.success : GBIcon.reward, emphasis: .chronicle)
                     Spacer()
                     Text(reward.category.rawValue)
                         .font(.caption.weight(.bold))
@@ -133,42 +196,65 @@ private struct NewRewardSpotlight: View {
                 Text(reward.meaning)
                     .font(.body)
                     .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
+                Text(reasonText)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(GBColor.Content.inverse.opacity(0.88))
 
                 if collected {
                     Label("Added to your Chronicle shelf", systemImage: GBIcon.success)
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(GBColor.Content.inverse)
                 } else {
-                    Button {
-                        onCollect()
-                    } label: {
-                        Label("Collect keepsake", systemImage: GBIcon.reward)
+                    Button(action: onCollect) {
+                        Label(state == .deepened ? "Collect deepened keepsake" : "Collect keepsake", systemImage: GBIcon.reward)
                     }
                     .buttonStyle(.gbSecondary)
                 }
             }
         }
     }
+
+    private var spotlightTitle: String {
+        switch state {
+        case .deepened:
+            return "Deepened keepsake"
+        case .earned:
+            return "New keepsake"
+        case .previewed:
+            return "Previewed keepsake"
+        case .hidden:
+            return "Chronicle keepsake"
+        }
+    }
+
+    private var reasonText: String {
+        switch state {
+        case .deepened:
+            return "You remembered \(linkedSceneTitle) strongly enough to deepen this keepsake's meaning."
+        case .earned:
+            return "You earned this by recalling \(linkedSceneTitle), not just by opening the scene."
+        case .previewed:
+            return "You have seen the story moment for \(linkedSceneTitle), but this keepsake still needs a recall win."
+        case .hidden:
+            return linkedSceneTitle
+        }
+    }
 }
 
-private struct RewardShelfCard: View {
+private struct ChronicleShelfCard: View {
     let reward: ChronicleReward
-    let unlocked: Bool
+    let state: ChronicleShelfState
+    let linkedSceneTitle: String
     let isHighlighted: Bool
     let collected: Bool
 
     var body: some View {
-        GBSurface(style: unlocked ? .plain : .elevated) {
+        GBSurface(style: surfaceStyle) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 HStack(alignment: .top, spacing: GBSpacing.small) {
                     VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
                         HStack(spacing: GBSpacing.xxSmall) {
-                            GBBadge(
-                                title: unlocked ? reward.mastery.rawValue : "Locked",
-                                symbol: unlocked ? GBIcon.success : GBIcon.locked,
-                                emphasis: unlocked ? .chronicle : .neutral
-                            )
-
+                            GBBadge(title: badgeTitle, symbol: badgeSymbol, emphasis: badgeEmphasis)
                             if isHighlighted {
                                 GBBadge(title: collected ? "Collected" : "New", symbol: collected ? GBIcon.success : GBIcon.reward, emphasis: .story)
                             }
@@ -176,7 +262,7 @@ private struct RewardShelfCard: View {
 
                         Text(reward.title)
                             .gbTitle()
-                            .foregroundStyle(GBColor.Content.primary)
+                            .foregroundStyle(titleColor)
                         Text(reward.subtitle)
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(GBColor.Content.secondary)
@@ -184,19 +270,98 @@ private struct RewardShelfCard: View {
 
                     Spacer()
 
-                    Image(systemName: unlocked ? GBIcon.chronicle : GBIcon.locked)
+                    Image(systemName: badgeSymbol)
                         .font(.title2)
-                        .foregroundStyle(unlocked ? GBColor.Accent.chronicle : GBColor.State.locked)
+                        .foregroundStyle(iconColor)
                 }
 
-                Text(unlocked ? reward.meaning : "Finish the linked story scene and answer its recall card to reveal this keepsake.")
+                Text(primaryText)
                     .gbBody()
                     .foregroundStyle(GBColor.Content.secondary)
 
-                Text(reward.category.rawValue)
+                Text("From: \(linkedSceneTitle)")
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(GBColor.accent(for: unlocked ? .chronicle : .neutral))
+                    .foregroundStyle(GBColor.accent(for: badgeEmphasis))
             }
+            .opacity(state == .hidden ? 0.82 : 1)
+        }
+    }
+
+    private var surfaceStyle: GBSurfaceStyle {
+        switch state {
+        case .hidden, .previewed:
+            return .elevated
+        case .earned:
+            return .plain
+        case .deepened:
+            return .accented(.chronicle)
+        }
+    }
+
+    private var badgeTitle: String {
+        switch state {
+        case .hidden:
+            return "Sealed"
+        case .previewed:
+            return "Previewed"
+        case .earned:
+            return "Earned"
+        case .deepened:
+            return "Deepened"
+        }
+    }
+
+    private var badgeSymbol: String {
+        switch state {
+        case .hidden:
+            return GBIcon.locked
+        case .previewed:
+            return "eye.fill"
+        case .earned:
+            return GBIcon.chronicle
+        case .deepened:
+            return GBIcon.success
+        }
+    }
+
+    private var badgeEmphasis: GBEmphasis {
+        switch state {
+        case .hidden:
+            return .neutral
+        case .previewed:
+            return .story
+        case .earned, .deepened:
+            return .chronicle
+        }
+    }
+
+    private var titleColor: Color {
+        state == .deepened ? GBColor.Content.inverse : GBColor.Content.primary
+    }
+
+    private var iconColor: Color {
+        switch state {
+        case .deepened:
+            return GBColor.Content.inverse
+        case .earned:
+            return GBColor.Accent.chronicle
+        case .previewed:
+            return GBColor.Accent.story
+        case .hidden:
+            return GBColor.State.locked
+        }
+    }
+
+    private var primaryText: String {
+        switch state {
+        case .hidden:
+            return "This keepsake has not appeared in the story yet. Reach its scene to let the silhouette appear."
+        case .previewed:
+            return "You have seen this story moment, but the Chronicle only opens the keepsake after a successful recall."
+        case .earned:
+            return reward.meaning
+        case .deepened:
+            return reward.meaning + " This keepsake now carries a deeper Chronicle glow because your mastery went beyond the first unlock."
         }
     }
 }

--- a/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
+++ b/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
@@ -248,54 +248,59 @@ private struct ChronicleShelfCard: View {
     let isHighlighted: Bool
     let collected: Bool
 
+    @ViewBuilder
     var body: some View {
-        GBSurface(style: surfaceStyle) {
-            VStack(alignment: .leading, spacing: GBSpacing.small) {
-                HStack(alignment: .top, spacing: GBSpacing.small) {
-                    VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
-                        HStack(spacing: GBSpacing.xxSmall) {
-                            GBBadge(title: badgeTitle, symbol: badgeSymbol, emphasis: badgeEmphasis)
-                            if isHighlighted {
-                                GBBadge(title: collected ? "Collected" : "New", symbol: collected ? GBIcon.success : GBIcon.reward, emphasis: .story)
-                            }
-                        }
-
-                        Text(reward.title)
-                            .gbTitle()
-                            .foregroundStyle(titleColor)
-                        Text(reward.subtitle)
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(GBColor.Content.secondary)
-                    }
-
-                    Spacer()
-
-                    Image(systemName: badgeSymbol)
-                        .font(.title2)
-                        .foregroundStyle(iconColor)
-                }
-
-                Text(primaryText)
-                    .gbBody()
-                    .foregroundStyle(GBColor.Content.secondary)
-
-                Text("From: \(linkedSceneTitle)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(GBColor.accent(for: badgeEmphasis))
-            }
-            .opacity(state == .hidden ? 0.82 : 1)
+        switch state {
+        case .hidden, .previewed:
+            cardSurface(style: .elevated)
+        case .earned:
+            cardSurface(style: .plain)
+        case .deepened:
+            cardSurface(style: .accented(.chronicle))
         }
     }
 
-    private var surfaceStyle: GBSurface<EmptyView>.Style {
-        switch state {
-        case .hidden, .previewed:
-            return .elevated
-        case .earned:
-            return .plain
-        case .deepened:
-            return .accented(.chronicle)
+    private func cardSurface(style: GBSurface<AnyView>.Style) -> some View {
+        GBSurface(style: style) {
+            AnyView(cardContent)
         }
+    }
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: GBSpacing.small) {
+            HStack(alignment: .top, spacing: GBSpacing.small) {
+                VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                    HStack(spacing: GBSpacing.xxSmall) {
+                        GBBadge(title: badgeTitle, symbol: badgeSymbol, emphasis: badgeEmphasis)
+                        if isHighlighted {
+                            GBBadge(title: collected ? "Collected" : "New", symbol: collected ? GBIcon.success : GBIcon.reward, emphasis: .story)
+                        }
+                    }
+
+                    Text(reward.title)
+                        .gbTitle()
+                        .foregroundStyle(titleColor)
+                    Text(reward.subtitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(GBColor.Content.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: badgeSymbol)
+                    .font(.title2)
+                    .foregroundStyle(iconColor)
+            }
+
+            Text(primaryText)
+                .gbBody()
+                .foregroundStyle(GBColor.Content.secondary)
+
+            Text("From: \(linkedSceneTitle)")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(GBColor.accent(for: badgeEmphasis))
+        }
+        .opacity(state == .hidden ? 0.82 : 1)
     }
 
     private var badgeTitle: String {

--- a/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
+++ b/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
@@ -287,7 +287,7 @@ private struct ChronicleShelfCard: View {
         }
     }
 
-    private var surfaceStyle: GBSurfaceStyle {
+    private var surfaceStyle: GBSurface<EmptyView>.Style {
         switch state {
         case .hidden, .previewed:
             return .elevated

--- a/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
+++ b/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
@@ -10,8 +10,16 @@ struct LessonHomeView: View {
         return appModel.content.scenes.last
     }
 
+    private var previewedRewardsCount: Int {
+        appModel.lessonStore.previewedChronicleCount
+    }
+
     private var unlockedRewardsCount: Int {
-        appModel.lessonStore.unlockedRewards(from: appModel.content.rewards).count
+        appModel.lessonStore.unlockedChronicleCount
+    }
+
+    private var enrichedRewardsCount: Int {
+        appModel.lessonStore.enrichedChronicleCount
     }
 
     var body: some View {
@@ -37,8 +45,9 @@ struct LessonHomeView: View {
 
                             HStack(spacing: GBSpacing.small) {
                                 JourneyStatPill(title: "Scenes", value: "\(appModel.lessonStore.completedScenes)/\(appModel.lessonStore.totalScenes)", emphasis: .story)
-                                JourneyStatPill(title: "Chronicle", value: "\(unlockedRewardsCount)", emphasis: .chronicle)
-                                JourneyStatPill(title: "Forts", value: "\(appModel.content.corePlaces.count)", emphasis: .place)
+                                JourneyStatPill(title: "Previewed", value: "\(previewedRewardsCount)", emphasis: .story)
+                                JourneyStatPill(title: "Earned", value: "\(unlockedRewardsCount)", emphasis: .chronicle)
+                                JourneyStatPill(title: "Deepened", value: "\(enrichedRewardsCount)", emphasis: .chronicle)
                             }
                         }
                     }
@@ -70,7 +79,9 @@ struct LessonHomeView: View {
                     } label: {
                         ChronicleJourneyCard(
                             headline: appModel.lessonStore.chronicleHeadline,
+                            previewedCount: previewedRewardsCount,
                             unlockedCount: unlockedRewardsCount,
+                            enrichedCount: enrichedRewardsCount,
                             totalCount: appModel.content.rewards.count
                         )
                     }
@@ -91,8 +102,8 @@ struct LessonHomeView: View {
             title: appModel.lessonStore.completedScenes == 0 ? "Begin the hill-fort adventure" : "Your next fort is ready",
             subtitle: nextScene.timelineMarker,
             detail: appModel.lessonStore.completedScenes == 0
-                ? "Start with one vivid scene, hold onto one memory hook, then earn your first Chronicle card."
-                : "Jump back in with one short scene, a place clue trail, and a Chronicle keepsake waiting at the finish.",
+                ? "Start with one vivid scene, let your first keepsake silhouette appear, then earn it with one recall win."
+                : "Jump back in with one short scene, a place clue trail, and Chronicle progress that now tracks previewed, earned, and deepened keepsakes.",
             ctaTitle: appModel.lessonStore.completedScenes == 0 ? "Start Scene \(nextScene.number)" : "Continue journey",
             badgeTitle: appModel.lessonStore.completedScenes == appModel.lessonStore.totalScenes ? "Journey complete" : "Next adventure",
             emphasis: .story,
@@ -219,7 +230,9 @@ private struct SceneJourneyCard: View {
 
 private struct ChronicleJourneyCard: View {
     let headline: String
+    let previewedCount: Int
     let unlockedCount: Int
+    let enrichedCount: Int
     let totalCount: Int
 
     var body: some View {
@@ -238,7 +251,7 @@ private struct ChronicleJourneyCard: View {
                     Text(headline)
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(GBColor.Content.inverse.opacity(0.9))
-                    Text("\(unlockedCount) of \(totalCount) keepsakes ready")
+                    Text("Previewed \(previewedCount)  •  Earned \(unlockedCount) of \(totalCount)  •  Deepened \(enrichedCount)")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(GBColor.Content.inverse.opacity(0.82))
                 }

--- a/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
+++ b/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
@@ -107,15 +107,41 @@ final class ShivajiLessonStore: ObservableObject {
         return (mastery(for: previousScene.id) ?? .witnessed) >= .understood
     }
 
+    func isPreviewed(_ reward: ChronicleReward) -> Bool {
+        guard let entry = content.activeHeroArc.chronicleEntries.first(where: { $0.id == reward.id }) else {
+            return masteryRecord(for: reward.unlockedBySceneID) != nil
+        }
+        return isPreviewedChronicleEntry(entry)
+    }
+
     func isUnlocked(_ reward: ChronicleReward) -> Bool {
         guard let entry = content.activeHeroArc.chronicleEntries.first(where: { $0.id == reward.id }) else {
-            return (mastery(for: reward.unlockedBySceneID) ?? .witnessed) >= reward.mastery
+            guard let mastery = mastery(for: reward.unlockedBySceneID) else { return false }
+            return mastery >= max(reward.mastery, .understood)
         }
-        return chronicleUnlockState(for: entry) != .silhouette
+        switch chronicleUnlockState(for: entry) {
+        case .silhouette:
+            return false
+        case .unlocked, .enriched:
+            return true
+        }
     }
 
     func unlockedRewards(from rewards: [ChronicleReward]) -> [ChronicleReward] {
         rewards.filter { isUnlocked($0) }
+    }
+
+    func previewedRewards(from rewards: [ChronicleReward]) -> [ChronicleReward] {
+        rewards.filter { isPreviewed($0) && !isUnlocked($0) }
+    }
+
+    func enrichedRewards(from rewards: [ChronicleReward]) -> [ChronicleReward] {
+        rewards.filter { reward in
+            guard let entry = content.activeHeroArc.chronicleEntries.first(where: { $0.id == reward.id }) else {
+                return false
+            }
+            return chronicleUnlockState(for: entry) == .enriched
+        }
     }
 
     func progress(for place: Place) -> PlaceProgress {
@@ -136,16 +162,27 @@ final class ShivajiLessonStore: ObservableObject {
     }
 
     func chronicleUnlockState(for entry: ChronicleEntry) -> ChronicleUnlockState {
-        let sceneMastery = mastery(for: entry.linkedSceneID) ?? .witnessed
-        guard sceneMastery >= entry.unlockRule.requiredMastery else {
+        guard let sceneMastery = mastery(for: entry.linkedSceneID) else {
             return .silhouette
         }
 
-        if let enhanced = entry.unlockRule.enhancedMastery, sceneMastery >= enhanced {
+        let unlockMastery = max(entry.unlockRule.requiredMastery, .understood)
+        guard sceneMastery >= unlockMastery else {
+            return .silhouette
+        }
+
+        if let enhanced = entry.unlockRule.enhancedMastery, sceneMastery >= max(enhanced, unlockMastery) {
             return .enriched
         }
 
         return .unlocked
+    }
+
+    func isPreviewedChronicleEntry(_ entry: ChronicleEntry) -> Bool {
+        guard let record = masteryRecord(for: entry.linkedSceneID) else {
+            return false
+        }
+        return record.exposureCount > 0 || !record.evidenceLog.isEmpty
     }
 
     func locationUnlockState(for node: LocationNode) -> LocationUnlockState {
@@ -208,12 +245,39 @@ final class ShivajiLessonStore: ObservableObject {
         return Double(completedScenes) / Double(totalScenes)
     }
 
+
+    var totalChronicleEntries: Int {
+        content.activeHeroArc.chronicleEntries.count
+    }
+
+    var previewedChronicleCount: Int {
+        content.activeHeroArc.chronicleEntries.filter(isPreviewedChronicleEntry).count
+    }
+
+    var unlockedChronicleCount: Int {
+        content.activeHeroArc.chronicleEntries.filter { chronicleUnlockState(for: $0) != .silhouette }.count
+    }
+
+    var enrichedChronicleCount: Int {
+        content.activeHeroArc.chronicleEntries.filter { chronicleUnlockState(for: $0) == .enriched }.count
+    }
+
     var chronicleHeadline: String {
-        switch completedScenes {
-        case 0:
+        let previewedCount = previewedChronicleCount
+        let unlockedCount = unlockedChronicleCount
+        let enrichedCount = enrichedChronicleCount
+
+        switch (previewedCount, unlockedCount, enrichedCount) {
+        case (0, 0, 0):
             return "Begin the Chronicle"
-        case totalScenes:
+        case let (_, 0, _):
+            return "Your first keepsake is taking shape"
+        case let (_, unlocked, enriched) where unlocked == totalChronicleEntries && enriched == totalChronicleEntries:
+            return "Your Chronicle shelf glows with meaning"
+        case let (_, unlocked, _) where unlocked == totalChronicleEntries:
             return "The first Chronicle page is complete"
+        case let (_, _, enriched) where enriched > 0:
+            return "Your Chronicle is deepening"
         default:
             return "Your Chronicle is taking shape"
         }

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -90,7 +90,8 @@ final class GreatsOfBharathaTests: XCTestCase {
         store.markScene("scene-1-shivneri", mastery: .observedClosely)
 
         XCTAssertEqual(store.chronicleUnlockState(for: guidanceEntry), .enriched)
-        XCTAssertEqual(store.enrichedChronicleCount, 3)
+        XCTAssertEqual(store.unlockedChronicleCount, 3)
+        XCTAssertEqual(store.enrichedChronicleCount, 2)
         XCTAssertEqual(store.chronicleHeadline, "Your Chronicle is deepening")
     }
 

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -51,18 +51,26 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertTrue(heroArc.reviewBlueprints.contains { $0.subjectID == "place-raigad" && $0.subjectType == .location })
     }
 
-    func testLessonStoreTracksProgressAndUnlocksRewards() {
+    func testLessonStorePreviewsChronicleRewardsBeforeUnlockingThem() {
         let defaults = UserDefaults(suiteName: #function)!
         defaults.removePersistentDomain(forName: #function)
         let store = ShivajiLessonStore(defaults: defaults)
 
         XCTAssertEqual(store.completedScenes, 0)
         XCTAssertEqual(store.nextSceneID, "scene-1-shivneri")
-        XCTAssertTrue(store.isUnlocked(SampleContent.birthFortCard))
+        XCTAssertFalse(store.isPreviewed(SampleContent.birthFortCard))
+        XCTAssertFalse(store.isUnlocked(SampleContent.birthFortCard))
 
         let guidanceEntry = SampleContent.shivajiHeroArc.chronicleEntry(withID: "reward-jijabai-guidance-badge")
         XCTAssertNotNil(guidanceEntry)
         XCTAssertEqual(store.chronicleUnlockState(for: guidanceEntry!), .silhouette)
+
+        store.recordStoryExposure(for: "scene-1-shivneri")
+
+        XCTAssertTrue(store.isPreviewed(SampleContent.birthFortCard))
+        XCTAssertFalse(store.isUnlocked(SampleContent.birthFortCard))
+        XCTAssertEqual(store.chronicleUnlockState(for: guidanceEntry!), .silhouette)
+        XCTAssertEqual(store.chronicleHeadline, "Your first keepsake is taking shape")
 
         store.markScene("scene-1-shivneri", mastery: .understood)
 
@@ -70,6 +78,20 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertEqual(store.nextSceneID, "scene-2-torna-rajgad")
         XCTAssertTrue(store.isUnlocked(SampleContent.birthFortCard))
         XCTAssertEqual(store.chronicleUnlockState(for: guidanceEntry!), .unlocked)
+    }
+
+    func testLessonStoreTracksEnrichedChronicleState() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let store = ShivajiLessonStore(defaults: defaults)
+
+        let guidanceEntry = SampleContent.shivajiHeroArc.chronicleEntry(withID: "reward-jijabai-guidance-badge")!
+
+        store.markScene("scene-1-shivneri", mastery: .observedClosely)
+
+        XCTAssertEqual(store.chronicleUnlockState(for: guidanceEntry), .enriched)
+        XCTAssertEqual(store.enrichedChronicleCount, 3)
+        XCTAssertEqual(store.chronicleHeadline, "Your Chronicle is deepening")
     }
 
     func testRecallEngineRevealsHintLadderBeforeRecognitionRescue() {


### PR DESCRIPTION
## Summary
- split Chronicle shelf state into previewed, earned, and deepened keepsakes
- require recall-level mastery before Chronicle rewards unlock while still surfacing silhouettes after story exposure
- update home progress and tests to match the staged Chronicle contract

## Testing
- not run locally (Linux workspace; validating via remote/CI next)

Closes #52