### PR TITLE
Add parent progress surface and child-safe settings hooks

### DIFF
--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */; };
 		86E2FF6E624F8374636950E5 /* README_BOOTSTRAP.md in Resources */ = {isa = PBXBuildFile; fileRef = AF8E819340759100DB074CD4 /* README_BOOTSTRAP.md */; };
 		A7BA06A197B5E5166A0F7BB6 /* ChronicleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B68FFD09AD399FAE5A7DA5F /* ChronicleView.swift */; };
+		F1A2B3C4D5E6F708192A3B4C /* ParentProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F708192A3B4B /* ParentProgressView.swift */; };
 		B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842D0166597E3756A21D8739 /* ContentModels.swift */; };
 		DA179384FDADDB751B69ED44 /* ALPHA_README.md in Resources */ = {isa = PBXBuildFile; fileRef = AE4ACA8DD1F96BF699DB84C3 /* ALPHA_README.md */; };
 		E192EA45F4DF6C39007360F9 /* GreatsOfBharathaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B8DF1FEE4414FC115FD0F1 /* GreatsOfBharathaTests.swift */; };
@@ -85,6 +86,7 @@
 		AB428856E6E0B33ECEAA8E36 /* LessonHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonHomeView.swift; sourceTree = "<group>"; };
 		AE4ACA8DD1F96BF699DB84C3 /* ALPHA_README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ALPHA_README.md; sourceTree = "<group>"; };
 		AF8E819340759100DB074CD4 /* README_BOOTSTRAP.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_BOOTSTRAP.md; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F708192A3B4B /* ParentProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentProgressView.swift; sourceTree = "<group>"; };
 		B437E2FBF7D8A3260B1C1DCC /* PlacesHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacesHubView.swift; sourceTree = "<group>"; };
 		BAABCCD639D0C3267861E9A8 /* ShivajiLessonStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShivajiLessonStore.swift; sourceTree = "<group>"; };
 		C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShivajiLessonModels.swift; sourceTree = "<group>"; };
@@ -161,6 +163,14 @@
 			path = Chronicle;
 			sourceTree = "<group>";
 		};
+		3B4C5D6E7F8091A2B3C4D5E6 /* Parent */ = {
+			isa = PBXGroup;
+			children = (
+				F1A2B3C4D5E6F708192A3B4B /* ParentProgressView.swift */,
+			);
+			path = Parent;
+			sourceTree = "<group>";
+		};
 		29C18B9AA5DE074DEE2233A4 /* GreatsOfBharathaTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -185,6 +195,7 @@
 				291D0A188BF00AB65634B378 /* Chronicle */,
 				2CAF176D76684F7BB625884A /* Lesson */,
 				B8EE4101C55EA21501F66716 /* Map */,
+				3B4C5D6E7F8091A2B3C4D5E6 /* Parent */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -370,6 +381,7 @@
 				1F8C2F1A8E2D4A1B9C7D1234 /* DebugNavigationRoute.swift in Sources */,
 				EE2374F1DB13184A06C4BBCA /* AppModel.swift in Sources */,
 				A7BA06A197B5E5166A0F7BB6 /* ChronicleView.swift in Sources */,
+				F1A2B3C4D5E6F708192A3B4C /* ParentProgressView.swift in Sources */,
 				B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */,
 				229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */,
 				3CE894040C86BE6F34F93C13 /* GreatsOfBharathaApp.swift in Sources */,

--- a/GreatsOfBharatha/App/CaptureRootView.swift
+++ b/GreatsOfBharatha/App/CaptureRootView.swift
@@ -41,6 +41,8 @@ struct CaptureRootView: View {
             }
         case .timelineHome:
             NavigationStack { TimelineHubView() }
+        case .parentHome:
+            NavigationStack { ParentProgressView() }
         case .learnHome:
             NavigationStack { LessonHomeView() }
         }

--- a/GreatsOfBharatha/App/ContentView.swift
+++ b/GreatsOfBharatha/App/ContentView.swift
@@ -36,6 +36,14 @@ struct ContentView: View {
                 Label("Chronicle", systemImage: "sparkles.rectangle.stack")
             }
             .tag(DebugTabRoute.chronicle)
+
+            NavigationStack {
+                ParentProgressView()
+            }
+            .tabItem {
+                Label("Parent", systemImage: "person.text.rectangle")
+            }
+            .tag(DebugTabRoute.parent)
         }
         .tint(.orange)
     }

--- a/GreatsOfBharatha/App/DebugNavigationRoute.swift
+++ b/GreatsOfBharatha/App/DebugNavigationRoute.swift
@@ -5,6 +5,7 @@ enum DebugTabRoute: String {
     case places
     case timeline
     case chronicle
+    case parent
 }
 
 enum CaptureSeedProfile {
@@ -20,6 +21,7 @@ enum DebugNavigationRoute: String {
     case placeShivneri = "place-shivneri"
     case timelineHome = "timeline-home"
     case chronicleUnlocked = "chronicle-unlocked"
+    case parentHome = "parent-home"
 
     static func current(from environment: [String: String] = ProcessInfo.processInfo.environment) -> DebugNavigationRoute? {
         if let raw = environment["GOB_CAPTURE_ROUTE"], let route = DebugNavigationRoute(rawValue: raw) {
@@ -44,6 +46,8 @@ enum DebugNavigationRoute: String {
             return .timelineHome
         case ("chronicle", "chronicle-unlocked"):
             return .chronicleUnlocked
+        case ("parent", ""), ("parent", "parent-home"):
+            return .parentHome
         default:
             return nil
         }

--- a/GreatsOfBharatha/Features/Parent/ParentProgressView.swift
+++ b/GreatsOfBharatha/Features/Parent/ParentProgressView.swift
@@ -1,0 +1,272 @@
+import SwiftUI
+
+struct ParentProgressView: View {
+    @EnvironmentObject private var appModel: AppModel
+
+    private var dueReviews: [ReviewSchedule] {
+        appModel.lessonStore.dueReviews()
+    }
+
+    private var upcomingReviews: [ReviewSchedule] {
+        appModel.lessonStore.upcomingReviews(limit: 4)
+    }
+
+    var body: some View {
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    heroCard
+
+                    GBSurface(style: .elevated) {
+                        VStack(alignment: .leading, spacing: GBSpacing.small) {
+                            GBSectionHeader(
+                                eyebrow: "Progress Snapshot",
+                                title: "What the child now knows",
+                                subtitle: "A calm adult-facing view of retrieval progress, place confidence, Chronicle growth, and revisit readiness."
+                            )
+
+                            HStack(spacing: GBSpacing.small) {
+                                ParentMetricCard(title: "Scenes", value: "\(appModel.lessonStore.completedScenes)/\(max(appModel.lessonStore.totalScenes, 1))", detail: "story understanding", emphasis: .story)
+                                ParentMetricCard(title: "Places", value: "\(appModel.lessonStore.masteredPlaceCount)/\(max(appModel.lessonStore.totalCorePlaces, 1))", detail: "mastered lightly", emphasis: .place)
+                            }
+
+                            HStack(spacing: GBSpacing.small) {
+                                ParentMetricCard(title: "Chronicle", value: "\(appModel.lessonStore.unlockedChronicleCount)/\(max(appModel.lessonStore.totalChronicleEntries, 1))", detail: "earned keepsakes", emphasis: .chronicle)
+                                ParentMetricCard(title: "Due", value: "\(appModel.lessonStore.dueReviewCount)", detail: "short revisits", emphasis: .neutral)
+                            }
+                        }
+                    }
+
+                    progressSections
+                    settingsSection
+                }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
+            }
+            .background(GBColor.Background.app)
+        }
+        .navigationTitle("Parent")
+    }
+
+    private var heroCard: some View {
+        GBHeroCard(
+            eyebrow: "Parent View",
+            title: "Progress without child-path clutter",
+            subtitle: appModel.lessonStore.parentProgressHeadline,
+            detail: appModel.lessonStore.retrievalExplanation,
+            ctaTitle: dueReviews.isEmpty ? "Learning is on track" : "\(dueReviews.count) revisit prompt\(dueReviews.count == 1 ? "" : "s") ready",
+            badgeTitle: "retrieval-first",
+            emphasis: .neutral,
+            progress: appModel.lessonStore.overallProgress
+        )
+    }
+
+    @ViewBuilder
+    private var progressSections: some View {
+        VStack(alignment: .leading, spacing: GBSpacing.small) {
+            GBSectionHeader(
+                eyebrow: "Learning Value",
+                title: "Why this progress matters",
+                subtitle: "The child-facing path stays playful. This surface explains the educational meaning in direct adult language."
+            )
+
+            ParentNarrativeCard(
+                title: "Hero progress",
+                badge: "\(appModel.lessonStore.completedScenes) scenes understood",
+                emphasis: .story,
+                message: appModel.lessonStore.completedScenes == 0
+                    ? "The child has not yet reached the first understanding checkpoint."
+                    : "The child is recalling story meaning well enough to move through \(appModel.lessonStore.completedScenes) of \(appModel.lessonStore.totalScenes) scenes without needing the path to become adult-heavy."
+            )
+
+            ParentNarrativeCard(
+                title: "Place confidence",
+                badge: "\(appModel.lessonStore.readyOrBetterPlaceCount) places opened",
+                emphasis: .place,
+                message: appModel.lessonStore.masteredPlaceCount == 0
+                    ? "Place learning is unlocked gradually so geography stays forgiving and identity comes before precision."
+                    : "\(appModel.lessonStore.masteredPlaceCount) core places are now holding with light mastery, which means the child is connecting story moments to geography."
+            )
+
+            ParentNarrativeCard(
+                title: "Chronicle meaning",
+                badge: "\(appModel.lessonStore.unlockedChronicleCount) keepsakes earned",
+                emphasis: .chronicle,
+                message: appModel.lessonStore.unlockedChronicleCount == 0
+                    ? "Chronicle keepsakes stay silhouetted until the child recalls enough meaning to earn them."
+                    : "Chronicle progress signals that meaning is being retrieved, not just exposed, which is why the reward shelf now reflects remembered understanding."
+            )
+        }
+
+        reviewSection
+    }
+
+    @ViewBuilder
+    private var reviewSection: some View {
+        VStack(alignment: .leading, spacing: GBSpacing.small) {
+            GBSectionHeader(
+                eyebrow: "Revisit Status",
+                title: dueReviews.isEmpty ? "Nothing is overdue right now" : "Short revisits are ready",
+                subtitle: dueReviews.isEmpty
+                    ? "Upcoming retrieval prompts are scheduled to bring knowledge back before it fades."
+                    : "These are calm return points, meant to strengthen memory without pressure."
+            )
+
+            if dueReviews.isEmpty {
+                ForEach(upcomingReviews, id: \.subjectID) { schedule in
+                    ParentReviewCard(title: title(for: schedule), schedule: schedule, isDue: false)
+                }
+            } else {
+                ForEach(dueReviews, id: \.subjectID) { schedule in
+                    ParentReviewCard(title: title(for: schedule), schedule: schedule, isDue: true)
+                }
+            }
+        }
+    }
+
+    private var settingsSection: some View {
+        GBSurface(style: .elevated) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSectionHeader(
+                    eyebrow: "Child-safe settings hooks",
+                    title: "Support without over-directing",
+                    subtitle: "These are hook points for adult choices around help, narration, and calmer transitions."
+                )
+
+                Toggle("Assist mode", isOn: settingBinding(\ParentLearningSettings.assistModeEnabled))
+                Toggle("Narration support", isOn: settingBinding(\ParentLearningSettings.narrationEnabled))
+                Toggle("Calm transitions", isOn: settingBinding(\ParentLearningSettings.calmTransitionsEnabled))
+            }
+        }
+    }
+
+    private func settingBinding(_ keyPath: WritableKeyPath<ParentLearningSettings, Bool>) -> Binding<Bool> {
+        Binding(
+            get: { appModel.parentSettings[keyPath: keyPath] },
+            set: { appModel.parentSettings[keyPath: keyPath] = $0 }
+        )
+    }
+
+    private func title(for schedule: ReviewSchedule) -> String {
+        switch schedule.subjectType {
+        case .scene:
+            return appModel.content.activeHeroArc.scene(withID: schedule.subjectID)?.title ?? schedule.subjectID
+        case .location:
+            return appModel.content.activeHeroArc.locationNode(withID: schedule.subjectID)?.name ?? schedule.subjectID
+        case .timeline:
+            return appModel.content.activeHeroArc.timelineEvent(withID: schedule.subjectID)?.title ?? schedule.subjectID
+        case .chronicle:
+            return appModel.content.activeHeroArc.chronicleEntry(withID: schedule.subjectID)?.title ?? schedule.subjectID
+        }
+    }
+}
+
+private struct ParentMetricCard: View {
+    let title: String
+    let value: String
+    let detail: String
+    let emphasis: GBEmphasis
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+            Text(title)
+                .gbCaption()
+                .foregroundStyle(GBColor.Content.secondary)
+            Text(value)
+                .gbHeadline()
+                .foregroundStyle(GBColor.accent(for: emphasis))
+            Text(detail)
+                .font(.caption)
+                .foregroundStyle(GBColor.Content.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(GBSpacing.xSmall)
+        .background(GBColor.Background.surface, in: RoundedRectangle(cornerRadius: GBRadius.control, style: .continuous))
+    }
+}
+
+private struct ParentNarrativeCard: View {
+    let title: String
+    let badge: String
+    let emphasis: GBEmphasis
+    let message: String
+
+    var bodyView: some View {
+        GBSurface(style: .plain) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack {
+                    Text(title)
+                        .gbTitle()
+                    Spacer()
+                    GBBadge(title: badge, symbol: badgeSymbol, emphasis: emphasis)
+                }
+
+                Text(message)
+                    .gbBody()
+                    .foregroundStyle(GBColor.Content.secondary)
+            }
+        }
+    }
+
+    var body: some View { bodyView }
+
+    private var badgeSymbol: String {
+        switch emphasis {
+        case .story:
+            return GBIcon.story
+        case .place:
+            return GBIcon.place
+        case .chronicle:
+            return GBIcon.chronicle
+        case .neutral:
+            return GBIcon.timeline
+        }
+    }
+}
+
+private struct ParentReviewCard: View {
+    let title: String
+    let schedule: ReviewSchedule
+    let isDue: Bool
+
+    var body: some View {
+        GBSurface(style: isDue ? .plain : .elevated) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack {
+                    GBBadge(title: isDue ? "Due now" : "Upcoming", symbol: isDue ? GBIcon.timeline : GBIcon.next, emphasis: isDue ? .chronicle : .neutral)
+                    Spacer()
+                    Text(schedule.stabilityBand.rawValue.capitalized)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(GBColor.Content.secondary)
+                }
+
+                Text(title)
+                    .gbTitle()
+                Text(detailText)
+                    .gbBody()
+                    .foregroundStyle(GBColor.Content.secondary)
+            }
+        }
+    }
+
+    private var detailText: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        let when = formatter.localizedString(for: schedule.nextDueAt, relativeTo: Date())
+        return "\(subjectLabel) revisit, interval \(schedule.intervalIndex + 1), \(when)."
+    }
+
+    private var subjectLabel: String {
+        switch schedule.subjectType {
+        case .scene:
+            return "Scene"
+        case .location:
+            return "Place"
+        case .timeline:
+            return "Timeline"
+        case .chronicle:
+            return "Chronicle"
+        }
+    }
+}

--- a/GreatsOfBharatha/Shared/Models/AppModel.swift
+++ b/GreatsOfBharatha/Shared/Models/AppModel.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+struct ParentLearningSettings: Equatable {
+    var assistModeEnabled: Bool = true
+    var narrationEnabled: Bool = true
+    var calmTransitionsEnabled: Bool = true
+}
+
 final class AppModel: ObservableObject {
     @Published var content: AppContent {
         didSet {
@@ -8,6 +14,7 @@ final class AppModel: ObservableObject {
     }
 
     @Published var lessonStore: ShivajiLessonStore
+    @Published var parentSettings = ParentLearningSettings()
 
     init(content: AppContent = SampleContent.shivajiVerticalSlice, captureSeedProfile: CaptureSeedProfile = .pristine) {
         self.content = content

--- a/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
+++ b/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
@@ -285,6 +285,43 @@ final class ShivajiLessonStore: ObservableObject {
         }
     }
 
+    var totalCorePlaces: Int {
+        content.corePlaces.count
+    }
+
+    var readyOrBetterPlaceCount: Int {
+        content.corePlaces.filter { progress(for: $0) != .locked }.count
+    }
+
+    var masteredPlaceCount: Int {
+        content.corePlaces.filter { progress(for: $0) == .masteredLightly }.count
+    }
+
+    var parentProgressHeadline: String {
+        switch (completedScenes, unlockedChronicleCount, masteredPlaceCount, dueReviewCount) {
+        case (0, 0, 0, 0):
+            return "The learning journey is ready to begin"
+        case let (scenes, chronicle, places, _) where scenes == totalScenes && chronicle == totalChronicleEntries && places == totalCorePlaces:
+            return "The full Shivaji MVP loop is holding together"
+        case let (_, _, _, due) where due > 0:
+            return "A short revisit is ready to strengthen memory"
+        case let (_, chronicle, _, _) where chronicle > 0:
+            return "Meaning is starting to stick, not just the story beats"
+        default:
+            return "Story, place, and review are beginning to connect"
+        }
+    }
+
+    var retrievalExplanation: String {
+        if dueReviewCount > 0 {
+            return "Short revisit prompts are now due, which helps move remembered facts into longer-lasting knowledge."
+        }
+        if unlockedChronicleCount > 0 {
+            return "Chronicle unlocks show the child is recalling meaning, not only tapping through scenes."
+        }
+        return "The app is designed to ask for gentle recall before giving the answer, so memory grows through retrieval instead of repetition alone."
+    }
+
     var totalChronicleEntries: Int {
         content.activeHeroArc.chronicleEntries.count
     }

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -202,4 +202,38 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertEqual(store.timelineHeadline, "Your timeline confidence is growing")
     }
 
+    func testParentProgressHelpersReflectRetrievalState() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let store = ShivajiLessonStore(defaults: defaults)
+
+        XCTAssertEqual(store.totalCorePlaces, 5)
+        XCTAssertEqual(store.masteredPlaceCount, 0)
+        XCTAssertEqual(store.parentProgressHeadline, "The learning journey is ready to begin")
+        XCTAssertTrue(store.retrievalExplanation.contains("gentle recall"))
+
+        store.markScene("scene-1-shivneri", mastery: .understood)
+        store.recordRecallOutcome(
+            subjectID: "place-shivneri",
+            subjectType: .location,
+            promptType: .mapPlacement,
+            wasSuccessful: true,
+            mastery: .placed,
+            detail: "Place mastered"
+        )
+
+        XCTAssertEqual(store.masteredPlaceCount, 1)
+        XCTAssertTrue(store.parentProgressHeadline.contains("Meaning is starting to stick") || store.parentProgressHeadline.contains("Story, place, and review"))
+    }
+
+    func testAppModelExposesParentSettingsHooks() {
+        let model = AppModel()
+        XCTAssertTrue(model.parentSettings.assistModeEnabled)
+        XCTAssertTrue(model.parentSettings.narrationEnabled)
+        XCTAssertTrue(model.parentSettings.calmTransitionsEnabled)
+
+        model.parentSettings.narrationEnabled = false
+        XCTAssertFalse(model.parentSettings.narrationEnabled)
+    }
+
 }


### PR DESCRIPTION
Closes #56

## Summary
- add a dedicated Parent tab and capture route for an adult-facing progress surface
- surface hero, place, Chronicle, timeline, and review helper metrics from ShivajiLessonStore
- add child-safe parent settings hooks for assist mode, narration support, and calm transitions
- cover the new progress helpers and settings defaults in tests

## Validation
- not run locally on this host, xcodebuild is unavailable here
- remote Mac validation was attempted but the SSH target was unreachable from this network
- GitHub CI should provide the authoritative iOS build and test proof