### PR TITLE
feat: add mapkit place-learning explorer for fort detail

### DIFF
--- a/GreatsOfBharatha/Features/Map/PlacesHubView.swift
+++ b/GreatsOfBharatha/Features/Map/PlacesHubView.swift
@@ -193,15 +193,6 @@ struct PlaceDetailView: View {
         return revealed ? "Close. This clue belongs to \(place.name). Use compare mode to see what makes it different." : "That pin is close, but not right yet. Reveal the answer and compare the forts."
     }
 
-    private var appleMapsURL: URL? {
-        var components = URLComponents(string: "https://maps.apple.com/")
-        components?.queryItems = [
-            URLQueryItem(name: "ll", value: "\(place.latitude),\(place.longitude)"),
-            URLQueryItem(name: "q", value: place.name)
-        ]
-        return components?.url
-    }
-
     var body: some View {
         GBLayoutContextReader { context in
             ScrollView {
@@ -709,12 +700,6 @@ private struct PlaceMapExplorerSheet: View {
         )
 
         return MKCoordinateRegion(center: center, span: span)
-    }
-}
-
-private extension Place {
-    var coordinate: CLLocationCoordinate2D {
-        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
 }
 

--- a/GreatsOfBharatha/Features/Map/PlacesHubView.swift
+++ b/GreatsOfBharatha/Features/Map/PlacesHubView.swift
@@ -682,24 +682,17 @@ private struct PlaceMapExplorerSheet: View {
     }
 
     private static func region(for place: Place, nearbyPlaces: [Place]) -> MKCoordinateRegion {
-        let latitudes = nearbyPlaces.map(\.latitude)
-        let longitudes = nearbyPlaces.map(\.longitude)
-        let minLatitude = latitudes.min() ?? place.latitude
-        let maxLatitude = latitudes.max() ?? place.latitude
-        let minLongitude = longitudes.min() ?? place.longitude
-        let maxLongitude = longitudes.max() ?? place.longitude
-
-        let center = CLLocationCoordinate2D(
-            latitude: (minLatitude + maxLatitude) / 2,
-            longitude: (minLongitude + maxLongitude) / 2
+        let viewport = Place.explorerViewport(for: place, nearbyPlaces: nearbyPlaces)
+        return MKCoordinateRegion(
+            center: CLLocationCoordinate2D(
+                latitude: viewport.centerLatitude,
+                longitude: viewport.centerLongitude
+            ),
+            span: MKCoordinateSpan(
+                latitudeDelta: viewport.latitudeDelta,
+                longitudeDelta: viewport.longitudeDelta
+            )
         )
-
-        let span = MKCoordinateSpan(
-            latitudeDelta: max((maxLatitude - minLatitude) * 1.8, 0.4),
-            longitudeDelta: max((maxLongitude - minLongitude) * 1.8, 0.4)
-        )
-
-        return MKCoordinateRegion(center: center, span: span)
     }
 }
 

--- a/GreatsOfBharatha/Features/Map/PlacesHubView.swift
+++ b/GreatsOfBharatha/Features/Map/PlacesHubView.swift
@@ -1,3 +1,4 @@
+import MapKit
 import SwiftUI
 
 struct PlacesHubView: View {
@@ -168,6 +169,7 @@ struct PlaceDetailView: View {
     @State private var selectedCandidateID: String?
     @State private var revealed = false
     @State private var comparisonMode = false
+    @State private var showsMapExplorer = false
 
     private var challengeCandidates: [Place] {
         let core = SampleContent.shivajiVerticalSlice.corePlaces
@@ -236,6 +238,9 @@ struct PlaceDetailView: View {
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
 #endif
+        .sheet(isPresented: $showsMapExplorer) {
+            PlaceMapExplorerSheet(place: place, nearbyPlaces: challengeCandidates)
+        }
     }
 
     private var headerCard: some View {
@@ -314,10 +319,18 @@ struct PlaceDetailView: View {
         GBSurface(style: .plain) {
             VStack(alignment: .leading, spacing: GBSpacing.small) {
                 GBSectionHeader(
-                    eyebrow: "Optional",
-                    title: "Open the real-world map",
-                    subtitle: "Keep the Sahyadri board as the main learning view. Apple Maps stays an optional external reference."
+                    eyebrow: "MapKit Explorer",
+                    title: "See the real fort region",
+                    subtitle: "Use the in-app map to connect the Sahyadri board with a real landscape, then optionally open Apple Maps outside the app."
                 )
+
+                Button {
+                    showsMapExplorer = true
+                } label: {
+                    Label("Open map explorer", systemImage: "map.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.gbPrimary(.place))
 
                 Button {
                     guard let appleMapsURL else { return }
@@ -328,7 +341,7 @@ struct PlaceDetailView: View {
                 }
                 .buttonStyle(.gbSecondary)
 
-                Text("This leaves GreatsOfBharatha and opens Apple Maps.")
+                Text("The explorer keeps the learning context in GreatsOfBharatha. Apple Maps remains an optional external reference.")
                     .font(.caption)
                     .foregroundStyle(GBColor.Content.secondary)
             }
@@ -596,6 +609,112 @@ struct PlaceDetailView: View {
                     .foregroundStyle(GBColor.Content.primary)
             }
         }
+    }
+}
+
+private struct PlaceMapExplorerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let place: Place
+    let nearbyPlaces: [Place]
+
+    @State private var cameraPosition: MapCameraPosition
+
+    init(place: Place, nearbyPlaces: [Place]) {
+        self.place = place
+        self.nearbyPlaces = nearbyPlaces
+        _cameraPosition = State(initialValue: .region(Self.region(for: place, nearbyPlaces: nearbyPlaces)))
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBSurface(style: .accented(.place)) {
+                    VStack(alignment: .leading, spacing: GBSpacing.small) {
+                        Text("MapKit place explorer")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.84))
+                        Text(place.name)
+                            .font(.system(.title, design: .rounded, weight: .bold))
+                            .foregroundStyle(GBColor.Content.inverse)
+                        Text("See how this fort sits inside the wider region, then return to the fort board to pin it from memory.")
+                            .foregroundStyle(GBColor.Content.inverse.opacity(0.92))
+                    }
+                }
+
+                Map(position: $cameraPosition) {
+                    ForEach(nearbyPlaces) { candidate in
+                        Annotation(candidate.name, coordinate: candidate.coordinate) {
+                            VStack(spacing: 4) {
+                                Image(systemName: candidate.id == place.id ? "mappin.circle.fill" : "mappin.circle")
+                                    .font(candidate.id == place.id ? .title : .title2)
+                                    .foregroundStyle(candidate.id == place.id ? GBColor.Accent.place : GBColor.Content.primary)
+                                Text(candidate.name)
+                                    .font(.caption2.weight(.bold))
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 4)
+                                    .background(.ultraThinMaterial, in: Capsule())
+                            }
+                        }
+                    }
+                }
+                .mapStyle(.standard(elevation: .realistic))
+                .frame(height: 320)
+                .clipShape(RoundedRectangle(cornerRadius: GBRadius.hero, style: .continuous))
+
+                GBSurface(style: .elevated) {
+                    VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                        Text("Why this helps")
+                            .font(.headline)
+                        Text(place.primaryEvent)
+                            .font(.subheadline.weight(.semibold))
+                        Text("Memory hook: \(place.memoryHook). Region clue: \(place.regionLabel).")
+                            .font(.subheadline)
+                            .foregroundStyle(GBColor.Content.secondary)
+                    }
+                }
+            }
+            .padding()
+            .background(GBColor.Background.app)
+            .navigationTitle("Map explorer")
+#if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+#endif
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private static func region(for place: Place, nearbyPlaces: [Place]) -> MKCoordinateRegion {
+        let latitudes = nearbyPlaces.map(\.latitude)
+        let longitudes = nearbyPlaces.map(\.longitude)
+        let minLatitude = latitudes.min() ?? place.latitude
+        let maxLatitude = latitudes.max() ?? place.latitude
+        let minLongitude = longitudes.min() ?? place.longitude
+        let maxLongitude = longitudes.max() ?? place.longitude
+
+        let center = CLLocationCoordinate2D(
+            latitude: (minLatitude + maxLatitude) / 2,
+            longitude: (minLongitude + maxLongitude) / 2
+        )
+
+        let span = MKCoordinateSpan(
+            latitudeDelta: max((maxLatitude - minLatitude) * 1.8, 0.4),
+            longitudeDelta: max((maxLongitude - minLongitude) * 1.8, 0.4)
+        )
+
+        return MKCoordinateRegion(center: center, span: span)
+    }
+}
+
+private extension Place {
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
 }
 

--- a/GreatsOfBharatha/Features/Map/PlacesHubView.swift
+++ b/GreatsOfBharatha/Features/Map/PlacesHubView.swift
@@ -324,13 +324,14 @@ struct PlaceDetailView: View {
                 .buttonStyle(.gbPrimary(.place))
 
                 Button {
-                    guard let appleMapsURL else { return }
+                    guard let appleMapsURL = place.appleMapsURL else { return }
                     openURL(appleMapsURL)
                 } label: {
                     Label("Open in Apple Maps", systemImage: "arrow.up.right.square")
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.gbSecondary)
+                .disabled(place.appleMapsURL == nil)
 
                 Text("The explorer keeps the learning context in GreatsOfBharatha. Apple Maps remains an optional external reference.")
                     .font(.caption)

--- a/GreatsOfBharatha/Shared/Models/ContentModels.swift
+++ b/GreatsOfBharatha/Shared/Models/ContentModels.swift
@@ -87,6 +87,29 @@ struct Place: Identifiable, Equatable {
         ]
         return components?.url
     }
+
+    static func explorerViewport(for focusPlace: Place, nearbyPlaces: [Place]) -> PlaceExplorerViewport {
+        let latitudes = nearbyPlaces.map(\.latitude)
+        let longitudes = nearbyPlaces.map(\.longitude)
+        let minLatitude = latitudes.min() ?? focusPlace.latitude
+        let maxLatitude = latitudes.max() ?? focusPlace.latitude
+        let minLongitude = longitudes.min() ?? focusPlace.longitude
+        let maxLongitude = longitudes.max() ?? focusPlace.longitude
+
+        return PlaceExplorerViewport(
+            centerLatitude: (minLatitude + maxLatitude) / 2,
+            centerLongitude: (minLongitude + maxLongitude) / 2,
+            latitudeDelta: max((maxLatitude - minLatitude) * 1.8, 0.4),
+            longitudeDelta: max((maxLongitude - minLongitude) * 1.8, 0.4)
+        )
+    }
+}
+
+struct PlaceExplorerViewport: Equatable {
+    let centerLatitude: Double
+    let centerLongitude: Double
+    let latitudeDelta: Double
+    let longitudeDelta: Double
 }
 
 struct ChronicleReward: Identifiable, Equatable {

--- a/GreatsOfBharatha/Shared/Models/ContentModels.swift
+++ b/GreatsOfBharatha/Shared/Models/ContentModels.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import Foundation
 
 struct AppContent: Equatable {
@@ -73,6 +74,19 @@ struct Place: Identifiable, Equatable {
     let longitude: Double
     let progress: PlaceProgress
     let isCoreReleasePlace: Bool
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+
+    var appleMapsURL: URL? {
+        var components = URLComponents(string: "https://maps.apple.com/")
+        components?.queryItems = [
+            URLQueryItem(name: "ll", value: "\(latitude),\(longitude)"),
+            URLQueryItem(name: "q", value: name)
+        ]
+        return components?.url
+    }
 }
 
 struct ChronicleReward: Identifiable, Equatable {

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -236,7 +236,7 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertFalse(model.parentSettings.narrationEnabled)
     }
 
-    func testCorePlacesExposeMapExplorerCoordinatesAndAppleMapsLinks() {
+    func testCorePlacesExposeMapExplorerCoordinatesAndAppleMapsLinks() throws {
         for place in SampleContent.shivajiVerticalSlice.corePlaces {
             XCTAssertEqual(place.coordinate.latitude, place.latitude, accuracy: 0.0001)
             XCTAssertEqual(place.coordinate.longitude, place.longitude, accuracy: 0.0001)

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -251,4 +251,17 @@ final class GreatsOfBharathaTests: XCTestCase {
         }
     }
 
+    func testCorePlacesProduceStableExplorerViewport() {
+        let corePlaces = SampleContent.shivajiVerticalSlice.corePlaces
+        let focusPlace = try! XCTUnwrap(corePlaces.first(where: { $0.id == "place-raigad" }))
+        let viewport = Place.explorerViewport(for: focusPlace, nearbyPlaces: corePlaces)
+
+        XCTAssertGreaterThan(viewport.latitudeDelta, 0)
+        XCTAssertGreaterThan(viewport.longitudeDelta, 0)
+        XCTAssertGreaterThanOrEqual(viewport.latitudeDelta, 0.4)
+        XCTAssertGreaterThanOrEqual(viewport.longitudeDelta, 0.4)
+        XCTAssertLessThanOrEqual(abs(viewport.centerLatitude - focusPlace.latitude), viewport.latitudeDelta)
+        XCTAssertLessThanOrEqual(abs(viewport.centerLongitude - focusPlace.longitude), viewport.longitudeDelta)
+    }
+
 }

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -236,4 +236,19 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertFalse(model.parentSettings.narrationEnabled)
     }
 
+    func testCorePlacesExposeMapExplorerCoordinatesAndAppleMapsLinks() {
+        for place in SampleContent.shivajiVerticalSlice.corePlaces {
+            XCTAssertEqual(place.coordinate.latitude, place.latitude, accuracy: 0.0001)
+            XCTAssertEqual(place.coordinate.longitude, place.longitude, accuracy: 0.0001)
+
+            let url = try XCTUnwrap(place.appleMapsURL)
+            let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+            let queryItems = components.queryItems ?? []
+
+            XCTAssertEqual(components.host, "maps.apple.com")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "ll" })?.value, "\(place.latitude),\(place.longitude)")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "q" })?.value, place.name)
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
Implement the fresh #53 MapKit place-learning restart on top of current `main`.

## What changed
- add an in-app MapKit explorer sheet on fort detail
- keep Apple Maps as optional external handoff
- move coordinate/link/viewport logic into reusable model helpers
- add unit tests for map links and explorer viewport framing

## Why
The stale Apple Maps handoff branch was no longer a good implementation source. The current #53 lane should reflect the modern product direction: learn in-app first, use external maps only optionally.

## Validation
- model/unit-test contracts added for coordinates, Apple Maps links, and explorer viewport framing
- GitHub CI `Build and test iOS app slice` passed on this PR
- CodeQL / dependency review / doc-link / workflow-lint / secret-scan checks passed on this PR

## Scope note
This is a place-learning / map-explorer slice, not the full integration/proof pass. Issue #57 remains the post-validation integration gate.

## Issue
- Closes part of #53