### PR TITLE
ci: capture scene-2 in Greats UI review lane

### DIFF
--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -120,9 +120,10 @@ jobs:
 
           capture_route "01-learn-home" "learn-home"
           capture_route "02-scene-1" "scene-1"
-          capture_route "03-places-hub" "places-hub"
-          capture_route "04-place-shivneri" "place-shivneri"
-          capture_route "05-chronicle-unlocked" "chronicle-unlocked"
+          capture_route "03-scene-2" "scene-2"
+          capture_route "04-places-hub" "places-hub"
+          capture_route "05-place-shivneri" "place-shivneri"
+          capture_route "06-chronicle-unlocked" "chronicle-unlocked"
 
           xcrun simctl terminate "$SIM_ID" "$BUNDLE_ID" || true
           xcrun simctl uninstall "$SIM_ID" "$BUNDLE_ID" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- add `scene-2` to the Greats hosted macOS routed screenshot capture lane
- keep the existing UI-review workflow aligned with the issue `#57` proof checklist
- preserve the current artifact naming sequence with simple renumbering

## Why
The current Greats UI-review workflow already captures useful remote Apple-proof surfaces for the active integration SHA:
- `learn-home`
- `scene-1`
- `places-hub`
- `place-shivneri`
- `chronicle-unlocked`

But it still misses direct-route `scene-2`, which remains one of the narrow proof gaps for issue `#57`.

This small CI follow-up reduces that gap without reopening broader integration work.

## Changes
- add `capture_route "03-scene-2" "scene-2"`
- renumber later screenshot artifact names to keep ordering clear

## Validation
- workflow YAML parsed successfully
- diff is limited to the routed capture list / artifact numbering

## Issue
- narrows the remaining remote proof gap for `#57`
