### PR TITLE
ci: extend Greats UI proof route capture

### DIFF
--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -120,9 +120,12 @@ jobs:
 
           capture_route "01-learn-home" "learn-home"
           capture_route "02-scene-1" "scene-1"
-          capture_route "03-places-hub" "places-hub"
-          capture_route "04-place-shivneri" "place-shivneri"
-          capture_route "05-chronicle-unlocked" "chronicle-unlocked"
+          capture_route "03-scene-2" "scene-2"
+          capture_route "04-places-hub" "places-hub"
+          capture_route "05-place-shivneri" "place-shivneri"
+          capture_route "06-chronicle-unlocked" "chronicle-unlocked"
+          capture_route "07-timeline-home" "timeline-home"
+          capture_route "08-parent-home" "parent-home"
 
           xcrun simctl terminate "$SIM_ID" "$BUNDLE_ID" || true
           xcrun simctl uninstall "$SIM_ID" "$BUNDLE_ID" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- extend the hosted main-only UI review capture lane with `scene-2`
- add hosted captures for `timeline-home` and `parent-home`
- keep the change workflow-only so issue #57 proof can advance without product refactors

## Why
Issue #57 still had three honest proof gaps in hosted artifacts:
- `scene-2`
- `timeline-home`
- `parent-home`

Those routes already exist in the app's debug capture plumbing on `main`; the missing piece was simply asking the hosted macOS artifact workflow to capture them.

This supersedes the narrower `scene-2`-only proof slice in #79.

## Validation
- YAML parse check passed locally
- diff is limited to `.github/workflows/ios-ui-review-main.yml`
- route list now captures:
  - `learn-home`
  - `scene-1`
  - `scene-2`
  - `places-hub`
  - `place-shivneri`
  - `chronicle-unlocked`
  - `timeline-home`
  - `parent-home`

## Issue
- closes the remaining workflow-routing gap for #57 proof, but does **not** by itself close #57
- after this lands and runs on hosted macOS, the remaining blocker should narrow to reviewing the final artifact set for full journey coherence
