### PR TITLE
Harden GitHub Actions workflow supply chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload unit test result bundle
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unit-test-results-${{ github.run_number }}
           path: TestResults.xcresult

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app
@@ -35,12 +35,12 @@ jobs:
         run: xcodegen generate
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: swift
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run dependency review when supported
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         continue-on-error: true

--- a/.github/workflows/doc-link-check.yml
+++ b/.github/workflows/doc-link-check.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Verify docs mention linked issue
         run: |
           python3 - <<'PY'

--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app
@@ -140,7 +140,7 @@ jobs:
 
       - name: Upload UI review result bundle
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ui-review-results-${{ github.run_number }}
           path: TestResults.xcresult
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload simulator UX artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ui-review-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
           path: ci_artifacts

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
     steps:
       - name: Require one status label at most
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const labels = context.payload.issue.labels.map(l => l.name)

--- a/.github/workflows/poll-testflight-build.yml
+++ b/.github/workflows/poll-testflight-build.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: pip3 install PyJWT cryptography requests
       - name: Validate build-trigger precondition
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Parse version from tag
         id: version

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,18 +20,18 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,9 +17,9 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           stale-issue-message: 'This issue has gone quiet. Update it if still active.'
           stale-pr-message: 'This PR has gone quiet. Update it if still active.'

--- a/.github/workflows/testflight-crash-feedback-sync.yml
+++ b/.github/workflows/testflight-crash-feedback-sync.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Python dependencies
         run: pip3 install PyJWT cryptography

--- a/.github/workflows/testflight-feedback-sync.yml
+++ b/.github/workflows/testflight-feedback-sync.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Python dependencies
         run: pip3 install PyJWT cryptography

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run actionlint
-        uses: raven-actions/actionlint@v2
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -1,0 +1,33 @@
+name: Workflow Security
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+      - ".github/dependabot.yml"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/docs/devsecops.md
+++ b/docs/devsecops.md
@@ -1,0 +1,11 @@
+# DevSecOps
+
+## GitHub Actions hardening
+
+All third-party `uses:` entries in `.github/workflows/*.yml` should be pinned to a full commit SHA. Keep the resolved version tag as an inline comment, for example `# v6.0.2`, so reviewers can understand what release the SHA represents.
+
+Dependabot remains the update path for GitHub Actions. The existing `.github/dependabot.yml` `github-actions` ecosystem entry should open weekly PRs; review those PRs, confirm the new upstream release is appropriate, and merge the SHA update with the version comment refreshed.
+
+`workflow-security.yml` runs zizmor against the repository's workflow definitions. zizmor is a static analyzer for GitHub Actions security issues such as risky triggers, token exposure, and supply-chain weaknesses. Its results are uploaded to code scanning when GitHub Advanced Security or public-repository code scanning support is available.
+
+Exceptions to SHA pinning should be rare. Document the reason in the workflow near the `uses:` line when a ref cannot be pinned without breaking the workflow, such as a trusted local reusable workflow, a temporary upstream incident workaround, or a GitHub-owned action that must deliberately track a moving ref for compatibility.


### PR DESCRIPTION
## Summary
- pin third-party GitHub Actions to full commit SHAs with release comments
- add a zizmor workflow security scan
- document GitHub Actions hardening expectations in docs/devsecops.md

## Validation
- parsed all .github/workflows/*.yml with PyYAML
- verified no unpinned third-party uses entries remain in this branch