### PR TITLE
Harden Python CI helper dependencies

### DIFF
--- a/.github/workflows/poll-testflight-build.yml
+++ b/.github/workflows/poll-testflight-build.yml
@@ -21,7 +21,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - run: pip3 install PyJWT cryptography requests
+      - name: Install Python dependencies
+        run: python3 -m pip install --disable-pip-version-check -r ci_scripts/requirements-ci.txt
       - name: Validate build-trigger precondition
         env:
           TARGET_VERSION: ${{ inputs.target_version }}

--- a/.github/workflows/python-ci-scripts.yml
+++ b/.github/workflows/python-ci-scripts.yml
@@ -1,0 +1,46 @@
+name: Python CI Scripts
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "ci_scripts/**"
+      - "pyproject.toml"
+      - ".github/workflows/python-ci-scripts.yml"
+      - ".github/workflows/testflight-feedback-sync.yml"
+      - ".github/workflows/testflight-crash-feedback-sync.yml"
+      - ".github/workflows/poll-testflight-build.yml"
+  push:
+    branches: [main]
+    paths:
+      - "ci_scripts/**"
+      - "pyproject.toml"
+      - ".github/workflows/python-ci-scripts.yml"
+      - ".github/workflows/testflight-feedback-sync.yml"
+      - ".github/workflows/testflight-crash-feedback-sync.yml"
+      - ".github/workflows/poll-testflight-build.yml"
+  schedule:
+    - cron: "18 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-audit:
+    name: Ruff and pip-audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Python CI dependencies
+        run: python3 -m pip install --disable-pip-version-check -r ci_scripts/requirements-ci.txt
+
+      - name: Lint CI scripts
+        run: ruff check ci_scripts
+
+      - name: Audit Python CI dependencies
+        run: pip-audit -r ci_scripts/requirements-ci.txt

--- a/.github/workflows/testflight-crash-feedback-sync.yml
+++ b/.github/workflows/testflight-crash-feedback-sync.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Python dependencies
-        run: pip3 install PyJWT cryptography
+        run: python3 -m pip install --disable-pip-version-check -r ci_scripts/requirements-ci.txt
 
       - name: Sync TestFlight crash feedback into GitHub issues
         env:

--- a/.github/workflows/testflight-feedback-sync.yml
+++ b/.github/workflows/testflight-feedback-sync.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Python dependencies
-        run: pip3 install PyJWT cryptography
+        run: python3 -m pip install --disable-pip-version-check -r ci_scripts/requirements-ci.txt
 
       - name: Sync TestFlight feedback into GitHub issues
         env:

--- a/ci_scripts/requirements-ci.txt
+++ b/ci_scripts/requirements-ci.txt
@@ -1,0 +1,5 @@
+PyJWT==2.12.1
+cryptography==47.0.0
+pip-audit==2.10.0
+requests==2.33.1
+ruff==0.15.12

--- a/ci_scripts/testflight_feedback_to_issues.py
+++ b/ci_scripts/testflight_feedback_to_issues.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import jwt
 
-
 APP_STORE_CONNECT_API_BASE = "https://api.appstoreconnect.apple.com"
 GITHUB_API_BASE = "https://api.github.com"
 DEFAULT_ISSUE_LABELS = ["source:testflight", "type:feedback"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["ci_scripts"]


### PR DESCRIPTION
## Summary
- add pinned ci_scripts/requirements-ci.txt
- add Python CI Scripts workflow running ruff and pip-audit
- update TestFlight helper workflows to install pinned requirements

## Validation
- compileall on ci_scripts
- local status clean after commit