### PR TITLE
Tighten Dependency Review and XcodeGen drift checks

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,5 +18,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Run dependency review when supported
         uses: actions/dependency-review-action@v4
+        # Keep advisory until Dependency graph is enabled for this repository;
+        # then remove continue-on-error to make high-severity findings blocking.
+        continue-on-error: true
         with:
           fail-on-severity: high

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,4 +18,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Run dependency review when supported
         uses: actions/dependency-review-action@v4
-        continue-on-error: true
+        with:
+          fail-on-severity: high

--- a/.github/workflows/xcodegen-drift.yml
+++ b/.github/workflows/xcodegen-drift.yml
@@ -1,0 +1,31 @@
+name: XcodeGen Drift
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - project.yml
+      - GreatsOfBharatha.xcodeproj/**
+
+permissions:
+  contents: read
+
+jobs:
+  xcodegen-drift:
+    name: Verify generated Xcode project
+    runs-on: macos-15
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Verify project is in sync
+        run: |
+          xcodegen generate
+          git diff --exit-code GreatsOfBharatha.xcodeproj


### PR DESCRIPTION
## Summary
- add XcodeGen drift workflow to verify generated project files stay in sync
- configure Dependency Review with high-severity threshold
- keep Dependency Review advisory (`continue-on-error`) until Dependency graph is enabled for this repository, after the first run showed GitHub currently reports the repository as unsupported

## Validation
- parsed workflow YAML with available tooling
- first hosted Dependency Review run failed with: repository unsupported / enable Dependency graph; branch updated to avoid a noisy hard block until the repo setting is enabled
- xcodegen generation could not be run locally in the worker environment because xcodegen/Homebrew/macOS tooling was unavailable