### PR TITLE
Fix haptic main-actor CI build

### DIFF
--- a/GreatsOfBharatha/DesignSystem/Tokens/GBMotion.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBMotion.swift
@@ -44,33 +44,40 @@ extension Animation {
 #if canImport(UIKit)
 import UIKit
 
-@MainActor
 enum GBHaptic {
     /// Fort pin confirmed — strong satisfaction
     static func pinCorrect() {
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        Task { @MainActor in
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        }
     }
 
     /// Fort pin near but not exact — soft cue
     static func pinClose() {
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        Task { @MainActor in
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        }
     }
 
     /// Timeline marker locked in — rigid click
     static func timelineLocked() {
-        UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+        Task { @MainActor in
+            UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+        }
     }
 
     /// Chronicle card reveal — success notification (ceremony)
     static func chronicleReveal() {
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        Task { @MainActor in
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        }
     }
 
     /// Coronation / arc completion — heavy × 2 (used once per arc)
     static func coronation() {
-        let gen = UIImpactFeedbackGenerator(style: .heavy)
-        gen.impactOccurred()
         Task { @MainActor in
+            let gen = UIImpactFeedbackGenerator(style: .heavy)
+            gen.impactOccurred()
             try? await Task.sleep(nanoseconds: 180_000_000)
             gen.impactOccurred()
         }
@@ -78,7 +85,9 @@ enum GBHaptic {
 
     /// Scene step advance — selection click
     static func stepAdvance() {
-        UISelectionFeedbackGenerator().selectionChanged()
+        Task { @MainActor in
+            UISelectionFeedbackGenerator().selectionChanged()
+        }
     }
 
     // Wrong answer: intentionally NO haptic — no shame signal.


### PR DESCRIPTION
## Summary
- make GBHaptic entry points safe to call from synchronous nonisolated contexts
- dispatch UIKit feedback generator work onto the main actor internally
- unblocks the DevSecOps hardening PR CI failures caused by Swift main-actor checking

## Validation
- git diff --check
- CI will validate the iOS build on GitHub
