### PR TITLE
Add Apple Maps handoff for known places

### DIFF
--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C3C8E7616436D7F22238B09C /* AppleMapsPlaceHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */; };
 		00F7762E6675FFA1591CB270 /* GBLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1F22519D406A575588CE02 /* GBLayoutContext.swift */; };
 		06EF311D881705EB5C28A94B /* ShivajiLessonStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAABCCD639D0C3267861E9A8 /* ShivajiLessonStore.swift */; };
 		073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C5A02CDD2D6DA5162F535 /* MasteryState.swift */; };
@@ -42,6 +41,7 @@
 		ACB64A9DB10FCF88E3BFFC1F /* CaptureRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FD76D3718D3AC479FF0985 /* CaptureRootView.swift */; };
 		ADBA27254FB49C8AC53B58C6 /* GBButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C0CC899F030C472E7720F0 /* GBButtonStyle.swift */; };
 		B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842D0166597E3756A21D8739 /* ContentModels.swift */; };
+		C3C8E7616436D7F22238B09C /* AppleMapsPlaceHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */; };
 		CD55EED6E4B1DFC5B1F20BCD /* ParentProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF974097779D0836FBDE59DD /* ParentProgressView.swift */; };
 		CE9E2F14877988A61A031337 /* GBChronicleCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0244C418BCB073D7CD511F45 /* GBChronicleCard.swift */; };
 		CF5BE7783A5885A44F0DF9D5 /* GBRecallPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E79CCE23974B1F749235073 /* GBRecallPrompt.swift */; };
@@ -66,10 +66,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMapsPlaceHandoff.swift; sourceTree = "<group>"; };
 		0048FE06EF01F9520955BAAD /* GBIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBIcon.swift; sourceTree = "<group>"; };
 		0244C418BCB073D7CD511F45 /* GBChronicleCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBChronicleCard.swift; sourceTree = "<group>"; };
 		0C84A1BE87F4CAA5D6281AD6 /* SceneLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLessonView.swift; sourceTree = "<group>"; };
+		1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMapsPlaceHandoff.swift; sourceTree = "<group>"; };
 		1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugNavigationRoute.swift; sourceTree = "<group>"; };
 		2E1F22519D406A575588CE02 /* GBLayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBLayoutContext.swift; sourceTree = "<group>"; };
 		30766CF8C2332F9E648E275A /* GBSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSectionHeader.swift; sourceTree = "<group>"; };

--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A1B2C3D4E5F60718293A4B5C /* AppleMapsPlaceHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F40516273849A0B1C2 /* AppleMapsPlaceHandoff.swift */; };
 		00F7762E6675FFA1591CB270 /* GBLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1F22519D406A575588CE02 /* GBLayoutContext.swift */; };
 		06EF311D881705EB5C28A94B /* ShivajiLessonStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAABCCD639D0C3267861E9A8 /* ShivajiLessonStore.swift */; };
 		073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C5A02CDD2D6DA5162F535 /* MasteryState.swift */; };
@@ -65,6 +66,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		C1D2E3F40516273849A0B1C2 /* AppleMapsPlaceHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMapsPlaceHandoff.swift; sourceTree = "<group>"; };
 		0048FE06EF01F9520955BAAD /* GBIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBIcon.swift; sourceTree = "<group>"; };
 		0244C418BCB073D7CD511F45 /* GBChronicleCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBChronicleCard.swift; sourceTree = "<group>"; };
 		0C84A1BE87F4CAA5D6281AD6 /* SceneLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLessonView.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				6413C33179A188AA0729938F /* AppModel.swift */,
+				C1D2E3F40516273849A0B1C2 /* AppleMapsPlaceHandoff.swift */,
 				842D0166597E3756A21D8739 /* ContentModels.swift */,
 				B69947B828E9DD4B794FBE0A /* HeroArcModels.swift */,
 				901C5A02CDD2D6DA5162F535 /* MasteryState.swift */,
@@ -417,6 +420,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EE2374F1DB13184A06C4BBCA /* AppModel.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* AppleMapsPlaceHandoff.swift in Sources */,
 				ACB64A9DB10FCF88E3BFFC1F /* CaptureRootView.swift in Sources */,
 				A7BA06A197B5E5166A0F7BB6 /* ChronicleView.swift in Sources */,
 				B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */,

--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A1B2C3D4E5F60718293A4B5C /* AppleMapsPlaceHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D2E3F40516273849A0B1C2 /* AppleMapsPlaceHandoff.swift */; };
+		C3C8E7616436D7F22238B09C /* AppleMapsPlaceHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */; };
 		00F7762E6675FFA1591CB270 /* GBLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1F22519D406A575588CE02 /* GBLayoutContext.swift */; };
 		06EF311D881705EB5C28A94B /* ShivajiLessonStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAABCCD639D0C3267861E9A8 /* ShivajiLessonStore.swift */; };
 		073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C5A02CDD2D6DA5162F535 /* MasteryState.swift */; };
@@ -66,7 +66,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		C1D2E3F40516273849A0B1C2 /* AppleMapsPlaceHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMapsPlaceHandoff.swift; sourceTree = "<group>"; };
+		1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMapsPlaceHandoff.swift; sourceTree = "<group>"; };
 		0048FE06EF01F9520955BAAD /* GBIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBIcon.swift; sourceTree = "<group>"; };
 		0244C418BCB073D7CD511F45 /* GBChronicleCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBChronicleCard.swift; sourceTree = "<group>"; };
 		0C84A1BE87F4CAA5D6281AD6 /* SceneLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLessonView.swift; sourceTree = "<group>"; };
@@ -120,8 +120,8 @@
 		0570398737C6B4A9BAA4000C /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */,
 				6413C33179A188AA0729938F /* AppModel.swift */,
-				C1D2E3F40516273849A0B1C2 /* AppleMapsPlaceHandoff.swift */,
 				842D0166597E3756A21D8739 /* ContentModels.swift */,
 				B69947B828E9DD4B794FBE0A /* HeroArcModels.swift */,
 				901C5A02CDD2D6DA5162F535 /* MasteryState.swift */,
@@ -420,7 +420,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EE2374F1DB13184A06C4BBCA /* AppModel.swift in Sources */,
-				A1B2C3D4E5F60718293A4B5C /* AppleMapsPlaceHandoff.swift in Sources */,
+				C3C8E7616436D7F22238B09C /* AppleMapsPlaceHandoff.swift in Sources */,
 				ACB64A9DB10FCF88E3BFFC1F /* CaptureRootView.swift in Sources */,
 				A7BA06A197B5E5166A0F7BB6 /* ChronicleView.swift in Sources */,
 				B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */,

--- a/GreatsOfBharatha/Features/Map/GBFortMapView.swift
+++ b/GreatsOfBharatha/Features/Map/GBFortMapView.swift
@@ -17,7 +17,7 @@ struct GBFortMapView: View {
         self.place = place
         _cameraPosition = State(
             initialValue: .region(MKCoordinateRegion(
-                center: CLLocationCoordinate2D(latitude: place.latitude, longitude: place.longitude),
+                center: place.coordinate ?? CLLocationCoordinate2D(latitude: 20.5937, longitude: 78.9629),
                 span: MKCoordinateSpan(latitudeDelta: 0.14, longitudeDelta: 0.14)
             ))
         )
@@ -25,8 +25,10 @@ struct GBFortMapView: View {
 
     var body: some View {
         Map(position: $cameraPosition) {
-            Annotation(place.name, coordinate: place.coordinate) {
-                fortPin
+            if let coordinate = place.coordinate {
+                Annotation(place.name, coordinate: coordinate) {
+                    fortPin
+                }
             }
         }
         .mapStyle(.standard(elevation: .realistic))

--- a/GreatsOfBharatha/Features/Map/PlacesHubView.swift
+++ b/GreatsOfBharatha/Features/Map/PlacesHubView.swift
@@ -162,7 +162,6 @@ private struct PlaceTrailCard: View {
 }
 
 struct PlaceDetailView: View {
-    @Environment(\.openURL) private var openURL
     let place: Place
     let progress: PlaceProgress
 
@@ -179,10 +178,12 @@ struct PlaceDetailView: View {
                     // Simplified header: fort icon + name + why it matters
                     simplifiedHeader
 
-                    // Real Apple Maps view replacing the abstract schematic board
-                    GBFortMapView(place: place)
-                        .frame(height: 250)
-                        .padding(.horizontal, context.containerPadding)
+                    // Real Apple Maps view replacing the abstract schematic board.
+                    if place.coordinate != nil {
+                        GBFortMapView(place: place)
+                            .frame(height: 250)
+                            .padding(.horizontal, context.containerPadding)
+                    }
 
                     // Kid-friendly fact card
                     kidFactCard(padding: context.containerPadding)
@@ -197,15 +198,23 @@ struct PlaceDetailView: View {
                         }
                         .buttonStyle(.gbPrimary(.place))
 
-                        Button {
-                            guard let url = place.appleMapsURL else { return }
-                            openURL(url)
-                        } label: {
-                            Label("Open in Apple Maps", systemImage: "arrow.up.right.square")
-                                .frame(maxWidth: .infinity)
+                        if place.canOpenInAppleMaps {
+                            VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                                Button {
+                                    place.appleMapsHandoff.openInAppleMaps()
+                                } label: {
+                                    Label("Open in Apple Maps", systemImage: "arrow.up.right.square")
+                                        .frame(maxWidth: .infinity)
+                                }
+                                .buttonStyle(.gbSecondary)
+                                .accessibilityLabel("Open \(place.appleMapsDisplayName) in Apple Maps")
+                                .accessibilityHint("Opens Apple Maps for directions and place details. Ask a grown-up before planning a visit.")
+
+                                Text("Opens Apple Maps for directions and place details. Ask a grown-up before planning a visit.")
+                                    .font(.caption)
+                                    .foregroundStyle(GBColor.Content.secondary)
+                            }
                         }
-                        .buttonStyle(.gbSecondary)
-                        .disabled(place.appleMapsURL == nil)
                     }
                     .padding(.horizontal, context.containerPadding)
                 }
@@ -316,8 +325,8 @@ private struct PlaceMapExplorerSheet: View {
                 }
 
                 Map(position: $cameraPosition) {
-                    ForEach(nearbyPlaces) { candidate in
-                        Annotation(candidate.name, coordinate: candidate.coordinate) {
+                    ForEach(nearbyPlaces.filter { $0.coordinate != nil }) { candidate in
+                        Annotation(candidate.name, coordinate: candidate.coordinate!) {
                             VStack(spacing: 4) {
                                 Image(systemName: candidate.id == place.id ? "mappin.circle.fill" : "mappin.circle")
                                     .font(candidate.id == place.id ? .title : .title2)

--- a/GreatsOfBharatha/Shared/Models/AppleMapsPlaceHandoff.swift
+++ b/GreatsOfBharatha/Shared/Models/AppleMapsPlaceHandoff.swift
@@ -1,0 +1,44 @@
+import CoreLocation
+import Foundation
+import MapKit
+
+struct AppleMapsPlaceHandoff {
+    let displayName: String
+    let coordinate: CLLocationCoordinate2D?
+
+    var isAvailable: Bool {
+        guard let coordinate else { return false }
+        return CLLocationCoordinate2DIsValid(coordinate)
+    }
+
+    var url: URL? {
+        guard isAvailable, let coordinate else { return nil }
+
+        var components = URLComponents(string: "https://maps.apple.com/")
+        components?.queryItems = [
+            URLQueryItem(name: "ll", value: "\(coordinate.latitude),\(coordinate.longitude)"),
+            URLQueryItem(name: "q", value: displayName)
+        ]
+        return components?.url
+    }
+
+    func makeMapItem() -> MKMapItem? {
+        guard isAvailable, let coordinate else { return nil }
+
+        let placemark = MKPlacemark(coordinate: coordinate)
+        let item = MKMapItem(placemark: placemark)
+        item.name = displayName
+        return item
+    }
+
+    @MainActor
+    @discardableResult
+    func openInAppleMaps() -> Bool {
+        guard let item = makeMapItem() else { return false }
+        item.openInMaps(launchOptions: [
+            MKLaunchOptionsMapCenterKey: NSValue(mkCoordinate: item.placemark.coordinate),
+            MKLaunchOptionsMapSpanKey: NSValue(mkCoordinateSpan: MKCoordinateSpan(latitudeDelta: 0.08, longitudeDelta: 0.08))
+        ])
+        return true
+    }
+}

--- a/GreatsOfBharatha/Shared/Models/ContentModels.swift
+++ b/GreatsOfBharatha/Shared/Models/ContentModels.swift
@@ -70,31 +70,59 @@ struct Place: Identifiable, Equatable {
     let primaryEvent: String
     let whyItMatters: String
     let regionLabel: String
-    let latitude: Double
-    let longitude: Double
+    let latitude: Double?
+    let longitude: Double?
     let progress: PlaceProgress
     let isCoreReleasePlace: Bool
 
-    var coordinate: CLLocationCoordinate2D {
-        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    init(
+        id: String,
+        name: String,
+        memoryHook: String,
+        primaryEvent: String,
+        whyItMatters: String,
+        regionLabel: String,
+        latitude: Double?,
+        longitude: Double?,
+        progress: PlaceProgress,
+        isCoreReleasePlace: Bool
+    ) {
+        self.id = id
+        self.name = name
+        self.memoryHook = memoryHook
+        self.primaryEvent = primaryEvent
+        self.whyItMatters = whyItMatters
+        self.regionLabel = regionLabel
+        self.latitude = latitude
+        self.longitude = longitude
+        self.progress = progress
+        self.isCoreReleasePlace = isCoreReleasePlace
     }
 
-    var appleMapsURL: URL? {
-        var components = URLComponents(string: "https://maps.apple.com/")
-        components?.queryItems = [
-            URLQueryItem(name: "ll", value: "\(latitude),\(longitude)"),
-            URLQueryItem(name: "q", value: name)
-        ]
-        return components?.url
+    var coordinate: CLLocationCoordinate2D? {
+        guard let latitude, let longitude else { return nil }
+        return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
+
+    var appleMapsDisplayName: String { name }
+
+    var appleMapsHandoff: AppleMapsPlaceHandoff {
+        AppleMapsPlaceHandoff(displayName: appleMapsDisplayName, coordinate: coordinate)
+    }
+
+    var appleMapsURL: URL? { appleMapsHandoff.url }
+
+    var canOpenInAppleMaps: Bool { appleMapsHandoff.isAvailable }
 
     static func explorerViewport(for focusPlace: Place, nearbyPlaces: [Place]) -> PlaceExplorerViewport {
-        let latitudes = nearbyPlaces.map(\.latitude)
-        let longitudes = nearbyPlaces.map(\.longitude)
-        let minLatitude = latitudes.min() ?? focusPlace.latitude
-        let maxLatitude = latitudes.max() ?? focusPlace.latitude
-        let minLongitude = longitudes.min() ?? focusPlace.longitude
-        let maxLongitude = longitudes.max() ?? focusPlace.longitude
+        let coordinates = (nearbyPlaces + [focusPlace]).compactMap(\.coordinate)
+        let fallback = focusPlace.coordinate ?? CLLocationCoordinate2D(latitude: 20.5937, longitude: 78.9629)
+        let latitudes = coordinates.map(\.latitude)
+        let longitudes = coordinates.map(\.longitude)
+        let minLatitude = latitudes.min() ?? fallback.latitude
+        let maxLatitude = latitudes.max() ?? fallback.latitude
+        let minLongitude = longitudes.min() ?? fallback.longitude
+        let maxLongitude = longitudes.max() ?? fallback.longitude
 
         return PlaceExplorerViewport(
             centerLatitude: (minLatitude + maxLatitude) / 2,
@@ -263,7 +291,7 @@ enum LegacyAppContentAdapter {
             return LocationNode(
                 id: place.id,
                 name: place.name,
-                canonicalCoordinate: Coordinate(latitude: place.latitude, longitude: place.longitude),
+                canonicalCoordinate: Coordinate(latitude: place.latitude ?? 0, longitude: place.longitude ?? 0),
                 memoryHook: place.memoryHook,
                 primaryEvent: place.primaryEvent,
                 regionLabel: place.regionLabel,

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -238,17 +238,46 @@ final class GreatsOfBharathaTests: XCTestCase {
 
     func testCorePlacesExposeMapExplorerCoordinatesAndAppleMapsLinks() throws {
         for place in SampleContent.shivajiVerticalSlice.corePlaces {
-            XCTAssertEqual(place.coordinate.latitude, place.latitude, accuracy: 0.0001)
-            XCTAssertEqual(place.coordinate.longitude, place.longitude, accuracy: 0.0001)
+            let latitude = try XCTUnwrap(place.latitude)
+            let longitude = try XCTUnwrap(place.longitude)
+            let coordinate = try XCTUnwrap(place.coordinate)
+            XCTAssertEqual(coordinate.latitude, latitude, accuracy: 0.0001)
+            XCTAssertEqual(coordinate.longitude, longitude, accuracy: 0.0001)
+            XCTAssertTrue(place.canOpenInAppleMaps)
 
             let url = try XCTUnwrap(place.appleMapsURL)
             let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
             let queryItems = components.queryItems ?? []
 
             XCTAssertEqual(components.host, "maps.apple.com")
-            XCTAssertEqual(queryItems.first(where: { $0.name == "ll" })?.value, "\(place.latitude),\(place.longitude)")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "ll" })?.value, "\(latitude),\(longitude)")
             XCTAssertEqual(queryItems.first(where: { $0.name == "q" })?.value, place.name)
+
+            let item = try XCTUnwrap(place.appleMapsHandoff.makeMapItem())
+            XCTAssertEqual(item.name, place.appleMapsDisplayName)
+            XCTAssertEqual(item.placemark.coordinate.latitude, latitude, accuracy: 0.0001)
+            XCTAssertEqual(item.placemark.coordinate.longitude, longitude, accuracy: 0.0001)
         }
+    }
+
+    func testAppleMapsHandoffIsHiddenWhenCoordinatesAreMissing() {
+        let place = Place(
+            id: "place-unknown",
+            name: "Unmapped Historical Place",
+            memoryHook: "Hidden map",
+            primaryEvent: "Coordinate not confirmed yet",
+            whyItMatters: "Avoid broken map handoffs",
+            regionLabel: "Unknown region",
+            latitude: nil,
+            longitude: nil,
+            progress: .readyToLearn,
+            isCoreReleasePlace: false
+        )
+
+        XCTAssertNil(place.coordinate)
+        XCTAssertFalse(place.canOpenInAppleMaps)
+        XCTAssertNil(place.appleMapsURL)
+        XCTAssertNil(place.appleMapsHandoff.makeMapItem())
     }
 
     func testCorePlacesProduceStableExplorerViewport() throws {
@@ -260,8 +289,10 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertGreaterThan(viewport.longitudeDelta, 0)
         XCTAssertGreaterThanOrEqual(viewport.latitudeDelta, 0.4)
         XCTAssertGreaterThanOrEqual(viewport.longitudeDelta, 0.4)
-        XCTAssertLessThanOrEqual(abs(viewport.centerLatitude - focusPlace.latitude), viewport.latitudeDelta)
-        XCTAssertLessThanOrEqual(abs(viewport.centerLongitude - focusPlace.longitude), viewport.longitudeDelta)
+        let focusLatitude = try XCTUnwrap(focusPlace.latitude)
+        let focusLongitude = try XCTUnwrap(focusPlace.longitude)
+        XCTAssertLessThanOrEqual(abs(viewport.centerLatitude - focusLatitude), viewport.latitudeDelta)
+        XCTAssertLessThanOrEqual(abs(viewport.centerLongitude - focusLongitude), viewport.longitudeDelta)
     }
 
 }


### PR DESCRIPTION
## Summary
- Adds a reusable `AppleMapsPlaceHandoff` helper that builds Apple Maps URLs and `MKMapItem` handoffs without requesting location permission.
- Shows an accessible `Open in Apple Maps` action on place detail screens only when confirmed coordinates exist.
- Keeps missing-coordinate places from rendering broken Apple Maps actions and avoids in-app navigation/route guidance.
- Extends tests for core Shivaji place coordinates, MKMapItem construction, URL construction, and missing-coordinate hiding.

## Validation
- `git diff --check`
- `xcodebuild -project GreatsOfBharatha.xcodeproj -scheme GreatsOfBharatha -destination "platform=iOS Simulator,name=iPhone 17" test` on `ganesh@mba` — 13 tests passed

Fixes #110
Refs #111
Refs #113
