### PR TITLE
Fix build 12 places hero feedback

### DIFF
--- a/GreatsOfBharatha/DesignSystem/Components/GBHeroCard.swift
+++ b/GreatsOfBharatha/DesignSystem/Components/GBHeroCard.swift
@@ -33,7 +33,7 @@ struct GBHeroCard: View {
                     Spacer(minLength: GBSpacing.small)
 
                     if let badgeTitle {
-                        GBBadge(title: badgeTitle, symbol: heroSymbol, emphasis: emphasis)
+                        GBBadge(title: badgeTitle, symbol: heroSymbol, emphasis: emphasis, inverted: true)
                     }
                 }
 

--- a/GreatsOfBharatha/DesignSystem/Foundation/GBBadge.swift
+++ b/GreatsOfBharatha/DesignSystem/Foundation/GBBadge.swift
@@ -4,6 +4,7 @@ struct GBBadge: View {
     let title: String
     var symbol: String?
     var emphasis: GBEmphasis = .neutral
+    var inverted: Bool = false
 
     var body: some View {
         Label {
@@ -23,28 +24,36 @@ struct GBBadge: View {
     }
 
     private var background: Color {
+        if inverted {
+            return GBColor.Content.inverse.opacity(0.22)
+        }
+
         switch emphasis {
         case .story:
-            GBColor.Accent.story.opacity(0.16)
+            return GBColor.Accent.story.opacity(0.16)
         case .place:
-            GBColor.Accent.place.opacity(0.16)
+            return GBColor.Accent.place.opacity(0.16)
         case .chronicle:
-            GBColor.Accent.chronicle.opacity(0.16)
+            return GBColor.Accent.chronicle.opacity(0.16)
         case .neutral:
-            GBColor.Background.elevated
+            return GBColor.Background.elevated
         }
     }
 
     private var foreground: Color {
+        if inverted {
+            return GBColor.Content.inverse
+        }
+
         switch emphasis {
         case .story:
-            GBColor.Accent.story
+            return GBColor.Accent.story
         case .place:
-            GBColor.Accent.place
+            return GBColor.Accent.place
         case .chronicle:
-            GBColor.Accent.chronicle
+            return GBColor.Accent.chronicle
         case .neutral:
-            GBColor.Content.secondary
+            return GBColor.Content.secondary
         }
     }
 }

--- a/GreatsOfBharatha/Features/Map/PlacesHubView.swift
+++ b/GreatsOfBharatha/Features/Map/PlacesHubView.swift
@@ -9,6 +9,10 @@ struct PlacesHubView: View {
         places.filter { appModel.lessonStore.progress(for: $0) != .locked }
     }
 
+    private var firstReadyPlace: Place? {
+        readyPlaces.first
+    }
+
     private var masteredCount: Int {
         places.filter { appModel.lessonStore.progress(for: $0) == .masteredLightly }.count
     }
@@ -75,14 +79,36 @@ struct PlacesHubView: View {
         .navigationTitle("Places")
     }
 
+    @ViewBuilder
     private var heroCard: some View {
+        if let firstReadyPlace {
+            NavigationLink {
+                PlaceDetailView(place: firstReadyPlace, progress: appModel.lessonStore.progress(for: firstReadyPlace))
+            } label: {
+                placeHeroContent(
+                    ctaTitle: "Open \(firstReadyPlace.memoryHook)",
+                    badgeTitle: "\(readyPlaces.count) ready now"
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint("Opens the first ready fort board.")
+        } else {
+            placeHeroContent(
+                ctaTitle: "Finish a story to unlock forts",
+                badgeTitle: "0 ready now"
+            )
+            .accessibilityHint("No forts are ready yet. Finish the next story scene to unlock one.")
+        }
+    }
+
+    private func placeHeroContent(ctaTitle: String, badgeTitle: String) -> some View {
         GBHeroCard(
             eyebrow: "Sahyadri Fort Trail",
             title: "Remember the place, not just the plot",
             subtitle: "The forts turn the story into a real landscape.",
             detail: "Pin one fort at a time, compare it with nearby mountains, and keep the geography tied to Shivaji Maharaj's journey.",
-            ctaTitle: "Open a ready fort",
-            badgeTitle: "\(readyPlaces.count) ready now",
+            ctaTitle: ctaTitle,
+            badgeTitle: badgeTitle,
             emphasis: .place,
             progress: places.isEmpty ? nil : Double(readyPlaces.count) / Double(places.count)
         )


### PR DESCRIPTION
## Summary
- Makes the Places hero CTA open the first ready fort when one is available, addressing latest TestFlight feedback #120.
- Improves hero-card badge contrast by allowing inverted badges on gradient hero cards, addressing the invisible top-right text reported in #119.
- Leaves broader kid-focused UX / voice-navigation feedback from #118 as a larger product-design slice rather than mixing it into this codefix.

## Validation
- Attempted `xcodebuild test -project GreatsOfBharatha.xcodeproj -scheme GreatsOfBharatha -destination "platform=iOS Simulator,name=iPhone 17,OS=26.4" ...` on `mba`; failed because available simulator OS is 26.4.1, not 26.4.
- Attempted `xcodebuild test ... OS=26.4.1`; first run caught and fixed Swift getter return errors in `GBBadge`.
- Retried `xcodebuild test ... OS=26.4.1`; build progressed past Swift compilation, but the SSH connection to `mba` timed out before final test result could be captured.
- GitHub CI: Build and test iOS app slice passed; SwiftLint/quality gate passed; dependency review, secret scan, doc links, and workflow lint passed. CodeQL Analyze Swift was still pending at last check.

Fixes #119
Fixes #120
Refs #118
