### PR TITLE
Fix build 12 font contrast

### DIFF
--- a/GreatsOfBharatha/DesignSystem/Components/GBFlashCard.swift
+++ b/GreatsOfBharatha/DesignSystem/Components/GBFlashCard.swift
@@ -77,7 +77,7 @@ struct GBFlashCard: View {
 
                 Text(card.storyBeat)
                     .font(GBFont.story(size: 20, italic: true))
-                    .foregroundStyle(.white.opacity(0.86))
+                    .foregroundStyle(.white.opacity(0.95))
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
                     .fixedSize(horizontal: false, vertical: true)
@@ -172,8 +172,8 @@ struct GBFlashCardDeck: View {
                 .padding(.horizontal, GBSpacing.medium)
             } else {
                 Label("Swipe to turn the card", systemImage: "hand.draw")
-                    .font(GBFont.ui(size: 12))
-                    .foregroundStyle(GBColor.Content.tertiary)
+                    .font(GBFont.ui(size: 13, weight: .bold))
+                    .foregroundStyle(GBColor.Content.secondary)
             }
         }
         .padding(.bottom, GBSpacing.medium)

--- a/GreatsOfBharatha/DesignSystem/Tokens/GBColor.swift
+++ b/GreatsOfBharatha/DesignSystem/Tokens/GBColor.swift
@@ -105,8 +105,8 @@ enum GBColor {
             dark: .init(0.980, 0.941, 0.851, 0.78)
         )
         static let tertiary = GBColor.adaptive(
-            light: .init(0.110, 0.078, 0.063, 0.52),
-            dark: .init(0.980, 0.941, 0.851, 0.58)
+            light: .init(0.110, 0.078, 0.063, 0.68),
+            dark: .init(0.980, 0.941, 0.851, 0.74)
         )
         static let inverse = Color.white
     }


### PR DESCRIPTION
## Summary
- raises the shared tertiary text token opacity so metadata/chrome labels clear WCAG-sized contrast on parchment surfaces
- increases story-card body copy opacity on orange flash cards
- makes the “Swipe to turn the card” hint larger/bolder and uses secondary text instead of tertiary

## Issue
Fixes #122

## Validation
- `git diff --check`
- Contrast spot-check: light tertiary text over app/surface/elevated/panel backgrounds improves from ~3.35–3.63:1 to ~5.39–6.16:1
- iOS simulator build not run: `ssh ganesh-mba` could not resolve `mba` from this host during this session

## Notes
#118 is a larger child UX/navigation slice and is intentionally not closed by this PR.