### PR TITLE
Add Shivaji reset art direction and validation docs

### DIFF
--- a/docs/design/2026-04-30-shivaji-learn-quiz-reset-visual-style-guide.md
+++ b/docs/design/2026-04-30-shivaji-learn-quiz-reset-visual-style-guide.md
@@ -1,0 +1,159 @@
+# Shivaji learn-and-quiz reset visual style guide
+
+- Linked issue: #126
+- Track: D1 visual style guide
+- Status: Draft for art generation and human review
+- Last updated: 2026-04-30
+
+## Purpose
+
+This guide defines the visual direction for the Shivaji Maharaj learn-and-quiz Chronicle pilot. It supports the reset loop:
+
+`Learn card -> quick quiz -> match/timeline reinforcement -> Chronicle reward -> spaced review`
+
+The art should help children remember time, place, action, and meaning. It should not compete with the learning task or drift into generic game decoration.
+
+## Audience
+
+- Primary: children ages 6 to 10
+- Secondary: parents evaluating whether the app feels historically respectful and educationally worthwhile
+- Product tone: warm, clear, proud, calm, and memorable
+
+## Core Style
+
+Use a **warm storybook + collectible Chronicle card** style:
+
+- bold readable silhouettes for forts, mountains, and card emblems
+- lightly textured painted shapes, not heavy realism
+- clean mobile-first compositions with one strong focal idea
+- collectible card framing that feels earned and educational
+- restrained ceremonial detail: seals, borders, ink marks, ridgelines, fort profiles
+- tactile mini-game tiles that read instantly at small size
+
+Avoid art that looks like a generic fantasy RPG, a battle game, a sticker pack, or a museum textbook plate.
+
+## Visual Hierarchy
+
+Every asset must read in this order:
+
+1. memory hook or place identity
+2. scene mood
+3. historical/cultural detail
+4. decorative polish
+
+If decorative detail weakens the memory hook, remove the detail.
+
+## Scene Color Worlds
+
+### Shivneri - Birth Fort
+
+- Mood: dawn, beginning, protection, Jijabai's guidance, values forming
+- Palette: warm dawn gold, stone beige, muted saffron, soft sky blue, light earth
+- Main shapes: Shivneri-inspired fort silhouette, hill profile, early light, protective enclosure
+- Avoid: baby imagery as the main focus, divine destiny effects, palace fantasy styling
+
+### Torna + Rajgad - First Big Fort / Early Capital
+
+- Mood: ascent, planning, early Swarajya-building, strong mountain base
+- Palette: muted greens, fort stone, terracotta, clear sky accents, controlled warm gold
+- Main shapes: high ridgelines, fort walls, two-place relationship, planning/base cues
+- Avoid: conquest spectacle, battle smoke, weapon-first compositions, exaggerated victory poses
+
+### Pratapgad - Turning Point
+
+- Mood: strategy, terrain, courage, a decisive turning point handled with restraint
+- Palette: blue-gray mist, stone charcoal, muted forest green, restrained saffron/gold highlight
+- Main shapes: dramatic hill terrain, angled paths, watchful fort silhouette, turning-point seal
+- Avoid: graphic violence, direct combat scene, revenge framing, villain caricature
+
+## Figure Depiction Rules
+
+Human figures are optional and should be used sparingly for the first pilot. Place and memory-hook art is preferred because it reduces risk and improves recognition.
+
+When depicting Shivaji Maharaj or Jijabai:
+
+- keep posture dignified, calm, and child-safe
+- use respectful Maratha-era clothing cues without overclaiming exact costume details
+- prefer medium or distant storybook treatment over portrait claims
+- show Jijabai as a guiding parental influence without turning the scene into mythology
+- avoid caricature, exaggerated facial features, comic mockery, or overly cinematic aggression
+
+## Historical and Cultural Guardrails
+
+Use stable, broad facts from the approved Shivaji V1 framing:
+
+- Shivneri is the beginning / Birth Fort
+- Torna and Rajgad represent early fort-building and planning base memory
+- Pratapgad is a turning point where terrain and planning mattered
+- Swarajya means self-rule / independent rule in child-safe language
+- forts, geography, preparation, courage, and responsibility are core themes
+
+Do not imply disputed micro-details as visual fact. Do not insert modern political symbols or present-day slogans. Do not use communal enemy imagery, totalized religious conflict, or revenge-centered visuals.
+
+## Forbidden Elements
+
+Across all generated assets, reject:
+
+- photorealistic violence, gore, bodies, blood, or injury
+- direct assassination/combat tableau for Pratapgad
+- villain caricatures or dehumanized enemy figures
+- modern weapons, vehicles, flags, buildings, microphones, cameras, or party-political symbols
+- fantasy castles, European medieval armor, pirate-map language, treasure chests, loot crates
+- random crowns, generic swords, skulls, flames, neon effects, or casino-style reward bursts
+- disrespectful Hindu symbols, decorative sacred marks used without purpose, or garbled script
+- text baked into art unless explicitly requested as a reviewed UI label
+- unreadable clutter at mobile card or tile size
+
+## Asset Surface Guidance
+
+### Learn Cards
+
+- Aspect: vertical card hero area, crop-safe for iPhone portrait
+- Composition: one clear scene environment, quiet lower area for chips/copy if overlaid
+- Focal point: fort/place first, then mood
+- Detail level: enough texture to feel crafted, simple enough for fast comprehension
+
+### Chronicle Reward Cards
+
+- Aspect: square master, crop-safe for vertical cards
+- Composition: emblem or seal with one primary motif
+- States: silhouette, inked, sealed/deepened, remembered-again mark
+- Reward feeling: keepsake earned through memory, not generic loot
+
+### Match Tiles
+
+- Aspect: square or rounded-rectangle tile art
+- Composition: icon-like, silhouette-first, strong contrast
+- Pair types: place <-> hook, place <-> action, event <-> time marker
+- Must be recognizable without paragraph text
+
+### Timeline Tiles
+
+- Aspect: compact horizontal or square tile
+- Composition: small scene emblem plus ordering cue
+- Avoid relying on dates for the pilot; use beginning / early forts / turning point memory
+
+## Accessibility and Readability
+
+- Assets must remain understandable at 120 px wide.
+- Avoid low-contrast text or line art.
+- Keep UI text outside generated images whenever possible.
+- Do not rely on color alone to distinguish scene identity; use silhouette and motif differences.
+- Leave enough negative space for SwiftUI chips, labels, and state marks.
+
+## Human Review Checklist
+
+Before any generated asset ships:
+
+- Memory: Can a child connect the art to the intended hook within 3 seconds?
+- Place: Is the fort or terrain cue specific enough for Shivneri, Torna/Rajgad, or Pratapgad?
+- Respect: Is Shivaji Maharaj, Jijabai, and Hindu/cultural context handled with dignity?
+- Safety: Is there no gore, direct violence, fear imagery, or shame-based reward language?
+- History: Does the art avoid disputed specifics and modern political messaging?
+- Product fit: Does it match the warm storybook + Chronicle card system?
+- Readability: Does it work at learn-card, reward-card, match-tile, and timeline-tile sizes?
+- Provenance: Is the generator, prompt version, review owner, and edit history recorded?
+
+## Approval Rule
+
+Generated art is not product-ready by default. A human reviewer must approve historical/cultural fit, child safety, and mobile readability before import into app assets.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -19,6 +19,8 @@ Linked umbrella issue: #38
 - `asset-briefs/2026-04-20-chronicle-reward-illustration-system.md` - issue #41 generation brief
 - `prompts/2026-04-20-issue-40-sahyadri-board-prompts.md` - prompt pack for board environment generation
 - `prompts/2026-04-20-issue-41-chronicle-reward-prompts.md` - prompt pack for Chronicle reward generation
+- `2026-04-30-shivaji-learn-quiz-reset-visual-style-guide.md` - issue #126 visual style guide for the learn-and-quiz reset
+- `prompts/2026-04-30-issue-126-shivaji-learn-quiz-reset-prompt-pack.md` - issue #126 structured prompt pack for pilot learn cards, Chronicle rewards, and tiles
 - `review-notes/2026-04-20-asset-review-checklist.md` - review checklist for both asset streams
 
 ## Working rule

--- a/docs/design/prompts/2026-04-30-issue-126-shivaji-learn-quiz-reset-prompt-pack.md
+++ b/docs/design/prompts/2026-04-30-issue-126-shivaji-learn-quiz-reset-prompt-pack.md
@@ -1,0 +1,306 @@
+# Prompt pack for issue #126 Shivaji learn-and-quiz reset
+
+- Linked issue: #126
+- Track: D2 pilot asset prompt pack
+- Depends on: `docs/design/2026-04-30-shivaji-learn-quiz-reset-visual-style-guide.md`
+- Status: Draft for generation, not final art approval
+- Last updated: 2026-04-30
+
+## Use
+
+These prompts prepare candidate art for the Shivaji Maharaj learn-and-quiz Chronicle pilot. They should be used to generate candidates only. Human review is required before any image becomes a product asset.
+
+Recommended sequence:
+
+1. Generate one conservative candidate per learn card.
+2. Generate one stronger collectible-card candidate per reward.
+3. Generate match/timeline tiles as a coordinated small-size set.
+4. Run the review checklist before choosing candidates for cleanup.
+
+## Shared Style Block
+
+Append this block to each prompt unless the generator has a separate style field:
+
+Warm storybook illustration for a premium children's history-learning app, collectible Chronicle card energy, bold readable silhouettes, lightly textured painted shapes, calm ceremonial mood, clear mobile-first composition, historically respectful, child-safe, not photorealistic, not fantasy RPG, not generic sticker art.
+
+## Shared Historical and Cultural Constraints
+
+- Shivaji Maharaj is presented respectfully as a Hindu king and builder of Swarajya.
+- Focus on forts, geography, planning, courage, responsibility, and self-rule.
+- Use broad stable memory hooks: Birth Fort, First Big Fort, Early Capital, Turning Point.
+- Avoid disputed micro-details and do not invent specific battle or costume claims.
+- No modern political symbols, slogans, maps, vehicles, weapons, or party colors as messaging.
+- No communal enemy caricatures, revenge framing, or totalized religious conflict.
+- Sacred or cultural motifs must be dignified, simple, and purposeful.
+
+## Shared Negative Prompt
+
+No gore, blood, injury, bodies, direct combat tableau, assassination scene, villain caricature, modern politics, modern flags, modern weapons, European medieval castle, fantasy armor, pirate map, treasure chest, loot crate, casino reward burst, neon, dark horror mood, disrespectful religious symbols, garbled script, baked-in text, cluttered tiny details.
+
+## Shared Human Review Checklist
+
+Use this for every generated candidate:
+
+- Does the asset strengthen the intended memory hook?
+- Is the place/terrain cue clear at mobile size?
+- Is the historical and Hindu cultural framing respectful?
+- Is the scene child-safe and free from graphic or fear-first imagery?
+- Does it avoid modern political, fantasy, and generic game-reward tropes?
+- Does it match the shared storybook + Chronicle card system?
+- Can UI labels, chips, and state marks sit near it without visual conflict?
+- Is provenance recorded: tool, date, prompt version, reviewer, edits?
+
+## Asset Naming Contract
+
+Proposed future asset slots:
+
+- `learn_shivneri_birth_fort`
+- `learn_torna_rajgad_early_forts`
+- `learn_pratapgad_turning_point`
+- `chronicle_birth_fort_card`
+- `chronicle_first_fort_early_capital_card`
+- `chronicle_turning_point_seal`
+- `chronicle_journey_so_far_page`
+- `tile_shivneri`
+- `tile_birth_fort`
+- `tile_torna`
+- `tile_rajgad`
+- `tile_first_big_fort`
+- `tile_early_capital`
+- `tile_pratapgad`
+- `tile_turning_point`
+- `tile_beginning`
+- `tile_early_swarajya`
+
+## Learn Card Prompt: Shivneri - Birth Fort
+
+### Scene Title
+
+Shivneri - Birth Fort
+
+### Memory Outcome
+
+The child remembers: Shivaji Maharaj's story begins at Shivneri.
+
+### Prompt
+
+Create a vertical learn-card hero illustration for a children's history-learning app about Shivaji Maharaj. Show Shivneri Fort as a calm hill-fort silhouette at dawn, with protective stone forms, soft early light, and a sense of beginning. The image should feel warm, respectful, and memorable for the hook "Birth Fort." Include subtle cues of Jijabai's guidance only if shown respectfully and simply, such as a distant parent-child silhouette or warm interior light, but keep the fort and place as the main focus. Leave quiet space for SwiftUI time/place/action chips and short story copy.
+
+### Composition
+
+- Fort silhouette and hill profile should dominate.
+- Dawn sky can frame the fort without heavy effects.
+- Keep foreground simple and non-cluttered.
+- No baked-in text.
+
+### Scene Palette
+
+Dawn gold, warm stone, muted saffron, light earth, soft sky blue.
+
+### Forbidden Elements
+
+No baby portrait as the central image, no divine destiny rays, no palace fantasy, no ornate crown-first imagery, no battle weapons, no modern city or flag.
+
+### Review Focus
+
+Can a child say "this is the beginning at Shivneri" after seeing it?
+
+## Learn Card Prompt: Torna + Rajgad - First Big Fort / Early Capital
+
+### Scene Title
+
+Torna + Rajgad - Early Forts and Planning Base
+
+### Memory Outcome
+
+The child remembers: Torna and Rajgad matter in the early Swarajya-building story; Rajgad is the early capital memory.
+
+### Prompt
+
+Create a vertical learn-card hero illustration for a children's history-learning app about Shivaji Maharaj. Show two Sahyadri hill-fort silhouettes connected by a quiet visual rhythm: one higher ridge for Torna as "First Big Fort," and one steadier planning-base fort for Rajgad as "Early Capital." The mood should be adventurous but calm, focused on planning, building, and mountain geography. Use warm storybook + collectible card styling with clear ridgelines, fort walls, and a child-readable relationship between the two places. Leave clean space for UI chips and story text.
+
+### Composition
+
+- Use two distinct fort/ridge silhouettes without making the scene busy.
+- Use a subtle path, light beam, or map-like contour to connect the places.
+- Make the "planning base" idea visible through organized shapes, not text.
+
+### Scene Palette
+
+Muted green mountains, fort stone, terracotta, controlled gold highlights, clear sky accents.
+
+### Forbidden Elements
+
+No battle charge, no smoke, no troops, no weapon-first scene, no victory pose, no fantasy conquest banner, no exact route map claim.
+
+### Review Focus
+
+Can a child distinguish "first fort energy" from "early capital/planning base" without needing dense explanation?
+
+## Learn Card Prompt: Pratapgad - Turning Point
+
+### Scene Title
+
+Pratapgad - Turning Point
+
+### Memory Outcome
+
+The child remembers: Pratapgad is the turning point where terrain and planning mattered.
+
+### Prompt
+
+Create a vertical learn-card hero illustration for a children's history-learning app about Shivaji Maharaj. Show Pratapgad as a dramatic but child-safe hill-fort silhouette surrounded by misty Sahyadri terrain, angled paths, and a visual sense of strategy. The mood should communicate "Turning Point" through terrain, planning, and courage, not combat. Use a restrained blue-gray and stone palette with one warm saffron/gold accent that draws attention to the fort or strategic path. Keep the composition dignified, calm, and readable on mobile.
+
+### Composition
+
+- Fort and terrain should create a clear turning-point shape or diagonal.
+- Mist may add drama but must not obscure readability.
+- No human confrontation scene.
+- Leave room for UI elements.
+
+### Scene Palette
+
+Blue-gray mist, stone charcoal, muted forest green, restrained saffron/gold highlight.
+
+### Forbidden Elements
+
+No Afzal Khan confrontation depiction, no stabbing, no blood, no bodies, no villain caricature, no revenge pose, no horror lighting, no weapon-centered composition.
+
+### Review Focus
+
+Does the image teach "terrain and planning mattered" instead of glamorizing violence?
+
+## Chronicle Reward Prompt: Birth Fort Chronicle Card
+
+### Reward State
+
+First correct recall inks the card; later match/timeline success can add a seal or border detail.
+
+### Prompt
+
+Create a square Chronicle reward card illustration called "Birth Fort" for a children's history-learning app about Shivaji Maharaj. Use a Shivneri-inspired fort emblem at dawn, with a clear silhouette, warm stone, and a quiet protective mood. It should feel like a meaningful keepsake earned because the child remembered where the story begins. Make it simple, ceremonial, and readable at small card size.
+
+### Variants
+
+- Silhouette preview: faint fort outline, low detail.
+- Inked card: clear fort, dawn light, warm border.
+- Deepened card: small reviewed seal or border mark, no loud effects.
+
+### Forbidden Elements
+
+No random trophy, no crown-only symbol, no loot glow, no baby portrait, no fantasy castle.
+
+## Chronicle Reward Prompt: First Fort / Early Capital Card
+
+### Reward State
+
+Recall inks the card; matching both Torna and Rajgad roles adds a double-fort border detail.
+
+### Prompt
+
+Create a square Chronicle reward card illustration for "First Fort / Early Capital" in a children's history-learning app about Shivaji Maharaj. Show a coordinated emblem with two Sahyadri fort silhouettes: Torna as upward first-fort momentum and Rajgad as a steady planning-base form. The reward should feel earned through memory, not like generic game loot. Use warm storybook emblem styling, strong silhouettes, muted mountain green, terracotta stone, and restrained gold.
+
+### Variants
+
+- Silhouette preview: two simple ridge/fort forms.
+- Inked card: both forts clear and balanced.
+- Deepened card: border detail or small planning mark after match success.
+
+### Forbidden Elements
+
+No troops, no battle smoke, no conquest flag, no exact campaign map, no generic trophy.
+
+## Chronicle Reward Prompt: Turning Point Seal
+
+### Reward State
+
+Correct Pratapgad recall earns the seal; match/timeline success adds a strategic path mark.
+
+### Prompt
+
+Create a square Chronicle reward seal called "Turning Point" for a children's history-learning app about Shivaji Maharaj. Use a Pratapgad-inspired hill-fort silhouette, misty mountain geometry, and a subtle turning path or angled ridge motif. The seal should suggest strategy, terrain, courage, and a major change in the story. Keep it dignified, child-safe, and readable at small size, with restrained blue-gray stone and one warm accent.
+
+### Variants
+
+- Silhouette preview: faint fort and ridge.
+- Inked seal: clear terrain and turning path.
+- Deepened seal: small remembered-again mark or border notch.
+
+### Forbidden Elements
+
+No combat, no blood, no weapon-first imagery, no villain face, no revenge symbol, no skull or flame motif.
+
+## Chronicle Reward Prompt: Shivaji Journey So Far Page
+
+### Reward State
+
+End-of-pilot page after the child completes the three-scene timeline.
+
+### Prompt
+
+Create a vertical Chronicle page illustration for a children's history-learning app showing the journey so far: Shivneri at the beginning, Torna/Rajgad as early forts and planning base, and Pratapgad as a turning point. Use three simple connected emblems or scene windows rather than a detailed route map. The page should feel like a child's remembered history book is becoming richer. Keep the style warm storybook, premium, respectful, and readable on mobile.
+
+### Forbidden Elements
+
+No exact route claim, no dense dates, no battle montage, no fantasy treasure map, no cluttered scroll.
+
+## Match Tile Prompt Set
+
+### Prompt
+
+Create a coordinated set of small square match tiles for a children's history-learning app about Shivaji Maharaj. Each tile must be icon-like, silhouette-first, high contrast, and readable at 80-120 px. Use the same warm storybook + Chronicle card style across the set. Generate tiles for: Shivneri, Birth Fort, Torna, First Big Fort, Rajgad, Early Capital, Pratapgad, Turning Point. Place tiles should use fort/terrain motifs; hook tiles should use simple emblem motifs. No baked-in text unless explicitly requested for a reviewed UI variant.
+
+### Required Pair Meanings
+
+- Shivneri <-> Birth Fort
+- Torna <-> First Big Fort
+- Rajgad <-> Early Capital
+- Pratapgad <-> Turning Point
+
+### Forbidden Elements
+
+No tiny detailed scenes, no text-dependent recognition, no generic stickers, no random medals, no weapons as primary icons.
+
+### Review Focus
+
+At 80 px, can a reviewer still identify which tile is a fort/place tile and which tile is a role/hook tile?
+
+## Timeline Tile Prompt Set
+
+### Prompt
+
+Create three coordinated timeline tiles for the Shivaji Maharaj learn-and-quiz pilot in a children's history-learning app. Tile 1: Shivneri / beginning. Tile 2: Torna + Rajgad / early forts and planning base. Tile 3: Pratapgad / turning point. Use simple scene emblems, clear ordering mood, and strong silhouettes. The set should support a drag-or-tap ordering game without relying on dates. Keep the style warm storybook + Chronicle card, child-safe, historically respectful, and readable at compact mobile size.
+
+### Forbidden Elements
+
+No date-heavy design, no exact route map, no combat scene, no cluttered border, no baked-in paragraphs.
+
+### Review Focus
+
+Can a child order the tiles by visual memory: beginning -> early forts -> turning point?
+
+## Placeholder Background/Icon Prompt
+
+### Prompt
+
+Create a quiet reusable background texture for the Shivaji learn-and-quiz reset screens. Use subtle Sahyadri contour shapes, soft stone texture, and very light warm paper or sky tone. It must stay behind SwiftUI cards, chips, answer buttons, and tile grids without reducing readability. The image should feel crafted and historical, not parchment cliche or fantasy map.
+
+### Forbidden Elements
+
+No pirate-map parchment, no labels, no routes, no forts as focal points, no high-contrast texture, no decorative clutter.
+
+## Candidate Review Record Template
+
+For each candidate, record:
+
+- Asset slot:
+- Generator/tool:
+- Prompt section:
+- Date generated:
+- Reviewer:
+- Accepted / revise / reject:
+- Memory-hook readability:
+- Historical/cultural notes:
+- Child-safety notes:
+- Mobile readability notes:
+- Required edits before import:

--- a/docs/research/000-index.md
+++ b/docs/research/000-index.md
@@ -15,3 +15,7 @@ Use this directory for product, market, domain, and technical research.
 2. Draft note from `docs/templates/research-template.md`
 3. Add sources and findings
 4. Summarize implications and next actions
+
+## Active validation scripts
+
+- `2026-04-30-shivaji-learn-quiz-child-parent-validation-script.md` - issue #126 child/parent validation script for fun, confusion, recall, and parent perceived value

--- a/docs/research/2026-04-30-shivaji-learn-quiz-child-parent-validation-script.md
+++ b/docs/research/2026-04-30-shivaji-learn-quiz-child-parent-validation-script.md
@@ -1,0 +1,252 @@
+# Shivaji learn-and-quiz child/parent validation script
+
+- Linked issue: #126
+- Track: A3 parent/child validation script
+- Status: Draft for pilot testing
+- Last updated: 2026-04-30
+
+## Research Question
+
+Does the Shivaji learn-and-quiz reset feel more fun, less confusing, and more memorable than the prior gameplay direction?
+
+This script validates whether a child can remember the first three pilot scenes as time, place, action, and meaning:
+
+1. Shivneri - Birth Fort
+2. Torna + Rajgad - First Big Fort / Early Capital
+3. Pratapgad - Turning Point
+
+## Participants
+
+- Child: ages 6 to 10
+- Parent/guardian: present for consent, observation, and parent-value questions
+- Session size: 3 to 5 families is enough for first signal
+- Setting: quiet room, screen recording optional with permission
+
+## Materials
+
+- Build or prototype with the 3-scene learn-and-quiz pilot
+- Observation sheet or notes doc
+- Timer
+- Optional: printed or digital prompt cards for next-day recall
+
+## Moderator Principles
+
+- Do not teach answers outside the app unless the child is stuck and distressed.
+- Do not use words like test, score, pass, fail, or wrong in front of the child.
+- Ask the child to think aloud only when it feels natural.
+- Let parent observe quietly during the child task.
+- If the child is anxious or tired, stop the session.
+
+## Session Plan
+
+Total live session: 20 to 25 minutes.
+
+### 1. Parent Consent and Setup - 2 Minutes
+
+Say:
+
+> We are trying a short history learning activity about Shivaji Maharaj. We are checking whether it is clear, fun, and memorable. This is not a test of your child.
+
+Record:
+
+- Child age:
+- Prior familiarity with Shivaji Maharaj: none / some / high
+- Language comfort: English / Marathi / Hindi / other
+- Device used:
+
+### 2. Warm-Up - 1 Minute
+
+Ask the child:
+
+- Have you heard of Shivaji Maharaj before?
+- Do you like stories, quizzes, matching games, or building collections?
+
+Observe:
+
+- Excitement: low / medium / high
+- Anxiety: none / mild / visible
+
+### 3. First-Run Pilot Task - 8 to 10 Minutes
+
+Ask the child to use the prototype naturally.
+
+Child tasks:
+
+1. Complete Shivneri learn card and quiz.
+2. Complete Torna/Rajgad learn card and quiz.
+3. Complete Pratapgad learn card and quiz.
+4. Complete one match activity.
+5. Complete the 3-tile timeline activity.
+6. View the Chronicle reward state.
+
+Do not explain app internals. If the child asks what to do, say:
+
+> What do you think you can tap next?
+
+Only help if the child is stuck for more than 20 seconds.
+
+## Observation Checklist
+
+Mark each item during the task.
+
+### Fun
+
+- Smiles, leans in, or verbally reacts to rewards
+- Wants to continue without prompting
+- Enjoys match/timeline interaction
+- Finds Chronicle reward meaningful, not random
+- Asks to retry or see another card
+
+Rating: 1 not fun / 2 mild / 3 okay / 4 fun / 5 very fun
+
+Evidence:
+
+### Confusion
+
+- Does not know next action
+- Misunderstands Learn Card versus Quiz
+- Cannot tell which items belong together
+- Timeline ordering feels arbitrary
+- Reward state is unclear
+- Text is too long or skipped
+
+Rating: 1 no confusion / 2 minor / 3 moderate / 4 high / 5 blocked
+
+Evidence:
+
+### Recall During Session
+
+Without looking at the answer, can the child recall:
+
+- Shivneri = Birth Fort
+- Torna = First Big Fort
+- Rajgad = Early Capital
+- Pratapgad = Turning Point
+- First three scenes order: Shivneri -> Torna/Rajgad -> Pratapgad
+
+Rating: 1 no recall / 2 recognition only / 3 partial / 4 mostly recalled / 5 recalled and explained
+
+Evidence:
+
+### Parent Perceived Value
+
+Observe parent comments during or after:
+
+- Parent sees historical learning, not just tapping
+- Parent trusts tone around Shivaji Maharaj
+- Parent understands Chronicle as memory evidence
+- Parent would let child use it again
+- Parent sees value versus generic game time
+
+Rating: 1 low value / 2 unclear / 3 moderate / 4 valuable / 5 highly valuable
+
+Evidence:
+
+## Five-Minute Recall
+
+After a 5-minute break or unrelated activity, ask the child:
+
+1. Where does Shivaji Maharaj's story begin?
+2. Which phrase goes with Shivneri?
+3. Which place was the early capital: Torna, Rajgad, or Pratapgad?
+4. Which fort is remembered as the turning point?
+5. Put these in order: Pratapgad, Shivneri, Torna/Rajgad.
+6. What is one thing forts helped with in this story?
+
+Scoring guidance:
+
+- 2 points: correct without hint
+- 1 point: correct after memory-hook or choice hint
+- 0 points: not recalled after hint
+
+Record total: ___ / 12
+
+Notes on confidence:
+
+## Next-Day Recall
+
+Send parent these questions for the next day. Ask parent not to coach first.
+
+1. Ask your child: "What was the Birth Fort?"
+2. Ask: "What happened early in the story with Torna or Rajgad?"
+3. Ask: "Which fort was the Turning Point?"
+4. Ask: "Can you put the first three moments in order?"
+5. Ask: "What did you like or remember from the Chronicle?"
+
+Parent records:
+
+- Answered independently:
+- Needed a clue:
+- Did not remember:
+- Child's exact words:
+
+## Parent Interview - 5 Minutes
+
+Ask after the child task:
+
+1. Did this feel like meaningful history learning?
+2. Did anything feel culturally off, disrespectful, or too intense?
+3. Did the Chronicle reward feel connected to what your child remembered?
+4. Was the app too easy, too hard, or about right?
+5. Would you prefer shorter stories, more audio, more map context, or more quiz practice?
+6. Would you let your child use this again tomorrow?
+
+Parent rating:
+
+- Educational value: 1 low / 2 / 3 / 4 / 5 high
+- Cultural respect: 1 concerning / 2 / 3 / 4 / 5 respectful
+- Repeat-use willingness: no / maybe / yes
+
+## Pass/Fail Signals
+
+Treat the pilot as ready to continue if most sessions meet these signals:
+
+- Fun rating averages 4 or higher.
+- Confusion rating averages 2 or lower.
+- 5-minute recall averages at least 8 / 12.
+- At least 70% of children recall Shivneri and Pratapgad without answer choices.
+- Most children can order the 3 scenes with no more than one hint.
+- Parent perceived value averages 4 or higher.
+- No parent flags cultural disrespect or age-inappropriate intensity.
+
+Treat as iterate-before-build if:
+
+- Children enjoy rewards but cannot recall places.
+- Children recognize answers only by multiple choice.
+- Parents see it as game decoration rather than memory-building.
+- Pratapgad art or wording triggers concern about violence or villain framing.
+- Timeline order feels arbitrary.
+
+## Issue Triage Tags
+
+When converting findings into GitHub issues, tag observations by:
+
+- `fun`: reward, motion, match feel, pacing
+- `confusion`: navigation, prompt wording, unclear tile, unclear reward
+- `recall`: place/hook, order, action, meaning
+- `parent-value`: trust, respect, learning proof, repeat use
+- `art-risk`: cultural review, violence, readability, style drift
+
+## Session Note Template
+
+Participant:
+Date:
+Build/prototype:
+Moderator:
+
+Child age:
+Prior knowledge:
+
+Fun rating:
+Confusion rating:
+Recall rating:
+Parent value rating:
+
+5-minute recall score:
+Next-day recall score:
+
+Best moment:
+Most confusing moment:
+Missed memory hook:
+Parent quote:
+Recommended product change:


### PR DESCRIPTION
## Summary

- Adds a visual style guide for the Shivaji learn-and-quiz reset.
- Adds a structured asset prompt pack for Shivneri, Torna/Rajgad, Pratapgad, Chronicle rewards, match tiles, timeline tiles, and placeholders.
- Adds a child/parent validation script measuring fun, confusion, recall, and parent perceived value.

## Evidence

- Docs-only change; no app code modified.
- Ran `git diff --check` successfully.
- Prompt pack includes historical/cultural constraints, forbidden elements, and human review checklist.

Part of #126