### PR TITLE
[codex] Add Shivaji learn quiz reset contracts

### DIFF
--- a/GreatsOfBharatha/App/CaptureRootView.swift
+++ b/GreatsOfBharatha/App/CaptureRootView.swift
@@ -12,6 +12,8 @@ struct CaptureRootView: View {
     @ViewBuilder
     private var captureScreen: some View {
         switch route {
+        case .learnQuizReset:
+            NavigationStack { LearnQuizResetPlaceholderView() }
         case .scene1:
             if let scene = appModel.content.scenes.first(where: { $0.id == "scene-1-shivneri" }) {
                 NavigationStack { SceneLessonView(scene: scene) }

--- a/GreatsOfBharatha/App/ContentView.swift
+++ b/GreatsOfBharatha/App/ContentView.swift
@@ -8,7 +8,11 @@ struct ContentView: View {
         TabView(selection: $selectedTab) {
             // ── Tab 1: Story ──────────────────────────────────
             NavigationStack {
-                LessonHomeView()
+                if FeatureFlags.historyLearnQuizResetEnabled {
+                    LearnQuizResetPlaceholderView()
+                } else {
+                    LessonHomeView()
+                }
             }
             .tabItem { Label("Story", systemImage: "book.fill") }
             .tag(DebugTabRoute.learn)
@@ -44,5 +48,56 @@ struct ContentView: View {
         .sheet(isPresented: $showsParentView) {
             NavigationStack { ParentProgressView() }
         }
+    }
+}
+
+struct LearnQuizResetPlaceholderView: View {
+    private let pilot = SampleContent.shivajiLearnQuizResetPilot
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: GBSpacing.large) {
+                VStack(alignment: .leading, spacing: GBSpacing.xSmall) {
+                    Text("Shivaji Chronicle Pilot")
+                        .gbTitle()
+                        .foregroundStyle(GBColor.Content.primary)
+
+                    Text("Learn, quiz, match, and build the Chronicle.")
+                        .gbBody()
+                        .foregroundStyle(GBColor.Content.secondary)
+                }
+
+                ForEach(pilot.scenes) { scene in
+                    VStack(alignment: .leading, spacing: GBSpacing.xSmall) {
+                        Text(scene.memoryHook)
+                            .gbCaption()
+                            .foregroundStyle(GBColor.Story.primary)
+
+                        Text(scene.title)
+                            .gbHeadline()
+                            .foregroundStyle(GBColor.Content.primary)
+
+                        Text(scene.childSafeStory)
+                            .gbStory()
+                            .foregroundStyle(GBColor.Content.secondary)
+
+                        Text(scene.quizItems.first?.prompt ?? "")
+                            .gbBody()
+                            .foregroundStyle(GBColor.Content.primary)
+                            .padding(.top, GBSpacing.xSmall)
+                    }
+                    .padding(GBSpacing.medium)
+                    .background(GBColor.Background.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: GBRadius.card, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: GBRadius.card, style: .continuous)
+                            .stroke(GBColor.Border.default)
+                    )
+                }
+            }
+            .padding(GBSpacing.large)
+        }
+        .background(GBColor.Background.app)
+        .navigationTitle("Chronicle Pilot")
     }
 }

--- a/GreatsOfBharatha/App/DebugNavigationRoute.swift
+++ b/GreatsOfBharatha/App/DebugNavigationRoute.swift
@@ -14,6 +14,7 @@ enum CaptureSeedProfile {
 }
 
 enum DebugNavigationRoute: String {
+    case learnQuizReset = "learn-quiz-reset"
     case learnHome = "learn-home"
     case scene1 = "scene-1"
     case scene2 = "scene-2"
@@ -32,6 +33,8 @@ enum DebugNavigationRoute: String {
         let destination = environment["GOB_CAPTURE_DESTINATION"] ?? ""
 
         switch (tab, destination) {
+        case ("learn", "learn-quiz-reset"):
+            return .learnQuizReset
         case ("learn", ""), ("learn", "learn-home"):
             return .learnHome
         case ("learn", "scene-1"):

--- a/GreatsOfBharatha/Shared/Models/AppModel.swift
+++ b/GreatsOfBharatha/Shared/Models/AppModel.swift
@@ -6,6 +6,13 @@ struct ParentLearningSettings: Equatable {
     var calmTransitionsEnabled: Bool = true
 }
 
+enum FeatureFlags {
+    static var historyLearnQuizResetEnabled: Bool {
+        let rawValue = ProcessInfo.processInfo.environment["GOB_HISTORY_LEARN_QUIZ_RESET_ENABLED"] ?? ""
+        return ["1", "true", "TRUE", "yes", "YES"].contains(rawValue)
+    }
+}
+
 final class AppModel: ObservableObject {
     @Published var content: AppContent {
         didSet {

--- a/GreatsOfBharatha/Shared/Models/HeroArcModels.swift
+++ b/GreatsOfBharatha/Shared/Models/HeroArcModels.swift
@@ -31,6 +31,81 @@ struct HeroArc: Identifiable, Equatable {
     }
 }
 
+struct HistoricalFigureArc: Identifiable, Equatable {
+    let id: String
+    let figureName: String
+    let title: String
+    let resetAnchorIssue: String
+    let scenes: [ChronicleScene]
+    let timelineBuilder: TimelineBuilderSeed
+    let endOfPilotReward: ChronicleReward
+}
+
+struct ChronicleScene: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let timeMarker: String
+    let placeAnchors: [PlaceAnchor]
+    let actionVerb: String
+    let memoryHook: String
+    let childSafeStory: String
+    let meaning: String
+    let quizItems: [QuizItem]
+    let matchPairs: [MatchPair]
+    let chronicleReward: ChronicleReward
+    let reviewSeeds: [ReviewSeed]
+}
+
+struct PlaceAnchor: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let regionLabel: String
+    let memoryHook: String
+}
+
+struct QuizItem: Identifiable, Equatable {
+    let id: String
+    let prompt: String
+    let acceptedAnswers: [String]
+    let answerChips: [String]
+    let hintLadder: [RecallHint]
+    let successFeedback: String
+    let recoveryFeedback: String
+}
+
+enum MatchPairKind: String, Codable, CaseIterable, Equatable {
+    case placeToHook
+    case placeToAction
+    case eventToTime
+    case actionToMeaning
+}
+
+struct MatchPair: Identifiable, Equatable {
+    let id: String
+    let left: String
+    let right: String
+    let kind: MatchPairKind
+    let teachingFeedback: String
+}
+
+struct TimelineBuilderSeed: Identifiable, Equatable {
+    let id: String
+    let prompt: String
+    let orderedSceneIDs: [String]
+    let completionRewardText: String
+}
+
+struct ReviewSeed: Identifiable, Equatable {
+    let id: String
+    let promptType: RecallPromptType
+    let front: String
+    let back: String
+    let meaning: String
+    let correctNoHintCadenceDays: Int
+    let correctWithHintCadenceDays: Int
+    let rescuedCadenceDays: Int
+}
+
 struct Hero: Equatable {
     let id: String
     let name: String

--- a/GreatsOfBharatha/Shared/Models/SampleContent.swift
+++ b/GreatsOfBharatha/Shared/Models/SampleContent.swift
@@ -3,6 +3,192 @@ import Foundation
 enum SampleContent {
     static let shivajiVerticalSlice = AppContent(heroArc: shivajiHeroArc)
 
+    static let shivajiLearnQuizResetPilot = HistoricalFigureArc(
+        id: "shivaji-learn-quiz-reset-pilot",
+        figureName: "Shivaji Maharaj",
+        title: "Shivaji Learn-and-Quiz Chronicle Pilot",
+        resetAnchorIssue: "#126",
+        scenes: [
+            ChronicleScene(
+                id: "reset-scene-1-shivneri",
+                title: "Shivneri - Birth Fort",
+                timeMarker: "Beginning of the journey",
+                placeAnchors: [
+                    PlaceAnchor(id: "place-shivneri", name: "Shivneri", regionLabel: "Junnar region", memoryHook: "Birth Fort"),
+                ],
+                actionVerb: "begins",
+                memoryHook: "Birth Fort",
+                childSafeStory: "Shivaji Maharaj's story begins at Shivneri Fort. Jijabai's guidance helped him grow with courage, care, and responsibility.",
+                meaning: "Shivneri matters because it anchors the beginning of the journey and the values Shivaji Maharaj carried forward.",
+                quizItems: [
+                    QuizItem(
+                        id: "quiz-shivneri-birth-fort",
+                        prompt: "Where does Shivaji Maharaj's story begin?",
+                        acceptedAnswers: ["Shivneri", "Shivneri Fort"],
+                        answerChips: ["Shivneri", "Rajgad", "Pratapgad"],
+                        hintLadder: [
+                            RecallHint(level: 1, title: "Memory hook", body: "Think of the Birth Fort."),
+                            RecallHint(level: 2, title: "Place clue", body: "It is the fort near Junnar where the story begins."),
+                            RecallHint(level: 3, title: "Recognition rescue", body: "Choose Shivneri."),
+                        ],
+                        successFeedback: "Yes. Shivneri is the Birth Fort where Shivaji Maharaj's story begins.",
+                        recoveryFeedback: "Remember the hook: Birth Fort means Shivneri."
+                    ),
+                ],
+                matchPairs: [
+                    MatchPair(id: "match-shivneri-birth-fort", left: "Shivneri", right: "Birth Fort", kind: .placeToHook, teachingFeedback: "Shivneri is the Birth Fort."),
+                    MatchPair(id: "match-shivneri-begins", left: "Shivneri", right: "Story begins", kind: .placeToAction, teachingFeedback: "The journey begins at Shivneri."),
+                ],
+                chronicleReward: ChronicleReward(
+                    id: "reset-reward-birth-fort-card",
+                    title: "Birth Fort Chronicle Card",
+                    subtitle: "First inked keepsake",
+                    meaning: "A Chronicle card for remembering Shivneri as the place where the journey begins.",
+                    unlockedBySceneID: "reset-scene-1-shivneri",
+                    mastery: .understood,
+                    category: .storyCard
+                ),
+                reviewSeeds: [
+                    ReviewSeed(
+                        id: "review-shivneri-birth-fort",
+                        promptType: .openPrompt,
+                        front: "Birth Fort",
+                        back: "Shivneri",
+                        meaning: "Shivneri is where Shivaji Maharaj's story begins.",
+                        correctNoHintCadenceDays: 1,
+                        correctWithHintCadenceDays: 0,
+                        rescuedCadenceDays: 0
+                    ),
+                ]
+            ),
+            ChronicleScene(
+                id: "reset-scene-2-torna-rajgad",
+                title: "Torna and Rajgad - Early Forts",
+                timeMarker: "Early Swarajya-building",
+                placeAnchors: [
+                    PlaceAnchor(id: "place-torna", name: "Torna", regionLabel: "Sahyadri range southwest of Pune", memoryHook: "First Big Fort"),
+                    PlaceAnchor(id: "place-rajgad", name: "Rajgad", regionLabel: "Sahyadri range near Torna", memoryHook: "Early Capital"),
+                ],
+                actionVerb: "builds",
+                memoryHook: "First Big Fort / Early Capital",
+                childSafeStory: "Shivaji Maharaj began building Swarajya through important forts. Torna marks an early breakthrough, and Rajgad became a planning base.",
+                meaning: "These forts matter because the story is not only about winning a fort; it is about building a stronger base.",
+                quizItems: [
+                    QuizItem(
+                        id: "quiz-rajgad-early-capital",
+                        prompt: "Which fort became an early capital?",
+                        acceptedAnswers: ["Rajgad"],
+                        answerChips: ["Torna", "Rajgad", "Shivneri"],
+                        hintLadder: [
+                            RecallHint(level: 1, title: "Memory hook", body: "Think of Early Capital."),
+                            RecallHint(level: 2, title: "Pair clue", body: "Torna is the First Big Fort; the other fort became the planning base."),
+                            RecallHint(level: 3, title: "Recognition rescue", body: "Choose Rajgad."),
+                        ],
+                        successFeedback: "Yes. Rajgad became an early capital and planning base.",
+                        recoveryFeedback: "Remember the pair: Torna is First Big Fort, Rajgad is Early Capital."
+                    ),
+                ],
+                matchPairs: [
+                    MatchPair(id: "match-torna-first-big-fort", left: "Torna", right: "First Big Fort", kind: .placeToHook, teachingFeedback: "Torna marks an early breakthrough."),
+                    MatchPair(id: "match-rajgad-early-capital", left: "Rajgad", right: "Early Capital", kind: .placeToHook, teachingFeedback: "Rajgad became an early capital."),
+                    MatchPair(id: "match-rajgad-planning-base", left: "Rajgad", right: "Planning base", kind: .placeToAction, teachingFeedback: "Rajgad helps children remember planning and state-building."),
+                ],
+                chronicleReward: ChronicleReward(
+                    id: "reset-reward-first-fort-early-capital-card",
+                    title: "First Fort / Early Capital Card",
+                    subtitle: "Fort-building keepsake",
+                    meaning: "A Chronicle card for remembering Torna as First Big Fort and Rajgad as Early Capital.",
+                    unlockedBySceneID: "reset-scene-2-torna-rajgad",
+                    mastery: .understood,
+                    category: .storyCard
+                ),
+                reviewSeeds: [
+                    ReviewSeed(
+                        id: "review-torna-rajgad-pair",
+                        promptType: .eventToPlaceMatch,
+                        front: "First Big Fort / Early Capital",
+                        back: "Torna / Rajgad",
+                        meaning: "Torna and Rajgad teach early fort-building and planning.",
+                        correctNoHintCadenceDays: 1,
+                        correctWithHintCadenceDays: 0,
+                        rescuedCadenceDays: 0
+                    ),
+                ]
+            ),
+            ChronicleScene(
+                id: "reset-scene-3-pratapgad",
+                title: "Pratapgad - Turning Point",
+                timeMarker: "Major rise and turning point",
+                placeAnchors: [
+                    PlaceAnchor(id: "place-pratapgad", name: "Pratapgad", regionLabel: "Hill country near Mahabaleshwar", memoryHook: "Turning Point"),
+                ],
+                actionVerb: "plans",
+                memoryHook: "Turning Point",
+                childSafeStory: "At Pratapgad, careful planning, courage, and hill terrain mattered in a dangerous moment. The story stays focused on preparation and judgment.",
+                meaning: "Pratapgad matters because terrain and planning changed the balance at a key moment.",
+                quizItems: [
+                    QuizItem(
+                        id: "quiz-pratapgad-turning-point",
+                        prompt: "Which fort is remembered as the turning point?",
+                        acceptedAnswers: ["Pratapgad"],
+                        answerChips: ["Pratapgad", "Shivneri", "Rajgad"],
+                        hintLadder: [
+                            RecallHint(level: 1, title: "Memory hook", body: "Think of Turning Point."),
+                            RecallHint(level: 2, title: "Place clue", body: "It stands in hill country near Mahabaleshwar."),
+                            RecallHint(level: 3, title: "Recognition rescue", body: "Choose Pratapgad."),
+                        ],
+                        successFeedback: "Yes. Pratapgad is remembered as the turning point.",
+                        recoveryFeedback: "Remember the hook: Turning Point means Pratapgad."
+                    ),
+                ],
+                matchPairs: [
+                    MatchPair(id: "match-pratapgad-turning-point", left: "Pratapgad", right: "Turning Point", kind: .placeToHook, teachingFeedback: "Pratapgad is the turning point fort."),
+                    MatchPair(id: "match-planning-terrain", left: "Planning and terrain", right: "Changed the balance", kind: .actionToMeaning, teachingFeedback: "The meaning is preparation, courage, and wise use of terrain."),
+                ],
+                chronicleReward: ChronicleReward(
+                    id: "reset-reward-turning-point-seal",
+                    title: "Turning Point Seal",
+                    subtitle: "Deepened Chronicle mark",
+                    meaning: "A Chronicle seal for remembering Pratapgad as the turning point where planning and terrain mattered.",
+                    unlockedBySceneID: "reset-scene-3-pratapgad",
+                    mastery: .understood,
+                    category: .emblemFragment
+                ),
+                reviewSeeds: [
+                    ReviewSeed(
+                        id: "review-pratapgad-turning-point",
+                        promptType: .compareFromMemory,
+                        front: "Turning Point",
+                        back: "Pratapgad",
+                        meaning: "Pratapgad teaches planning, terrain, and courage.",
+                        correctNoHintCadenceDays: 1,
+                        correctWithHintCadenceDays: 0,
+                        rescuedCadenceDays: 0
+                    ),
+                ]
+            ),
+        ],
+        timelineBuilder: TimelineBuilderSeed(
+            id: "timeline-shivaji-reset-pilot",
+            prompt: "Put the first three Shivaji scenes in order.",
+            orderedSceneIDs: [
+                "reset-scene-1-shivneri",
+                "reset-scene-2-torna-rajgad",
+                "reset-scene-3-pratapgad",
+            ],
+            completionRewardText: "The Chronicle gains a Journey So Far timeline strip."
+        ),
+        endOfPilotReward: ChronicleReward(
+            id: "reset-reward-shivaji-journey-so-far",
+            title: "Shivaji Journey So Far",
+            subtitle: "Pilot completion page",
+            meaning: "A page for remembering the order: Shivneri, Torna/Rajgad, Pratapgad.",
+            unlockedBySceneID: "reset-scene-3-pratapgad",
+            mastery: .remembered,
+            category: .leadershipBadge
+        )
+    )
+
     static let shivajiHeroArc = HeroArc(
         id: shivajiHero.id,
         hero: shivajiHero,

--- a/GreatsOfBharatha/Shared/Models/SampleContent.swift
+++ b/GreatsOfBharatha/Shared/Models/SampleContent.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// #126 reset pilot content intentionally keeps the static fixture in one namespace.
+// swiftlint:disable type_body_length
 enum SampleContent {
     static let shivajiVerticalSlice = AppContent(heroArc: shivajiHeroArc)
 
@@ -985,3 +987,4 @@ enum SampleContent {
         }
     }
 }
+// swiftlint:enable type_body_length

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -51,6 +51,43 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertTrue(heroArc.reviewBlueprints.contains { $0.subjectID == "place-raigad" && $0.subjectType == .location })
     }
 
+    func testLearnQuizResetPilotContentContract() {
+        let pilot = SampleContent.shivajiLearnQuizResetPilot
+
+        XCTAssertEqual(pilot.resetAnchorIssue, "#126")
+        XCTAssertEqual(pilot.scenes.map(\.id), [
+            "reset-scene-1-shivneri",
+            "reset-scene-2-torna-rajgad",
+            "reset-scene-3-pratapgad",
+        ])
+        XCTAssertEqual(pilot.scenes.map(\.memoryHook), [
+            "Birth Fort",
+            "First Big Fort / Early Capital",
+            "Turning Point",
+        ])
+        XCTAssertEqual(pilot.scenes.flatMap(\.quizItems).count, 3)
+        XCTAssertGreaterThanOrEqual(pilot.scenes.flatMap(\.matchPairs).count, 6)
+        XCTAssertEqual(pilot.timelineBuilder.orderedSceneIDs, pilot.scenes.map(\.id))
+        XCTAssertEqual(pilot.endOfPilotReward.title, "Shivaji Journey So Far")
+    }
+
+    func testLearnQuizResetPilotHasTeachingHintsRewardsAndReviewSeeds() {
+        let pilot = SampleContent.shivajiLearnQuizResetPilot
+
+        for scene in pilot.scenes {
+            XCTAssertFalse(scene.timeMarker.isEmpty)
+            XCTAssertFalse(scene.actionVerb.isEmpty)
+            XCTAssertFalse(scene.meaning.isEmpty)
+            XCTAssertFalse(scene.placeAnchors.isEmpty)
+            XCTAssertEqual(scene.quizItems.first?.hintLadder.count, 3)
+            XCTAssertEqual(scene.chronicleReward.unlockedBySceneID, scene.id)
+            XCTAssertFalse(scene.reviewSeeds.isEmpty)
+        }
+
+        let matchIDs = Set(pilot.scenes.flatMap(\.matchPairs).map(\.id))
+        XCTAssertEqual(matchIDs.count, pilot.scenes.flatMap(\.matchPairs).count)
+    }
+
     func testLessonStorePreviewsChronicleRewardsBeforeUnlockingThem() throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
         defaults.removePersistentDomain(forName: #function)

--- a/docs/specs/000-index.md
+++ b/docs/specs/000-index.md
@@ -18,5 +18,6 @@ Use this directory for durable product and technical specifications.
 
 ## Active highlighted specs
 
+- `2026-04-30-shivaji-learn-quiz-reset-implementation-spec.md` - #126 gameplay reset direction. Older gameplay specs are pre-reset exploration unless explicitly reused here or in later #126 follow-ups.
 - `2026-04-19-main-ux-iteration-spec.md`
 - `2026-04-20-responsive-design-system-spec.md`

--- a/docs/specs/2026-04-12-shivaji-maharaj-story-map-timeline-lesson-flow.md
+++ b/docs/specs/2026-04-12-shivaji-maharaj-story-map-timeline-lesson-flow.md
@@ -6,6 +6,8 @@
 - Owner: @ganesh47
 - Last updated: 2026-04-12
 
+> Reset note (2026-04-30): #126 is now the gameplay reset anchor. This six-scene story/map/timeline flow remains useful content exploration, but the active MVP pilot is the three-scene learn-and-quiz Chronicle loop in `2026-04-30-shivaji-learn-quiz-reset-implementation-spec.md`.
+
 ## Purpose
 
 Define the canonical V1 lesson flow for Shivaji Maharaj in Greats of Bharatha.

--- a/docs/specs/2026-04-19-main-ux-iteration-spec.md
+++ b/docs/specs/2026-04-19-main-ux-iteration-spec.md
@@ -6,6 +6,8 @@
 - Owner: @ganesh47
 - Last updated: 2026-04-19
 
+> Reset note (2026-04-30): #126 supersedes this as the main gameplay direction. Treat this document as pre-reset UX exploration unless a later #126 implementation spec explicitly reuses a pattern.
+
 ## Problem
 
 The latest successful `iOS UI Review (main)` CI artifact run on `main` shows that the product direction is coherent, but the current UX still reads as a careful prototype rather than a compelling child-learning experience.

--- a/docs/specs/2026-04-30-shivaji-learn-quiz-reset-implementation-spec.md
+++ b/docs/specs/2026-04-30-shivaji-learn-quiz-reset-implementation-spec.md
@@ -1,0 +1,165 @@
+# Shivaji learn-and-quiz reset implementation spec
+
+- Status: Draft
+- Linked issue: #126
+- Planning comment: https://github.com/ganesh47/greatsofbharatha/issues/126#issuecomment-4351294484
+- Owner: @ganesh47
+- Last updated: 2026-04-30
+
+## Reset decision
+
+Issue #126 is the gameplay reset anchor for the Shivaji MVP. The product direction is now:
+
+> A fun learn-and-quiz app where kids build a memorable Chronicle of Shivaji Maharaj through time, place, and action.
+
+Older gameplay specs and UX explorations remain useful reference material, but they are pre-reset exploration unless this spec or a later #126 follow-up explicitly reuses a mechanic. Do not polish the old gameplay path as the main MVP center.
+
+## Related specs
+
+- `2026-04-12-shivaji-maharaj-story-map-timeline-lesson-flow.md` - six-scene pre-reset content exploration.
+- `2026-04-18-shivaji-content-schema.md` - current alpha schema for existing `HeroArc`/`SceneCluster` data.
+- `2026-04-19-main-ux-iteration-spec.md` - pre-reset UX iteration notes.
+- `2026-04-20-responsive-design-system-spec.md` - reusable design guidance that can still inform reset UI.
+
+## Product promise
+
+For each historical figure, children should remember:
+
+- Time: what came before and after.
+- Place: forts, regions, terrain, capitals, and routes.
+- Action: what the figure did, decided, endured, built, or protected.
+- Meaning: why it matters in child-safe language.
+- Memory proof: recall, match, order, and explain before the Chronicle deepens.
+
+## MVP loop
+
+Each pilot scene should follow the same small loop:
+
+1. Learn card with one illustrated episode.
+2. Memory hook with one sticky phrase.
+3. Quick retrieval quiz.
+4. Mini-game reinforcement through match, order, tap place, or flashcard.
+5. Chronicle unlock or deepen event.
+6. Spaced review seed based on correctness and hint use.
+
+## Feature flag and routing
+
+Use `historyLearnQuizResetEnabled` as the reset gate. In the current PR, the safe implementation surface is:
+
+- environment flag: `GOB_HISTORY_LEARN_QUIZ_RESET_ENABLED=1`
+- default behavior: off, existing app route unchanged
+- capture placeholder route: `GOB_CAPTURE_ROUTE=learn-quiz-reset`
+
+The placeholder exists only to prove route isolation and content availability. Full reset UI work belongs in later #126 PRs.
+
+## Pilot content contract
+
+The first shippable pilot is exactly three scenes:
+
+1. Shivneri - Birth Fort
+2. Torna and Rajgad - Early Forts
+3. Pratapgad - Turning Point
+
+The Swift fixture source of truth for this pilot is `SampleContent.shivajiLearnQuizResetPilot`.
+
+### Scene 1: Shivneri - Birth Fort
+
+- Time: beginning of the journey
+- Place: Shivneri Fort, Junnar region
+- Action: childhood begins under Jijabai's guidance
+- Meaning: Shivneri anchors the beginning and the values carried forward
+- Memory hook: Birth Fort
+- Quiz: Where does Shivaji Maharaj's story begin?
+- Hints:
+  - Think of the Birth Fort.
+  - It is the fort near Junnar where the story begins.
+  - Choose Shivneri.
+- Match pairs:
+  - Shivneri <-> Birth Fort
+  - Shivneri <-> Story begins
+- Chronicle reward: Birth Fort Chronicle Card
+- Review prompt: Birth Fort -> Shivneri
+
+### Scene 2: Torna and Rajgad - Early Forts
+
+- Time: early Swarajya-building
+- Place: Torna and Rajgad
+- Action: wins an early fort and builds a planning base
+- Meaning: the early forts show building and planning, not only winning
+- Memory hooks: First Big Fort, Early Capital
+- Quiz: Which fort became an early capital?
+- Hints:
+  - Think of Early Capital.
+  - Torna is the First Big Fort; the other fort became the planning base.
+  - Choose Rajgad.
+- Match pairs:
+  - Torna <-> First Big Fort
+  - Rajgad <-> Early Capital
+  - Rajgad <-> Planning base
+- Chronicle reward: First Fort / Early Capital Card
+- Review prompt: First Big Fort / Early Capital -> Torna / Rajgad
+
+### Scene 3: Pratapgad - Turning Point
+
+- Time: major rise and turning point
+- Place: Pratapgad, hill terrain near Mahabaleshwar
+- Action: plans with courage and terrain awareness
+- Meaning: preparation and terrain changed the balance at a key moment
+- Memory hook: Turning Point
+- Quiz: Which fort is remembered as the turning point?
+- Hints:
+  - Think of Turning Point.
+  - It stands in hill country near Mahabaleshwar.
+  - Choose Pratapgad.
+- Match pairs:
+  - Pratapgad <-> Turning Point
+  - Planning and terrain <-> Changed the balance
+- Chronicle reward: Turning Point Seal
+- Review prompt: Turning Point -> Pratapgad
+
+## Timeline builder seed
+
+Pilot order:
+
+1. Shivneri
+2. Torna/Rajgad
+3. Pratapgad
+
+Completion reward: the Chronicle gains a Journey So Far timeline strip.
+
+## Data contracts
+
+Use the reset-specific models for new learn-and-quiz work:
+
+- `HistoricalFigureArc`
+- `ChronicleScene`
+- `PlaceAnchor`
+- `QuizItem`
+- `MatchPair`
+- `TimelineBuilderSeed`
+- `ReviewSeed`
+
+Keep `HeroArc`, `SceneCluster`, and the existing six-scene sample available for old/pre-reset UI until replacement is proven. Later PRs may add pure engines for quiz evaluation, match completion, review scheduling, and Chronicle deepening against these reset contracts.
+
+## Child UX principles
+
+- Retrieval first: ask the child to pull from memory before relying on recognition.
+- Kind recovery: wrong answers rebuild the hook without shame.
+- Low anxiety: no lives, harsh fail states, public scoring, or punishment loops.
+- Interleaving: rotate place, time, action, and meaning prompts.
+- Chronicle as evidence: rewards should show remembered history, not generic loot.
+
+## Non-goals for PR1
+
+- Do not delete old gameplay or the six-scene Shivaji arc.
+- Do not build the full reset UI.
+- Do not implement quiz, match, scheduler, or Chronicle reward engines yet.
+- Do not add new generated art.
+- Do not make `historyLearnQuizResetEnabled` default-on.
+
+## Follow-up PRs
+
+1. Pure learning engines: quiz, match, review scheduler, Chronicle progress.
+2. Isolated UI: reset home, learn card, quiz, match, Chronicle book shell.
+3. Shivneri vertical slice: learn card -> quiz -> match -> reward -> review seed.
+4. Full three-scene pilot: timeline builder, flashcards, and review evidence.


### PR DESCRIPTION
## Summary

- Adds `docs/specs/2026-04-30-shivaji-learn-quiz-reset-implementation-spec.md` as the #126 gameplay reset anchor.
- Marks older Shivaji gameplay/UX docs as pre-reset exploration without deleting them.
- Adds reset-specific Swift contracts and a 3-scene Shivaji learn-and-quiz pilot fixture covering Shivneri, Torna/Rajgad, and Pratapgad.
- Adds a safe `historyLearnQuizResetEnabled` route placeholder via `GOB_HISTORY_LEARN_QUIZ_RESET_ENABLED=1` and `GOB_CAPTURE_ROUTE=learn-quiz-reset`.
- Adds unit-test coverage for the reset pilot content contract.

Part of #126 for PR1 spec/content/contracts scope; follow-up PRs should build the engines and UI slices described in the spec.

## Validation

- `git diff --check` passed.
- `xcodebuild -version` blocked: `xcodebuild` is not installed in this Linux worktree.
- `swift --version` / `swift test` blocked: `swift` is not installed in this Linux worktree.

## Notes

The old six-scene Shivaji sample and default route remain intact. The reset route is opt-in only.