### PR TITLE
[codex] Add pure learning engines for Chronicle pilot

### DIFF
--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C5A02CDD2D6DA5162F535 /* MasteryState.swift */; };
 		07FB948684566346F8B09A98 /* GBSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6043F267C6727A816F8CE8 /* GBSpacing.swift */; };
 		0C3412C4E22C4B63092DB4BE /* DebugNavigationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */; };
+		0F60391B69E871D92A190695 /* LearningEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DA6906D09845768BD10894 /* LearningEnginesTests.swift */; };
 		16E40D4D9552B57A027D9FF5 /* StoryHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA3B33CD2FFC1A53263C40A /* StoryHomeView.swift */; };
 		229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE540544C5E9622DB91B7EF8 /* ContentView.swift */; };
 		22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB428856E6E0B33ECEAA8E36 /* LessonHomeView.swift */; };
@@ -27,6 +28,7 @@
 		57A372CC37EE9EDD83A56710 /* GBTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA553A6C52FF405536FB4B58 /* GBTypography.swift */; };
 		59DDE6A3CB3C27E2595A3085 /* GBSceneCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB52F4EF3B015973D3C6D088 /* GBSceneCard.swift */; };
 		5BD4A172E915378D3A9CC856 /* GBShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891FE8601621FF7A7BDE9AC6 /* GBShadow.swift */; };
+		5F221219F078C24A391DF518 /* LearningEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0445C80B266E35D8784D6E /* LearningEngines.swift */; };
 		608CCC7416A6F35837C15A04 /* TimelineHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E8E42D945004543238A06E /* TimelineHubView.swift */; };
 		6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */; };
 		86E2FF6E624F8374636950E5 /* README_BOOTSTRAP.md in Resources */ = {isa = PBXBuildFile; fileRef = AF8E819340759100DB074CD4 /* README_BOOTSTRAP.md */; };
@@ -73,6 +75,8 @@
 		1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugNavigationRoute.swift; sourceTree = "<group>"; };
 		2E1F22519D406A575588CE02 /* GBLayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBLayoutContext.swift; sourceTree = "<group>"; };
 		30766CF8C2332F9E648E275A /* GBSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSectionHeader.swift; sourceTree = "<group>"; };
+		2D0445C80B266E35D8784D6E /* LearningEngines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEngines.swift; sourceTree = "<group>"; };
+		35DA6906D09845768BD10894 /* LearningEnginesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEnginesTests.swift; sourceTree = "<group>"; };
 		35DD7C78E273FA67916C2743 /* GBHeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBHeroCard.swift; sourceTree = "<group>"; };
 		38AE753749107F40681898D3 /* GreatsOfBharathaTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = GreatsOfBharathaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		40039999B2C8D4999FB8C254 /* LessonFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonFeedback.swift; sourceTree = "<group>"; };
@@ -124,6 +128,7 @@
 				6413C33179A188AA0729938F /* AppModel.swift */,
 				842D0166597E3756A21D8739 /* ContentModels.swift */,
 				B69947B828E9DD4B794FBE0A /* HeroArcModels.swift */,
+				2D0445C80B266E35D8784D6E /* LearningEngines.swift */,
 				901C5A02CDD2D6DA5162F535 /* MasteryState.swift */,
 				71BEDED465CA437D09ADDCD5 /* SampleContent.swift */,
 				C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */,
@@ -144,6 +149,7 @@
 			isa = PBXGroup;
 			children = (
 				85B8DF1FEE4414FC115FD0F1 /* GreatsOfBharathaTests.swift */,
+				35DA6906D09845768BD10894 /* LearningEnginesTests.swift */,
 			);
 			path = GreatsOfBharathaTests;
 			sourceTree = "<group>";
@@ -450,6 +456,7 @@
 				57A372CC37EE9EDD83A56710 /* GBTypography.swift in Sources */,
 				3CE894040C86BE6F34F93C13 /* GreatsOfBharathaApp.swift in Sources */,
 				3C4FB3ADBB894FDAC9244FBA /* HeroArcModels.swift in Sources */,
+				5F221219F078C24A391DF518 /* LearningEngines.swift in Sources */,
 				98B47696937C9BCD2D0E9235 /* LessonFeedback.swift in Sources */,
 				22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */,
 				073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */,
@@ -469,6 +476,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E192EA45F4DF6C39007360F9 /* GreatsOfBharathaTests.swift in Sources */,
+				0F60391B69E871D92A190695 /* LearningEnginesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -12,8 +12,8 @@
 		073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C5A02CDD2D6DA5162F535 /* MasteryState.swift */; };
 		07FB948684566346F8B09A98 /* GBSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6043F267C6727A816F8CE8 /* GBSpacing.swift */; };
 		0C3412C4E22C4B63092DB4BE /* DebugNavigationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */; };
-		0F60391B69E871D92A190695 /* LearningEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DA6906D09845768BD10894 /* LearningEnginesTests.swift */; };
 		16E40D4D9552B57A027D9FF5 /* StoryHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA3B33CD2FFC1A53263C40A /* StoryHomeView.swift */; };
+		1D46FB6ECD9C7608AF1C984E /* LearningEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E960C45C97D2EAE06A7FBBB /* LearningEnginesTests.swift */; };
 		229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE540544C5E9622DB91B7EF8 /* ContentView.swift */; };
 		22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB428856E6E0B33ECEAA8E36 /* LessonHomeView.swift */; };
 		2ABB675D9B13E6BC94627094 /* GBSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD34478F7C8BC5F5EE50AD37 /* GBSurface.swift */; };
@@ -28,7 +28,7 @@
 		57A372CC37EE9EDD83A56710 /* GBTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA553A6C52FF405536FB4B58 /* GBTypography.swift */; };
 		59DDE6A3CB3C27E2595A3085 /* GBSceneCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB52F4EF3B015973D3C6D088 /* GBSceneCard.swift */; };
 		5BD4A172E915378D3A9CC856 /* GBShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891FE8601621FF7A7BDE9AC6 /* GBShadow.swift */; };
-		5F221219F078C24A391DF518 /* LearningEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0445C80B266E35D8784D6E /* LearningEngines.swift */; };
+		5D281628DB3CC42AD77F0D7A /* LearningEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390AE8B48E7C52C376816E87 /* LearningEngines.swift */; };
 		608CCC7416A6F35837C15A04 /* TimelineHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E8E42D945004543238A06E /* TimelineHubView.swift */; };
 		6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */; };
 		86E2FF6E624F8374636950E5 /* README_BOOTSTRAP.md in Resources */ = {isa = PBXBuildFile; fileRef = AF8E819340759100DB074CD4 /* README_BOOTSTRAP.md */; };
@@ -44,6 +44,7 @@
 		ADBA27254FB49C8AC53B58C6 /* GBButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C0CC899F030C472E7720F0 /* GBButtonStyle.swift */; };
 		B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842D0166597E3756A21D8739 /* ContentModels.swift */; };
 		C3C8E7616436D7F22238B09C /* AppleMapsPlaceHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */; };
+		C59E6685BB680CF41B71A059 /* GBChildSafeAIPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2855D2317D822D5995E534DE /* GBChildSafeAIPlan.swift */; };
 		CD55EED6E4B1DFC5B1F20BCD /* ParentProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF974097779D0836FBDE59DD /* ParentProgressView.swift */; };
 		CE9E2F14877988A61A031337 /* GBChronicleCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0244C418BCB073D7CD511F45 /* GBChronicleCard.swift */; };
 		CF5BE7783A5885A44F0DF9D5 /* GBRecallPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E79CCE23974B1F749235073 /* GBRecallPrompt.swift */; };
@@ -73,12 +74,13 @@
 		0C84A1BE87F4CAA5D6281AD6 /* SceneLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLessonView.swift; sourceTree = "<group>"; };
 		1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMapsPlaceHandoff.swift; sourceTree = "<group>"; };
 		1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugNavigationRoute.swift; sourceTree = "<group>"; };
+		2855D2317D822D5995E534DE /* GBChildSafeAIPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBChildSafeAIPlan.swift; sourceTree = "<group>"; };
 		2E1F22519D406A575588CE02 /* GBLayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBLayoutContext.swift; sourceTree = "<group>"; };
+		2E960C45C97D2EAE06A7FBBB /* LearningEnginesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEnginesTests.swift; sourceTree = "<group>"; };
 		30766CF8C2332F9E648E275A /* GBSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSectionHeader.swift; sourceTree = "<group>"; };
-		2D0445C80B266E35D8784D6E /* LearningEngines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEngines.swift; sourceTree = "<group>"; };
-		35DA6906D09845768BD10894 /* LearningEnginesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEnginesTests.swift; sourceTree = "<group>"; };
 		35DD7C78E273FA67916C2743 /* GBHeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBHeroCard.swift; sourceTree = "<group>"; };
 		38AE753749107F40681898D3 /* GreatsOfBharathaTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = GreatsOfBharathaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		390AE8B48E7C52C376816E87 /* LearningEngines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEngines.swift; sourceTree = "<group>"; };
 		40039999B2C8D4999FB8C254 /* LessonFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonFeedback.swift; sourceTree = "<group>"; };
 		596CBD0FA93B029F56E14FDF /* GBBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBBadge.swift; sourceTree = "<group>"; };
 		5A6043F267C6727A816F8CE8 /* GBSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSpacing.swift; sourceTree = "<group>"; };
@@ -128,7 +130,7 @@
 				6413C33179A188AA0729938F /* AppModel.swift */,
 				842D0166597E3756A21D8739 /* ContentModels.swift */,
 				B69947B828E9DD4B794FBE0A /* HeroArcModels.swift */,
-				2D0445C80B266E35D8784D6E /* LearningEngines.swift */,
+				390AE8B48E7C52C376816E87 /* LearningEngines.swift */,
 				901C5A02CDD2D6DA5162F535 /* MasteryState.swift */,
 				71BEDED465CA437D09ADDCD5 /* SampleContent.swift */,
 				C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */,
@@ -149,7 +151,7 @@
 			isa = PBXGroup;
 			children = (
 				85B8DF1FEE4414FC115FD0F1 /* GreatsOfBharathaTests.swift */,
-				35DA6906D09845768BD10894 /* LearningEnginesTests.swift */,
+				2E960C45C97D2EAE06A7FBBB /* LearningEnginesTests.swift */,
 			);
 			path = GreatsOfBharathaTests;
 			sourceTree = "<group>";
@@ -300,6 +302,7 @@
 		D1CA5C958078395C8E7ADE1B /* Intelligence */ = {
 			isa = PBXGroup;
 			children = (
+				2855D2317D822D5995E534DE /* GBChildSafeAIPlan.swift */,
 				C552711CAEFFD3AB955E26E7 /* GBIntelligenceHint.swift */,
 				CCE07361DC3C1D6D864BB326 /* GBNLRecallEvaluator.swift */,
 			);
@@ -435,6 +438,7 @@
 				DF919F38C0D6D11586812C90 /* GBBadge.swift in Sources */,
 				ADBA27254FB49C8AC53B58C6 /* GBButtonStyle.swift in Sources */,
 				89E3FE1D90324B34D697C540 /* GBCardStyle.swift in Sources */,
+				C59E6685BB680CF41B71A059 /* GBChildSafeAIPlan.swift in Sources */,
 				CE9E2F14877988A61A031337 /* GBChronicleCard.swift in Sources */,
 				8B7734948D0D0BE63E8E43B9 /* GBColor.swift in Sources */,
 				8B6F5ED2AC090236774D73A1 /* GBFlashCard.swift in Sources */,
@@ -456,7 +460,7 @@
 				57A372CC37EE9EDD83A56710 /* GBTypography.swift in Sources */,
 				3CE894040C86BE6F34F93C13 /* GreatsOfBharathaApp.swift in Sources */,
 				3C4FB3ADBB894FDAC9244FBA /* HeroArcModels.swift in Sources */,
-				5F221219F078C24A391DF518 /* LearningEngines.swift in Sources */,
+				5D281628DB3CC42AD77F0D7A /* LearningEngines.swift in Sources */,
 				98B47696937C9BCD2D0E9235 /* LessonFeedback.swift in Sources */,
 				22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */,
 				073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */,
@@ -476,7 +480,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E192EA45F4DF6C39007360F9 /* GreatsOfBharathaTests.swift in Sources */,
-				0F60391B69E871D92A190695 /* LearningEnginesTests.swift in Sources */,
+				1D46FB6ECD9C7608AF1C984E /* LearningEnginesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GreatsOfBharatha/Shared/Models/LearningEngines.swift
+++ b/GreatsOfBharatha/Shared/Models/LearningEngines.swift
@@ -1,0 +1,565 @@
+import Foundation
+
+enum ChronicleQuizAttemptKind: Codable, Equatable {
+    case correctWithoutHint
+    case correctWithHint
+    case rescuedRecognition
+    case incorrect
+}
+
+struct ChronicleQuizState: Codable, Equatable {
+    var typedAnswer: String
+    var selectedAnswer: String?
+    var revealedHintCount: Int
+    var recognitionRescueUnlocked: Bool
+    var attempts: Int
+
+    init(
+        typedAnswer: String = "",
+        selectedAnswer: String? = nil,
+        revealedHintCount: Int = 0,
+        recognitionRescueUnlocked: Bool = false,
+        attempts: Int = 0
+    ) {
+        self.typedAnswer = typedAnswer
+        self.selectedAnswer = selectedAnswer
+        self.revealedHintCount = revealedHintCount
+        self.recognitionRescueUnlocked = recognitionRescueUnlocked
+        self.attempts = attempts
+    }
+}
+
+struct ChronicleQuizResult: Codable, Equatable {
+    let kind: ChronicleQuizAttemptKind
+    let isCorrect: Bool
+    let masteryAwarded: MasteryState
+    let feedback: String
+    let nextState: ChronicleQuizState
+
+    var shouldUseSoonReview: Bool {
+        switch kind {
+        case .correctWithoutHint:
+            return false
+        case .correctWithHint, .rescuedRecognition, .incorrect:
+            return true
+        }
+    }
+}
+
+enum ChronicleQuizEngine {
+    static func normalizedAnswer(_ text: String) -> String {
+        let folded = text.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        let scalars = folded.unicodeScalars.map { scalar in
+            CharacterSet.alphanumerics.contains(scalar) ? Character(scalar) : " "
+        }
+        return String(scalars)
+            .split(separator: " ")
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func answerMatches(_ answer: String, challenge: RecallChallenge) -> Bool {
+        let candidate = normalizedAnswer(answer)
+        guard !candidate.isEmpty else { return false }
+
+        return challenge.correctAnswers.contains { correctAnswer in
+            let normalizedCorrectAnswer = normalizedAnswer(correctAnswer)
+            return candidate == normalizedCorrectAnswer
+                || candidate.hasPrefix(normalizedCorrectAnswer + " ")
+                || normalizedCorrectAnswer.hasPrefix(candidate + " ")
+        }
+    }
+
+    static func currentHint(for state: ChronicleQuizState, challenge: RecallChallenge) -> RecallHint? {
+        guard state.revealedHintCount > 0 else { return nil }
+        let index = min(state.revealedHintCount - 1, challenge.hintLadder.count - 1)
+        guard challenge.hintLadder.indices.contains(index) else { return nil }
+        return challenge.hintLadder[index]
+    }
+
+    static func revealNextHint(from state: ChronicleQuizState, challenge: RecallChallenge) -> ChronicleQuizState {
+        var nextState = state
+        if nextState.revealedHintCount < challenge.hintLadder.count {
+            nextState.revealedHintCount += 1
+        } else {
+            nextState.recognitionRescueUnlocked = true
+        }
+        return nextState
+    }
+
+    static func evaluate(
+        state: ChronicleQuizState,
+        challenge: RecallChallenge,
+        typedAnswer: String? = nil,
+        selectedAnswer: String? = nil
+    ) -> ChronicleQuizResult {
+        var nextState = state
+        if let typedAnswer {
+            nextState.typedAnswer = typedAnswer
+        }
+        if let selectedAnswer {
+            nextState.selectedAnswer = selectedAnswer
+        }
+        nextState.attempts += 1
+
+        let candidateAnswer = normalizedAnswer(nextState.typedAnswer).isEmpty
+            ? (nextState.selectedAnswer ?? "")
+            : nextState.typedAnswer
+
+        if answerMatches(candidateAnswer, challenge: challenge) {
+            let kind: ChronicleQuizAttemptKind = nextState.recognitionRescueUnlocked
+                ? .rescuedRecognition
+                : (nextState.revealedHintCount == 0 ? .correctWithoutHint : .correctWithHint)
+            return ChronicleQuizResult(
+                kind: kind,
+                isCorrect: true,
+                masteryAwarded: challenge.masteryContribution,
+                feedback: challenge.feedback.success,
+                nextState: nextState
+            )
+        }
+
+        nextState = revealNextHint(from: nextState, challenge: challenge)
+        let feedback: String
+        if let hint = currentHint(for: nextState, challenge: challenge) {
+            feedback = "Try again. \(hint.title): \(hint.body)"
+        } else {
+            feedback = challenge.feedback.recovery
+        }
+
+        return ChronicleQuizResult(
+            kind: nextState.recognitionRescueUnlocked ? .rescuedRecognition : .incorrect,
+            isCorrect: false,
+            masteryAwarded: .witnessed,
+            feedback: feedback,
+            nextState: nextState
+        )
+    }
+}
+
+enum ChronicleMatchPairKind: String, Codable, CaseIterable, Equatable {
+    case placeToHook
+    case placeToAction
+    case eventToTimeMarker
+    case meaningToScene
+}
+
+struct ChronicleMatchPair: Identifiable, Codable, Equatable {
+    let id: String
+    let leftID: String
+    let leftText: String
+    let rightID: String
+    let rightText: String
+    let kind: ChronicleMatchPairKind
+    let teachingClue: String
+}
+
+enum ChronicleMatchTileSide: String, Codable, Equatable {
+    case left
+    case right
+}
+
+struct ChronicleMatchTile: Identifiable, Codable, Equatable {
+    let id: String
+    let pairID: String
+    let side: ChronicleMatchTileSide
+    let text: String
+}
+
+enum ChronicleMatchSelectionOutcome: Codable, Equatable {
+    case selected(ChronicleMatchTile)
+    case matched(pairID: String, feedback: String, completedSet: Bool)
+    case mismatched(clue: String)
+    case ignored
+}
+
+struct ChronicleMatchState: Codable, Equatable {
+    var selectedTileID: String?
+    var completedPairIDs: Set<String>
+    var mismatchCount: Int
+    var lastOutcome: ChronicleMatchSelectionOutcome?
+
+    init(
+        selectedTileID: String? = nil,
+        completedPairIDs: Set<String> = [],
+        mismatchCount: Int = 0,
+        lastOutcome: ChronicleMatchSelectionOutcome? = nil
+    ) {
+        self.selectedTileID = selectedTileID
+        self.completedPairIDs = completedPairIDs
+        self.mismatchCount = mismatchCount
+        self.lastOutcome = lastOutcome
+    }
+}
+
+enum ChronicleMatchEngine {
+    static func tiles(for pairs: [ChronicleMatchPair], shuffleSeed: Int? = nil) -> [ChronicleMatchTile] {
+        let tiles = pairs.flatMap { pair in
+            [
+                ChronicleMatchTile(id: pair.leftID, pairID: pair.id, side: .left, text: pair.leftText),
+                ChronicleMatchTile(id: pair.rightID, pairID: pair.id, side: .right, text: pair.rightText),
+            ]
+        }
+
+        guard let shuffleSeed else { return tiles }
+        return seededShuffle(tiles, seed: shuffleSeed)
+    }
+
+    static func select(tileID: String, state: ChronicleMatchState, pairs: [ChronicleMatchPair]) -> ChronicleMatchState {
+        let tiles = tiles(for: pairs)
+        guard let tile = tiles.first(where: { $0.id == tileID }) else {
+            var nextState = state
+            nextState.lastOutcome = .ignored
+            return nextState
+        }
+        guard !state.completedPairIDs.contains(tile.pairID) else {
+            var nextState = state
+            nextState.lastOutcome = .ignored
+            return nextState
+        }
+        guard let selectedTileID = state.selectedTileID else {
+            var nextState = state
+            nextState.selectedTileID = tile.id
+            nextState.lastOutcome = .selected(tile)
+            return nextState
+        }
+        guard selectedTileID != tile.id else {
+            var nextState = state
+            nextState.selectedTileID = nil
+            nextState.lastOutcome = .ignored
+            return nextState
+        }
+        guard let selectedTile = tiles.first(where: { $0.id == selectedTileID }) else {
+            var nextState = state
+            nextState.selectedTileID = tile.id
+            nextState.lastOutcome = .selected(tile)
+            return nextState
+        }
+
+        var nextState = state
+        nextState.selectedTileID = nil
+
+        if selectedTile.pairID == tile.pairID && selectedTile.side != tile.side {
+            nextState.completedPairIDs.insert(tile.pairID)
+            nextState.lastOutcome = .matched(
+                pairID: tile.pairID,
+                feedback: "Yes. \(selectedTile.text) belongs with \(tile.text).",
+                completedSet: nextState.completedPairIDs.count == pairs.count
+            )
+            return nextState
+        }
+
+        nextState.mismatchCount += 1
+        let clue = mismatchClue(first: selectedTile, second: tile, pairs: pairs)
+        nextState.lastOutcome = .mismatched(clue: clue)
+        return nextState
+    }
+
+    private static func mismatchClue(first: ChronicleMatchTile, second: ChronicleMatchTile, pairs: [ChronicleMatchPair]) -> String {
+        let preferredPairID = first.side == .left ? first.pairID : second.pairID
+        if let pair = pairs.first(where: { $0.id == preferredPairID }) {
+            return pair.teachingClue
+        }
+        return "Look for the memory hook that belongs with this place."
+    }
+
+    private static func seededShuffle<T>(_ values: [T], seed: Int) -> [T] {
+        guard values.count > 1 else { return values }
+        var shuffled = values
+        var generator = SeededNumberGenerator(seed: UInt64(abs(seed) + 1))
+
+        for index in stride(from: shuffled.count - 1, through: 1, by: -1) {
+            let swapIndex = Int(generator.next() % UInt64(index + 1))
+            shuffled.swapAt(index, swapIndex)
+        }
+        return shuffled
+    }
+}
+
+private struct SeededNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state = 6364136223846793005 &* state &+ 1442695040888963407
+        return state
+    }
+}
+
+enum LearningReviewResponse: String, Codable, CaseIterable, Equatable {
+    case knewIt
+    case neededClue
+    case teachAgain
+}
+
+struct LearningReviewSeed: Identifiable, Codable, Equatable {
+    let id: String
+    let subjectID: String
+    let subjectType: MasterySubjectType
+    let promptTypes: [RecallPromptType]
+    let cadenceDays: [Int]
+}
+
+struct LearningReviewSchedulingResult: Codable, Equatable {
+    let schedule: ReviewSchedule
+    let nextPromptType: RecallPromptType
+    let shouldReviewInCurrentSession: Bool
+}
+
+enum SpacedReviewScheduler {
+    static func makeInitialSchedule(from seed: LearningReviewSeed, now: Date) -> ReviewSchedule {
+        ReviewSchedule(
+            subjectID: seed.subjectID,
+            subjectType: seed.subjectType,
+            nextDueAt: now,
+            intervalIndex: 0,
+            stabilityBand: .new,
+            difficultyAdjustment: 0,
+            cadenceDays: seed.cadenceDays.isEmpty ? [0, 1, 3, 7, 14] : seed.cadenceDays
+        )
+    }
+
+    static func schedule(
+        _ schedule: ReviewSchedule,
+        after quizResult: ChronicleQuizResult,
+        promptHistory: [RecallPromptType],
+        now: Date,
+        calendar: Calendar = .current
+    ) -> LearningReviewSchedulingResult {
+        let response: LearningReviewResponse
+        switch quizResult.kind {
+        case .correctWithoutHint:
+            response = .knewIt
+        case .correctWithHint:
+            response = .neededClue
+        case .rescuedRecognition, .incorrect:
+            response = .teachAgain
+        }
+
+        return schedule(schedule, after: response, promptHistory: promptHistory, now: now, calendar: calendar)
+    }
+
+    static func schedule(
+        _ schedule: ReviewSchedule,
+        after response: LearningReviewResponse,
+        promptHistory: [RecallPromptType],
+        now: Date,
+        calendar: Calendar = .current
+    ) -> LearningReviewSchedulingResult {
+        var nextSchedule = schedule
+        let shouldReviewInCurrentSession: Bool
+
+        switch response {
+        case .knewIt:
+            nextSchedule.intervalIndex = min(schedule.intervalIndex + 1, max(schedule.cadenceDays.count - 1, 0))
+            shouldReviewInCurrentSession = false
+        case .neededClue:
+            nextSchedule.intervalIndex = max(schedule.intervalIndex, min(1, max(schedule.cadenceDays.count - 1, 0)))
+            shouldReviewInCurrentSession = false
+        case .teachAgain:
+            nextSchedule.intervalIndex = 0
+            shouldReviewInCurrentSession = true
+        }
+
+        nextSchedule.stabilityBand = stabilityBand(for: nextSchedule.intervalIndex)
+        nextSchedule.difficultyAdjustment = difficultyAdjustment(for: response, current: schedule.difficultyAdjustment)
+        nextSchedule.nextDueAt = nextDueAt(
+            for: response,
+            schedule: nextSchedule,
+            now: now,
+            calendar: calendar
+        )
+
+        return LearningReviewSchedulingResult(
+            schedule: nextSchedule,
+            nextPromptType: nextPromptType(after: promptHistory),
+            shouldReviewInCurrentSession: shouldReviewInCurrentSession
+        )
+    }
+
+    static func dueReviews(from schedules: [ReviewSchedule], now: Date) -> [ReviewSchedule] {
+        schedules
+            .filter { $0.nextDueAt <= now }
+            .sorted { lhs, rhs in
+                if lhs.nextDueAt == rhs.nextDueAt {
+                    return lhs.subjectID < rhs.subjectID
+                }
+                return lhs.nextDueAt < rhs.nextDueAt
+            }
+    }
+
+    static func nextPromptType(after history: [RecallPromptType]) -> RecallPromptType {
+        let rotation: [RecallPromptType] = [.openPrompt, .eventToPlaceMatch, .sequenceSlot, .compareFromMemory]
+        guard let last = history.last, let index = rotation.firstIndex(of: last) else {
+            return rotation[0]
+        }
+        return rotation[(index + 1) % rotation.count]
+    }
+
+    private static func nextDueAt(
+        for response: LearningReviewResponse,
+        schedule: ReviewSchedule,
+        now: Date,
+        calendar: Calendar
+    ) -> Date {
+        switch response {
+        case .knewIt:
+            let days = schedule.cadenceDays.isEmpty ? 1 : max(schedule.cadenceDays[schedule.intervalIndex], 1)
+            return calendar.date(byAdding: .day, value: days, to: now) ?? now.addingTimeInterval(24 * 60 * 60)
+        case .neededClue:
+            return calendar.date(byAdding: .hour, value: 4, to: now) ?? now.addingTimeInterval(4 * 60 * 60)
+        case .teachAgain:
+            return now
+        }
+    }
+
+    private static func stabilityBand(for intervalIndex: Int) -> ReviewStabilityBand {
+        switch intervalIndex {
+        case 0:
+            return .new
+        case 1:
+            return .warming
+        case 2...3:
+            return .steady
+        default:
+            return .durable
+        }
+    }
+
+    private static func difficultyAdjustment(for response: LearningReviewResponse, current: Int) -> Int {
+        switch response {
+        case .knewIt:
+            return max(current - 1, -2)
+        case .neededClue:
+            return current
+        case .teachAgain:
+            return min(current + 1, 3)
+        }
+    }
+}
+
+enum ChronicleProgressEvent: String, Codable, CaseIterable, Equatable, Hashable {
+    case lessonSeen
+    case recallCorrect
+    case matchCompleted
+    case timelineCompleted
+    case reviewCorrect
+}
+
+enum ChronicleRewardDetailLevel: String, Codable, CaseIterable, Comparable, Equatable {
+    case hidden
+    case silhouette
+    case inked
+    case sealed
+    case rememberedAgain
+
+    var rank: Int {
+        switch self {
+        case .hidden:
+            return 0
+        case .silhouette:
+            return 1
+        case .inked:
+            return 2
+        case .sealed:
+            return 3
+        case .rememberedAgain:
+            return 4
+        }
+    }
+
+    static func < (lhs: ChronicleRewardDetailLevel, rhs: ChronicleRewardDetailLevel) -> Bool {
+        lhs.rank < rhs.rank
+    }
+}
+
+struct ChronicleRewardProgress: Identifiable, Codable, Equatable {
+    let id: String
+    let entryID: String
+    let sceneID: String
+    var detailLevel: ChronicleRewardDetailLevel
+    var unlockState: ChronicleUnlockState
+    var completedEvents: Set<ChronicleProgressEvent>
+    var updatedAt: Date?
+
+    init(
+        entryID: String,
+        sceneID: String,
+        detailLevel: ChronicleRewardDetailLevel = .hidden,
+        unlockState: ChronicleUnlockState = .silhouette,
+        completedEvents: Set<ChronicleProgressEvent> = [],
+        updatedAt: Date? = nil
+    ) {
+        self.id = entryID
+        self.entryID = entryID
+        self.sceneID = sceneID
+        self.detailLevel = detailLevel
+        self.unlockState = unlockState
+        self.completedEvents = completedEvents
+        self.updatedAt = updatedAt
+    }
+}
+
+enum ChronicleProgressEngine {
+    static func initialProgress(for entry: ChronicleEntry) -> ChronicleRewardProgress {
+        ChronicleRewardProgress(entryID: entry.id, sceneID: entry.linkedSceneID)
+    }
+
+    static func apply(
+        _ event: ChronicleProgressEvent,
+        to progress: ChronicleRewardProgress,
+        at date: Date
+    ) -> ChronicleRewardProgress {
+        var nextProgress = progress
+        nextProgress.completedEvents.insert(event)
+        nextProgress.detailLevel = max(nextProgress.detailLevel, detailLevel(for: event))
+        nextProgress.unlockState = unlockState(for: nextProgress.detailLevel)
+        nextProgress.updatedAt = date
+        return nextProgress
+    }
+
+    static func apply(
+        _ events: [ChronicleProgressEvent],
+        to progress: ChronicleRewardProgress,
+        at date: Date
+    ) -> ChronicleRewardProgress {
+        events.reduce(progress) { partialResult, event in
+            apply(event, to: partialResult, at: date)
+        }
+    }
+
+    static func progress(
+        for entry: ChronicleEntry,
+        evidence: [ChronicleProgressEvent],
+        at date: Date
+    ) -> ChronicleRewardProgress {
+        apply(evidence, to: initialProgress(for: entry), at: date)
+    }
+
+    private static func detailLevel(for event: ChronicleProgressEvent) -> ChronicleRewardDetailLevel {
+        switch event {
+        case .lessonSeen:
+            return .silhouette
+        case .recallCorrect:
+            return .inked
+        case .matchCompleted, .timelineCompleted:
+            return .sealed
+        case .reviewCorrect:
+            return .rememberedAgain
+        }
+    }
+
+    private static func unlockState(for detailLevel: ChronicleRewardDetailLevel) -> ChronicleUnlockState {
+        switch detailLevel {
+        case .hidden, .silhouette:
+            return .silhouette
+        case .inked:
+            return .unlocked
+        case .sealed, .rememberedAgain:
+            return .enriched
+        }
+    }
+}

--- a/GreatsOfBharatha/Shared/Models/LearningEngines.swift
+++ b/GreatsOfBharatha/Shared/Models/LearningEngines.swift
@@ -339,7 +339,13 @@ enum SpacedReviewScheduler {
             response = .teachAgain
         }
 
-        return SpacedReviewScheduler.schedule(schedule, after: response, promptHistory: promptHistory, now: now, calendar: calendar)
+        return SpacedReviewScheduler.schedule(
+            schedule,
+            after: response,
+            promptHistory: promptHistory,
+            now: now,
+            calendar: calendar
+        )
     }
 
     static func schedule(

--- a/GreatsOfBharatha/Shared/Models/LearningEngines.swift
+++ b/GreatsOfBharatha/Shared/Models/LearningEngines.swift
@@ -121,7 +121,9 @@ enum ChronicleQuizEngine {
 
         nextState = revealNextHint(from: nextState, challenge: challenge)
         let feedback: String
-        if let hint = currentHint(for: nextState, challenge: challenge) {
+        if nextState.recognitionRescueUnlocked {
+            feedback = challenge.feedback.recovery
+        } else if let hint = currentHint(for: nextState, challenge: challenge) {
             feedback = "Try again. \(hint.title): \(hint.body)"
         } else {
             feedback = challenge.feedback.recovery

--- a/GreatsOfBharatha/Shared/Models/LearningEngines.swift
+++ b/GreatsOfBharatha/Shared/Models/LearningEngines.swift
@@ -339,7 +339,7 @@ enum SpacedReviewScheduler {
             response = .teachAgain
         }
 
-        return schedule(schedule, after: response, promptHistory: promptHistory, now: now, calendar: calendar)
+        return SpacedReviewScheduler.schedule(schedule, after: response, promptHistory: promptHistory, now: now, calendar: calendar)
     }
 
     static func schedule(

--- a/GreatsOfBharathaTests/LearningEnginesTests.swift
+++ b/GreatsOfBharathaTests/LearningEnginesTests.swift
@@ -1,0 +1,279 @@
+import XCTest
+@testable import Greats_Of_Bharatha
+
+final class LearningEnginesTests: XCTestCase {
+    func testQuizEngineAcceptsNormalizedCorrectAnswerWithoutHint() {
+        let result = ChronicleQuizEngine.evaluate(
+            state: ChronicleQuizState(),
+            challenge: shivneriChallenge,
+            typedAnswer: "  shivneri fort! "
+        )
+
+        XCTAssertTrue(result.isCorrect)
+        XCTAssertEqual(result.kind, .correctWithoutHint)
+        XCTAssertEqual(result.masteryAwarded, .understood)
+        XCTAssertFalse(result.shouldUseSoonReview)
+    }
+
+    func testQuizEngineProgressesThroughHintLadderThenRecognitionRescue() {
+        var state = ChronicleQuizState()
+
+        let firstMiss = ChronicleQuizEngine.evaluate(state: state, challenge: shivneriChallenge, typedAnswer: "Rajgad")
+        XCTAssertFalse(firstMiss.isCorrect)
+        XCTAssertEqual(firstMiss.kind, .incorrect)
+        XCTAssertEqual(firstMiss.nextState.revealedHintCount, 1)
+        XCTAssertFalse(firstMiss.nextState.recognitionRescueUnlocked)
+        XCTAssertTrue(firstMiss.feedback.contains("Birth Fort"))
+
+        state = firstMiss.nextState
+        state = ChronicleQuizEngine.evaluate(state: state, challenge: shivneriChallenge, typedAnswer: "Torna").nextState
+        state = ChronicleQuizEngine.evaluate(state: state, challenge: shivneriChallenge, typedAnswer: "Pratapgad").nextState
+        let rescued = ChronicleQuizEngine.evaluate(state: state, challenge: shivneriChallenge, typedAnswer: "Raigad")
+
+        XCTAssertFalse(rescued.isCorrect)
+        XCTAssertEqual(rescued.kind, .rescuedRecognition)
+        XCTAssertEqual(rescued.nextState.revealedHintCount, 3)
+        XCTAssertTrue(rescued.nextState.recognitionRescueUnlocked)
+        XCTAssertEqual(rescued.feedback, "Shivneri is the Birth Fort where the journey begins.")
+    }
+
+    func testQuizEngineMarksCorrectAnswerAfterHintAsCorrectWithHint() {
+        let hintedState = ChronicleQuizState(revealedHintCount: 1)
+
+        let result = ChronicleQuizEngine.evaluate(
+            state: hintedState,
+            challenge: rajgadChallenge,
+            typedAnswer: "Rajgad"
+        )
+
+        XCTAssertTrue(result.isCorrect)
+        XCTAssertEqual(result.kind, .correctWithHint)
+        XCTAssertTrue(result.shouldUseSoonReview)
+    }
+
+    func testMatchEngineCompletesPairAndFullSet() {
+        var state = ChronicleMatchState()
+
+        state = ChronicleMatchEngine.select(tileID: "place-shivneri", state: state, pairs: matchPairs)
+        XCTAssertEqual(state.selectedTileID, "place-shivneri")
+
+        state = ChronicleMatchEngine.select(tileID: "hook-birth-fort", state: state, pairs: matchPairs)
+        XCTAssertEqual(state.completedPairIDs, ["shivneri-birth-fort"])
+        XCTAssertNil(state.selectedTileID)
+
+        guard case let .matched(pairID, _, completedSet)? = state.lastOutcome else {
+            return XCTFail("Expected matched outcome")
+        }
+        XCTAssertEqual(pairID, "shivneri-birth-fort")
+        XCTAssertFalse(completedSet)
+
+        state = ChronicleMatchEngine.select(tileID: "place-rajgad", state: state, pairs: matchPairs)
+        state = ChronicleMatchEngine.select(tileID: "hook-early-capital", state: state, pairs: matchPairs)
+
+        guard case let .matched(_, _, completedSet)? = state.lastOutcome else {
+            return XCTFail("Expected matched outcome")
+        }
+        XCTAssertTrue(completedSet)
+        XCTAssertEqual(state.completedPairIDs.count, 2)
+    }
+
+    func testMatchEngineMismatchReturnsClueWithoutCompletingPair() {
+        var state = ChronicleMatchState()
+
+        state = ChronicleMatchEngine.select(tileID: "place-shivneri", state: state, pairs: matchPairs)
+        state = ChronicleMatchEngine.select(tileID: "hook-early-capital", state: state, pairs: matchPairs)
+
+        XCTAssertEqual(state.completedPairIDs.count, 0)
+        XCTAssertEqual(state.mismatchCount, 1)
+        XCTAssertNil(state.selectedTileID)
+
+        guard case let .mismatched(clue)? = state.lastOutcome else {
+            return XCTFail("Expected mismatch outcome")
+        }
+        XCTAssertEqual(clue, "Shivneri is remembered as the Birth Fort.")
+    }
+
+    func testMatchEngineIgnoresAlreadyCompletedPair() {
+        var state = ChronicleMatchState(completedPairIDs: ["shivneri-birth-fort"])
+
+        state = ChronicleMatchEngine.select(tileID: "place-shivneri", state: state, pairs: matchPairs)
+
+        XCTAssertNil(state.selectedTileID)
+        XCTAssertEqual(state.completedPairIDs, ["shivneri-birth-fort"])
+        XCTAssertEqual(state.lastOutcome, .ignored)
+    }
+
+    func testReviewSchedulerSchedulesNoHintSuccessForTomorrowAndRotatesPrompt() {
+        let now = Date(timeIntervalSince1970: 1_800_000)
+        let schedule = baseSchedule(nextDueAt: now)
+        let quizResult = ChronicleQuizResult(
+            kind: .correctWithoutHint,
+            isCorrect: true,
+            masteryAwarded: .understood,
+            feedback: "Yes.",
+            nextState: ChronicleQuizState()
+        )
+
+        let result = SpacedReviewScheduler.schedule(
+            schedule,
+            after: quizResult,
+            promptHistory: [.openPrompt],
+            now: now,
+            calendar: gregorianUTC
+        )
+
+        XCTAssertEqual(result.schedule.intervalIndex, 1)
+        XCTAssertEqual(result.schedule.stabilityBand, .warming)
+        XCTAssertEqual(result.nextPromptType, .eventToPlaceMatch)
+        XCTAssertFalse(result.shouldReviewInCurrentSession)
+        XCTAssertEqual(result.schedule.nextDueAt, gregorianUTC.date(byAdding: .day, value: 1, to: now))
+    }
+
+    func testReviewSchedulerSchedulesHintedAndRescuedWorkSooner() {
+        let now = Date(timeIntervalSince1970: 1_800_000)
+        let schedule = baseSchedule(nextDueAt: now)
+
+        let hinted = SpacedReviewScheduler.schedule(
+            schedule,
+            after: .neededClue,
+            promptHistory: [.eventToPlaceMatch],
+            now: now,
+            calendar: gregorianUTC
+        )
+        XCTAssertEqual(hinted.schedule.intervalIndex, 1)
+        XCTAssertEqual(hinted.schedule.nextDueAt, gregorianUTC.date(byAdding: .hour, value: 4, to: now))
+        XCTAssertEqual(hinted.nextPromptType, .sequenceSlot)
+        XCTAssertFalse(hinted.shouldReviewInCurrentSession)
+
+        let rescued = SpacedReviewScheduler.schedule(
+            hinted.schedule,
+            after: .teachAgain,
+            promptHistory: [.sequenceSlot],
+            now: now,
+            calendar: gregorianUTC
+        )
+        XCTAssertEqual(rescued.schedule.intervalIndex, 0)
+        XCTAssertEqual(rescued.schedule.nextDueAt, now)
+        XCTAssertEqual(rescued.schedule.stabilityBand, .new)
+        XCTAssertEqual(rescued.nextPromptType, .compareFromMemory)
+        XCTAssertTrue(rescued.shouldReviewInCurrentSession)
+    }
+
+    func testReviewSchedulerReturnsDueReviewsInStableOrder() {
+        let now = Date(timeIntervalSince1970: 1_800_000)
+        let dueLater = baseSchedule(subjectID: "scene-b", nextDueAt: now.addingTimeInterval(10))
+        let dueNowB = baseSchedule(subjectID: "scene-b", nextDueAt: now)
+        let dueNowA = baseSchedule(subjectID: "scene-a", nextDueAt: now)
+
+        let due = SpacedReviewScheduler.dueReviews(from: [dueLater, dueNowB, dueNowA], now: now)
+
+        XCTAssertEqual(due.map(\.subjectID), ["scene-a", "scene-b"])
+    }
+
+    func testChronicleProgressEngineTransitionsFromSilhouetteToRememberedAgain() {
+        let now = Date(timeIntervalSince1970: 1_800_000)
+        let entry = ChronicleEntry(
+            id: "reward-birth-fort-card",
+            title: "Birth Fort",
+            keepsakeTitle: "Birth Fort Chronicle Card",
+            meaningStatement: "Shivneri anchors the beginning.",
+            linkedSceneID: "scene-1-shivneri",
+            linkedPlaceID: "place-shivneri",
+            linkedTimelineEventID: "timeline-born-at-shivneri",
+            unlockRule: UnlockRule(requiredMastery: .understood, enhancedMastery: .observedClosely)
+        )
+
+        var progress = ChronicleProgressEngine.initialProgress(for: entry)
+        XCTAssertEqual(progress.detailLevel, .hidden)
+        XCTAssertEqual(progress.unlockState, .silhouette)
+
+        progress = ChronicleProgressEngine.apply(.lessonSeen, to: progress, at: now)
+        XCTAssertEqual(progress.detailLevel, .silhouette)
+        XCTAssertEqual(progress.unlockState, .silhouette)
+
+        progress = ChronicleProgressEngine.apply(.recallCorrect, to: progress, at: now)
+        XCTAssertEqual(progress.detailLevel, .inked)
+        XCTAssertEqual(progress.unlockState, .unlocked)
+
+        progress = ChronicleProgressEngine.apply(.matchCompleted, to: progress, at: now)
+        XCTAssertEqual(progress.detailLevel, .sealed)
+        XCTAssertEqual(progress.unlockState, .enriched)
+
+        progress = ChronicleProgressEngine.apply(.reviewCorrect, to: progress, at: now)
+        XCTAssertEqual(progress.detailLevel, .rememberedAgain)
+        XCTAssertEqual(progress.unlockState, .enriched)
+        XCTAssertEqual(progress.completedEvents, [.lessonSeen, .recallCorrect, .matchCompleted, .reviewCorrect])
+    }
+
+    private var shivneriChallenge: RecallChallenge {
+        RecallChallenge(
+            id: "scene-1-shivneri-recall",
+            promptType: .openPrompt,
+            prompt: "Which fort is Shivaji Maharaj's birth place?",
+            correctAnswers: ["Shivneri Fort", "Shivneri"],
+            hintLadder: [
+                RecallHint(level: 1, title: "Anchor hint", body: "Think about the Birth Fort."),
+                RecallHint(level: 2, title: "Place hint", body: "It is near Junnar."),
+                RecallHint(level: 3, title: "Category hint", body: "It is a hill fort."),
+            ],
+            feedback: RecallFeedback(
+                success: "Yes. Shivneri Fort is remembered as Shivaji Maharaj's birth place.",
+                recovery: "Shivneri is the Birth Fort where the journey begins."
+            ),
+            masteryContribution: .understood
+        )
+    }
+
+    private var rajgadChallenge: RecallChallenge {
+        RecallChallenge(
+            id: "scene-2-rajgad-recall",
+            promptType: .compareFromMemory,
+            prompt: "Which fort became an early capital?",
+            correctAnswers: ["Rajgad"],
+            hintLadder: [RecallHint(level: 1, title: "Pair hint", body: "It came after Torna.")],
+            feedback: RecallFeedback(success: "Yes. Rajgad became an early capital.", recovery: "Rajgad is the early capital."),
+            masteryContribution: .observedClosely
+        )
+    }
+
+    private var matchPairs: [ChronicleMatchPair] {
+        [
+            ChronicleMatchPair(
+                id: "shivneri-birth-fort",
+                leftID: "place-shivneri",
+                leftText: "Shivneri",
+                rightID: "hook-birth-fort",
+                rightText: "Birth Fort",
+                kind: .placeToHook,
+                teachingClue: "Shivneri is remembered as the Birth Fort."
+            ),
+            ChronicleMatchPair(
+                id: "rajgad-early-capital",
+                leftID: "place-rajgad",
+                leftText: "Rajgad",
+                rightID: "hook-early-capital",
+                rightText: "Early Capital",
+                kind: .placeToHook,
+                teachingClue: "Rajgad became an early capital and planning base."
+            ),
+        ]
+    }
+
+    private var gregorianUTC: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func baseSchedule(subjectID: String = "scene-1-shivneri", nextDueAt: Date) -> ReviewSchedule {
+        ReviewSchedule(
+            subjectID: subjectID,
+            subjectType: .scene,
+            nextDueAt: nextDueAt,
+            intervalIndex: 0,
+            stabilityBand: .new,
+            difficultyAdjustment: 0,
+            cadenceDays: [0, 1, 3, 7, 14]
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #126 PR2 pure learning engines on top of the current PR1-compatible model layer:

- Chronicle quiz answer evaluation with normalized matching, hint progression, recognition rescue, and result classifications.
- Chronicle Match state engine with pair selection, mismatch teaching clues, completion tracking, idempotency, and deterministic tile shuffle support.
- Minimum viable spaced review scheduler with no-hint, hinted, and rescued/teach-again timing plus prompt rotation and due-review selection.
- Chronicle progress/reward transition engine for lesson seen, recall correct, match/timeline success, and later review success.
- Unit tests for quiz, match, scheduler, and Chronicle reward transitions.

Closes part of #126. This PR specifically covers the planning comment PR2 scope: B3, B4, B5, and B6.

## Validation

- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `gh auth status` passed for `ganesh47`.

## Blockers

- Could not run iOS build or XCTest in this environment because `xcodebuild` is not installed (`/bin/bash: xcodebuild: command not found`).
- Could not run a standalone Swift compiler check because `swift` is not installed in this environment.

## Notes

UI is intentionally out of scope. The new engine types are pure Swift and added to the app/test targets in `GreatsOfBharatha.xcodeproj`.