### PR TITLE
[codex] Add learn quiz UI shells

### DIFF
--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		07FB948684566346F8B09A98 /* GBSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6043F267C6727A816F8CE8 /* GBSpacing.swift */; };
 		0C3412C4E22C4B63092DB4BE /* DebugNavigationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */; };
 		16E40D4D9552B57A027D9FF5 /* StoryHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA3B33CD2FFC1A53263C40A /* StoryHomeView.swift */; };
+		1D46FB6ECD9C7608AF1C984E /* LearningEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E960C45C97D2EAE06A7FBBB /* LearningEnginesTests.swift */; };
 		211E19D2035927C41FB3C2E9 /* LearnQuizComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7FCD376566BEDC5C726FF4 /* LearnQuizComponents.swift */; };
 		229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE540544C5E9622DB91B7EF8 /* ContentView.swift */; };
 		22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB428856E6E0B33ECEAA8E36 /* LessonHomeView.swift */; };
@@ -30,6 +31,7 @@
 		59DDE6A3CB3C27E2595A3085 /* GBSceneCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB52F4EF3B015973D3C6D088 /* GBSceneCard.swift */; };
 		5BD4A172E915378D3A9CC856 /* GBShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891FE8601621FF7A7BDE9AC6 /* GBShadow.swift */; };
 		5C9B9B95F0A16A53E02C8B38 /* SceneLearnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAB7F46ABBA5FCDA7A016BB /* SceneLearnView.swift */; };
+		5D281628DB3CC42AD77F0D7A /* LearningEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390AE8B48E7C52C376816E87 /* LearningEngines.swift */; };
 		608CCC7416A6F35837C15A04 /* TimelineHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E8E42D945004543238A06E /* TimelineHubView.swift */; };
 		62EF82978E25896FA52FEAA8 /* ChronicleQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6CE8B3071CC2D92499A35E /* ChronicleQuizView.swift */; };
 		6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */; };
@@ -82,9 +84,11 @@
 		2855D2317D822D5995E534DE /* GBChildSafeAIPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBChildSafeAIPlan.swift; sourceTree = "<group>"; };
 		2A7FCD376566BEDC5C726FF4 /* LearnQuizComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizComponents.swift; sourceTree = "<group>"; };
 		2E1F22519D406A575588CE02 /* GBLayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBLayoutContext.swift; sourceTree = "<group>"; };
+		2E960C45C97D2EAE06A7FBBB /* LearningEnginesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEnginesTests.swift; sourceTree = "<group>"; };
 		30766CF8C2332F9E648E275A /* GBSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSectionHeader.swift; sourceTree = "<group>"; };
 		35DD7C78E273FA67916C2743 /* GBHeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBHeroCard.swift; sourceTree = "<group>"; };
 		38AE753749107F40681898D3 /* GreatsOfBharathaTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = GreatsOfBharathaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		390AE8B48E7C52C376816E87 /* LearningEngines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEngines.swift; sourceTree = "<group>"; };
 		3F908003C182E0D3D3047941 /* LearnQuizPilotData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizPilotData.swift; sourceTree = "<group>"; };
 		40039999B2C8D4999FB8C254 /* LessonFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonFeedback.swift; sourceTree = "<group>"; };
 		596CBD0FA93B029F56E14FDF /* GBBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBBadge.swift; sourceTree = "<group>"; };
@@ -140,6 +144,7 @@
 				6413C33179A188AA0729938F /* AppModel.swift */,
 				842D0166597E3756A21D8739 /* ContentModels.swift */,
 				B69947B828E9DD4B794FBE0A /* HeroArcModels.swift */,
+				390AE8B48E7C52C376816E87 /* LearningEngines.swift */,
 				901C5A02CDD2D6DA5162F535 /* MasteryState.swift */,
 				71BEDED465CA437D09ADDCD5 /* SampleContent.swift */,
 				C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */,
@@ -160,6 +165,7 @@
 			isa = PBXGroup;
 			children = (
 				85B8DF1FEE4414FC115FD0F1 /* GreatsOfBharathaTests.swift */,
+				2E960C45C97D2EAE06A7FBBB /* LearningEnginesTests.swift */,
 			);
 			path = GreatsOfBharathaTests;
 			sourceTree = "<group>";
@@ -489,6 +495,7 @@
 				211E19D2035927C41FB3C2E9 /* LearnQuizComponents.swift in Sources */,
 				DBA6A92348B871BDD6F726A1 /* LearnQuizHomeView.swift in Sources */,
 				28F96E8FA507F0D5650F8C95 /* LearnQuizPilotData.swift in Sources */,
+				5D281628DB3CC42AD77F0D7A /* LearningEngines.swift in Sources */,
 				98B47696937C9BCD2D0E9235 /* LessonFeedback.swift in Sources */,
 				22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */,
 				073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */,
@@ -509,6 +516,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E192EA45F4DF6C39007360F9 /* GreatsOfBharathaTests.swift in Sources */,
+				1D46FB6ECD9C7608AF1C984E /* LearningEnginesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -12,16 +12,11 @@
 		073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C5A02CDD2D6DA5162F535 /* MasteryState.swift */; };
 		07FB948684566346F8B09A98 /* GBSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6043F267C6727A816F8CE8 /* GBSpacing.swift */; };
 		0C3412C4E22C4B63092DB4BE /* DebugNavigationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */; };
-		101126000000000000000001 /* LearnQuizPilotData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000011 /* LearnQuizPilotData.swift */; };
-		101126000000000000000002 /* LearnQuizComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000012 /* LearnQuizComponents.swift */; };
-		101126000000000000000003 /* LearnQuizHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000013 /* LearnQuizHomeView.swift */; };
-		101126000000000000000004 /* SceneLearnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000014 /* SceneLearnView.swift */; };
-		101126000000000000000005 /* ChronicleQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000015 /* ChronicleQuizView.swift */; };
-		101126000000000000000006 /* ChronicleMatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000016 /* ChronicleMatchView.swift */; };
-		101126000000000000000007 /* ChronicleBookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000017 /* ChronicleBookView.swift */; };
 		16E40D4D9552B57A027D9FF5 /* StoryHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA3B33CD2FFC1A53263C40A /* StoryHomeView.swift */; };
+		211E19D2035927C41FB3C2E9 /* LearnQuizComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7FCD376566BEDC5C726FF4 /* LearnQuizComponents.swift */; };
 		229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE540544C5E9622DB91B7EF8 /* ContentView.swift */; };
 		22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB428856E6E0B33ECEAA8E36 /* LessonHomeView.swift */; };
+		28F96E8FA507F0D5650F8C95 /* LearnQuizPilotData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F908003C182E0D3D3047941 /* LearnQuizPilotData.swift */; };
 		2ABB675D9B13E6BC94627094 /* GBSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD34478F7C8BC5F5EE50AD37 /* GBSurface.swift */; };
 		32E281A86CD24DEF8DBD980E /* SampleContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BEDED465CA437D09ADDCD5 /* SampleContent.swift */; };
 		38181663217C8A05A26880D2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CD5C939A7D069E35B849A5A8 /* Assets.xcassets */; };
@@ -34,9 +29,12 @@
 		57A372CC37EE9EDD83A56710 /* GBTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA553A6C52FF405536FB4B58 /* GBTypography.swift */; };
 		59DDE6A3CB3C27E2595A3085 /* GBSceneCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB52F4EF3B015973D3C6D088 /* GBSceneCard.swift */; };
 		5BD4A172E915378D3A9CC856 /* GBShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891FE8601621FF7A7BDE9AC6 /* GBShadow.swift */; };
+		5C9B9B95F0A16A53E02C8B38 /* SceneLearnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAB7F46ABBA5FCDA7A016BB /* SceneLearnView.swift */; };
 		608CCC7416A6F35837C15A04 /* TimelineHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E8E42D945004543238A06E /* TimelineHubView.swift */; };
+		62EF82978E25896FA52FEAA8 /* ChronicleQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6CE8B3071CC2D92499A35E /* ChronicleQuizView.swift */; };
 		6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */; };
 		86E2FF6E624F8374636950E5 /* README_BOOTSTRAP.md in Resources */ = {isa = PBXBuildFile; fileRef = AF8E819340759100DB074CD4 /* README_BOOTSTRAP.md */; };
+		88F9E6C20BBFA38264D4077B /* ChronicleMatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7731536CB354B63B77E73A4 /* ChronicleMatchView.swift */; };
 		89E3FE1D90324B34D697C540 /* GBCardStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8609E7F8AFD990A81250F928 /* GBCardStyle.swift */; };
 		8B6F5ED2AC090236774D73A1 /* GBFlashCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8664679DB91BD8C821702F4F /* GBFlashCard.swift */; };
 		8B7734948D0D0BE63E8E43B9 /* GBColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96600FFDF84328236B5EFACF /* GBColor.swift */; };
@@ -48,11 +46,14 @@
 		ACB64A9DB10FCF88E3BFFC1F /* CaptureRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FD76D3718D3AC479FF0985 /* CaptureRootView.swift */; };
 		ADBA27254FB49C8AC53B58C6 /* GBButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C0CC899F030C472E7720F0 /* GBButtonStyle.swift */; };
 		B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842D0166597E3756A21D8739 /* ContentModels.swift */; };
+		B8D344B8DE9447BA85DF20D4 /* ChronicleBookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A22615A77AECE2536BA1E9 /* ChronicleBookView.swift */; };
 		C3C8E7616436D7F22238B09C /* AppleMapsPlaceHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */; };
+		C59E6685BB680CF41B71A059 /* GBChildSafeAIPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2855D2317D822D5995E534DE /* GBChildSafeAIPlan.swift */; };
 		CD55EED6E4B1DFC5B1F20BCD /* ParentProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF974097779D0836FBDE59DD /* ParentProgressView.swift */; };
 		CE9E2F14877988A61A031337 /* GBChronicleCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0244C418BCB073D7CD511F45 /* GBChronicleCard.swift */; };
 		CF5BE7783A5885A44F0DF9D5 /* GBRecallPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E79CCE23974B1F749235073 /* GBRecallPrompt.swift */; };
 		DA179384FDADDB751B69ED44 /* ALPHA_README.md in Resources */ = {isa = PBXBuildFile; fileRef = AE4ACA8DD1F96BF699DB84C3 /* ALPHA_README.md */; };
+		DBA6A92348B871BDD6F726A1 /* LearnQuizHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E795D04E3E7952F19DB2D559 /* LearnQuizHomeView.swift */; };
 		DF919F38C0D6D11586812C90 /* GBBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596CBD0FA93B029F56E14FDF /* GBBadge.swift */; };
 		E192EA45F4DF6C39007360F9 /* GreatsOfBharathaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B8DF1FEE4414FC115FD0F1 /* GreatsOfBharathaTests.swift */; };
 		E349019EB5DCB1F8BDA9E0E0 /* GBQuestProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649333F6BBA2EEBE56A1E2E /* GBQuestProgress.swift */; };
@@ -76,19 +77,15 @@
 		0048FE06EF01F9520955BAAD /* GBIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBIcon.swift; sourceTree = "<group>"; };
 		0244C418BCB073D7CD511F45 /* GBChronicleCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBChronicleCard.swift; sourceTree = "<group>"; };
 		0C84A1BE87F4CAA5D6281AD6 /* SceneLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLessonView.swift; sourceTree = "<group>"; };
-		101126000000000000000011 /* LearnQuizPilotData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizPilotData.swift; sourceTree = "<group>"; };
-		101126000000000000000012 /* LearnQuizComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizComponents.swift; sourceTree = "<group>"; };
-		101126000000000000000013 /* LearnQuizHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizHomeView.swift; sourceTree = "<group>"; };
-		101126000000000000000014 /* SceneLearnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLearnView.swift; sourceTree = "<group>"; };
-		101126000000000000000015 /* ChronicleQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleQuizView.swift; sourceTree = "<group>"; };
-		101126000000000000000016 /* ChronicleMatchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleMatchView.swift; sourceTree = "<group>"; };
-		101126000000000000000017 /* ChronicleBookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleBookView.swift; sourceTree = "<group>"; };
 		1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMapsPlaceHandoff.swift; sourceTree = "<group>"; };
 		1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugNavigationRoute.swift; sourceTree = "<group>"; };
+		2855D2317D822D5995E534DE /* GBChildSafeAIPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBChildSafeAIPlan.swift; sourceTree = "<group>"; };
+		2A7FCD376566BEDC5C726FF4 /* LearnQuizComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizComponents.swift; sourceTree = "<group>"; };
 		2E1F22519D406A575588CE02 /* GBLayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBLayoutContext.swift; sourceTree = "<group>"; };
 		30766CF8C2332F9E648E275A /* GBSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSectionHeader.swift; sourceTree = "<group>"; };
 		35DD7C78E273FA67916C2743 /* GBHeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBHeroCard.swift; sourceTree = "<group>"; };
 		38AE753749107F40681898D3 /* GreatsOfBharathaTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = GreatsOfBharathaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F908003C182E0D3D3047941 /* LearnQuizPilotData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizPilotData.swift; sourceTree = "<group>"; };
 		40039999B2C8D4999FB8C254 /* LessonFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonFeedback.swift; sourceTree = "<group>"; };
 		596CBD0FA93B029F56E14FDF /* GBBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBBadge.swift; sourceTree = "<group>"; };
 		5A6043F267C6727A816F8CE8 /* GBSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSpacing.swift; sourceTree = "<group>"; };
@@ -107,7 +104,9 @@
 		8E87053068FDF0CC0A7FAEC5 /* GBFortMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBFortMapView.swift; sourceTree = "<group>"; };
 		901C5A02CDD2D6DA5162F535 /* MasteryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryState.swift; sourceTree = "<group>"; };
 		96600FFDF84328236B5EFACF /* GBColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBColor.swift; sourceTree = "<group>"; };
+		AAAB7F46ABBA5FCDA7A016BB /* SceneLearnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLearnView.swift; sourceTree = "<group>"; };
 		AB428856E6E0B33ECEAA8E36 /* LessonHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonHomeView.swift; sourceTree = "<group>"; };
+		AC6CE8B3071CC2D92499A35E /* ChronicleQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleQuizView.swift; sourceTree = "<group>"; };
 		AE4ACA8DD1F96BF699DB84C3 /* ALPHA_README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ALPHA_README.md; sourceTree = "<group>"; };
 		AF8E819340759100DB074CD4 /* README_BOOTSTRAP.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_BOOTSTRAP.md; sourceTree = "<group>"; };
 		B437E2FBF7D8A3260B1C1DCC /* PlacesHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacesHubView.swift; sourceTree = "<group>"; };
@@ -116,6 +115,7 @@
 		BAABCCD639D0C3267861E9A8 /* ShivajiLessonStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShivajiLessonStore.swift; sourceTree = "<group>"; };
 		BD34478F7C8BC5F5EE50AD37 /* GBSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSurface.swift; sourceTree = "<group>"; };
 		C0C0CC899F030C472E7720F0 /* GBButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBButtonStyle.swift; sourceTree = "<group>"; };
+		C2A22615A77AECE2536BA1E9 /* ChronicleBookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleBookView.swift; sourceTree = "<group>"; };
 		C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShivajiLessonModels.swift; sourceTree = "<group>"; };
 		C552711CAEFFD3AB955E26E7 /* GBIntelligenceHint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBIntelligenceHint.swift; sourceTree = "<group>"; };
 		CCE07361DC3C1D6D864BB326 /* GBNLRecallEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBNLRecallEvaluator.swift; sourceTree = "<group>"; };
@@ -125,7 +125,9 @@
 		DB52F4EF3B015973D3C6D088 /* GBSceneCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSceneCard.swift; sourceTree = "<group>"; };
 		DDA3B33CD2FFC1A53263C40A /* StoryHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryHomeView.swift; sourceTree = "<group>"; };
 		E6FD76D3718D3AC479FF0985 /* CaptureRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureRootView.swift; sourceTree = "<group>"; };
+		E795D04E3E7952F19DB2D559 /* LearnQuizHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizHomeView.swift; sourceTree = "<group>"; };
 		F649333F6BBA2EEBE56A1E2E /* GBQuestProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBQuestProgress.swift; sourceTree = "<group>"; };
+		F7731536CB354B63B77E73A4 /* ChronicleMatchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleMatchView.swift; sourceTree = "<group>"; };
 		FA553A6C52FF405536FB4B58 /* GBTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBTypography.swift; sourceTree = "<group>"; };
 		FF974097779D0836FBDE59DD /* ParentProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentProgressView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -152,20 +154,6 @@
 				5B68FFD09AD399FAE5A7DA5F /* ChronicleView.swift */,
 			);
 			path = Chronicle;
-			sourceTree = "<group>";
-		};
-		101126000000000000000010 /* LearnQuiz */ = {
-			isa = PBXGroup;
-			children = (
-				101126000000000000000017 /* ChronicleBookView.swift */,
-				101126000000000000000016 /* ChronicleMatchView.swift */,
-				101126000000000000000015 /* ChronicleQuizView.swift */,
-				101126000000000000000012 /* LearnQuizComponents.swift */,
-				101126000000000000000013 /* LearnQuizHomeView.swift */,
-				101126000000000000000011 /* LearnQuizPilotData.swift */,
-				101126000000000000000014 /* SceneLearnView.swift */,
-			);
-			path = LearnQuiz;
 			sourceTree = "<group>";
 		};
 		29C18B9AA5DE074DEE2233A4 /* GreatsOfBharathaTests */ = {
@@ -221,7 +209,7 @@
 			isa = PBXGroup;
 			children = (
 				291D0A188BF00AB65634B378 /* Chronicle */,
-				101126000000000000000010 /* LearnQuiz */,
+				5C178F2679E0F6818E5B55CA /* LearnQuiz */,
 				2CAF176D76684F7BB625884A /* Lesson */,
 				B8EE4101C55EA21501F66716 /* Map */,
 				D7A23AC84F04ED8249356C10 /* Parent */,
@@ -245,6 +233,20 @@
 				74DD589F8E91F14A920C59F9 /* Theme */,
 			);
 			path = Shared;
+			sourceTree = "<group>";
+		};
+		5C178F2679E0F6818E5B55CA /* LearnQuiz */ = {
+			isa = PBXGroup;
+			children = (
+				C2A22615A77AECE2536BA1E9 /* ChronicleBookView.swift */,
+				F7731536CB354B63B77E73A4 /* ChronicleMatchView.swift */,
+				AC6CE8B3071CC2D92499A35E /* ChronicleQuizView.swift */,
+				2A7FCD376566BEDC5C726FF4 /* LearnQuizComponents.swift */,
+				E795D04E3E7952F19DB2D559 /* LearnQuizHomeView.swift */,
+				3F908003C182E0D3D3047941 /* LearnQuizPilotData.swift */,
+				AAAB7F46ABBA5FCDA7A016BB /* SceneLearnView.swift */,
+			);
+			path = LearnQuiz;
 			sourceTree = "<group>";
 		};
 		6316ABC4AC5FF73B8BB04D46 /* Foundation */ = {
@@ -323,6 +325,7 @@
 		D1CA5C958078395C8E7ADE1B /* Intelligence */ = {
 			isa = PBXGroup;
 			children = (
+				2855D2317D822D5995E534DE /* GBChildSafeAIPlan.swift */,
 				C552711CAEFFD3AB955E26E7 /* GBIntelligenceHint.swift */,
 				CCE07361DC3C1D6D864BB326 /* GBNLRecallEvaluator.swift */,
 			);
@@ -451,9 +454,9 @@
 				EE2374F1DB13184A06C4BBCA /* AppModel.swift in Sources */,
 				C3C8E7616436D7F22238B09C /* AppleMapsPlaceHandoff.swift in Sources */,
 				ACB64A9DB10FCF88E3BFFC1F /* CaptureRootView.swift in Sources */,
-				101126000000000000000007 /* ChronicleBookView.swift in Sources */,
-				101126000000000000000006 /* ChronicleMatchView.swift in Sources */,
-				101126000000000000000005 /* ChronicleQuizView.swift in Sources */,
+				B8D344B8DE9447BA85DF20D4 /* ChronicleBookView.swift in Sources */,
+				88F9E6C20BBFA38264D4077B /* ChronicleMatchView.swift in Sources */,
+				62EF82978E25896FA52FEAA8 /* ChronicleQuizView.swift in Sources */,
 				A7BA06A197B5E5166A0F7BB6 /* ChronicleView.swift in Sources */,
 				B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */,
 				229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */,
@@ -461,6 +464,7 @@
 				DF919F38C0D6D11586812C90 /* GBBadge.swift in Sources */,
 				ADBA27254FB49C8AC53B58C6 /* GBButtonStyle.swift in Sources */,
 				89E3FE1D90324B34D697C540 /* GBCardStyle.swift in Sources */,
+				C59E6685BB680CF41B71A059 /* GBChildSafeAIPlan.swift in Sources */,
 				CE9E2F14877988A61A031337 /* GBChronicleCard.swift in Sources */,
 				8B7734948D0D0BE63E8E43B9 /* GBColor.swift in Sources */,
 				8B6F5ED2AC090236774D73A1 /* GBFlashCard.swift in Sources */,
@@ -482,16 +486,16 @@
 				57A372CC37EE9EDD83A56710 /* GBTypography.swift in Sources */,
 				3CE894040C86BE6F34F93C13 /* GreatsOfBharathaApp.swift in Sources */,
 				3C4FB3ADBB894FDAC9244FBA /* HeroArcModels.swift in Sources */,
+				211E19D2035927C41FB3C2E9 /* LearnQuizComponents.swift in Sources */,
+				DBA6A92348B871BDD6F726A1 /* LearnQuizHomeView.swift in Sources */,
+				28F96E8FA507F0D5650F8C95 /* LearnQuizPilotData.swift in Sources */,
 				98B47696937C9BCD2D0E9235 /* LessonFeedback.swift in Sources */,
 				22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */,
-				101126000000000000000002 /* LearnQuizComponents.swift in Sources */,
-				101126000000000000000003 /* LearnQuizHomeView.swift in Sources */,
-				101126000000000000000001 /* LearnQuizPilotData.swift in Sources */,
 				073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */,
 				CD55EED6E4B1DFC5B1F20BCD /* ParentProgressView.swift in Sources */,
 				EC86C80AAD4DC6283501CE97 /* PlacesHubView.swift in Sources */,
 				32E281A86CD24DEF8DBD980E /* SampleContent.swift in Sources */,
-				101126000000000000000004 /* SceneLearnView.swift in Sources */,
+				5C9B9B95F0A16A53E02C8B38 /* SceneLearnView.swift in Sources */,
 				EC46491021CBEFACB6398346 /* SceneLessonView.swift in Sources */,
 				6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */,
 				06EF311D881705EB5C28A94B /* ShivajiLessonStore.swift in Sources */,

--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -12,6 +12,13 @@
 		073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901C5A02CDD2D6DA5162F535 /* MasteryState.swift */; };
 		07FB948684566346F8B09A98 /* GBSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6043F267C6727A816F8CE8 /* GBSpacing.swift */; };
 		0C3412C4E22C4B63092DB4BE /* DebugNavigationRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */; };
+		101126000000000000000001 /* LearnQuizPilotData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000011 /* LearnQuizPilotData.swift */; };
+		101126000000000000000002 /* LearnQuizComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000012 /* LearnQuizComponents.swift */; };
+		101126000000000000000003 /* LearnQuizHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000013 /* LearnQuizHomeView.swift */; };
+		101126000000000000000004 /* SceneLearnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000014 /* SceneLearnView.swift */; };
+		101126000000000000000005 /* ChronicleQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000015 /* ChronicleQuizView.swift */; };
+		101126000000000000000006 /* ChronicleMatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000016 /* ChronicleMatchView.swift */; };
+		101126000000000000000007 /* ChronicleBookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101126000000000000000017 /* ChronicleBookView.swift */; };
 		16E40D4D9552B57A027D9FF5 /* StoryHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA3B33CD2FFC1A53263C40A /* StoryHomeView.swift */; };
 		229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE540544C5E9622DB91B7EF8 /* ContentView.swift */; };
 		22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB428856E6E0B33ECEAA8E36 /* LessonHomeView.swift */; };
@@ -69,6 +76,13 @@
 		0048FE06EF01F9520955BAAD /* GBIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBIcon.swift; sourceTree = "<group>"; };
 		0244C418BCB073D7CD511F45 /* GBChronicleCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBChronicleCard.swift; sourceTree = "<group>"; };
 		0C84A1BE87F4CAA5D6281AD6 /* SceneLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLessonView.swift; sourceTree = "<group>"; };
+		101126000000000000000011 /* LearnQuizPilotData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizPilotData.swift; sourceTree = "<group>"; };
+		101126000000000000000012 /* LearnQuizComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizComponents.swift; sourceTree = "<group>"; };
+		101126000000000000000013 /* LearnQuizHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizHomeView.swift; sourceTree = "<group>"; };
+		101126000000000000000014 /* SceneLearnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneLearnView.swift; sourceTree = "<group>"; };
+		101126000000000000000015 /* ChronicleQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleQuizView.swift; sourceTree = "<group>"; };
+		101126000000000000000016 /* ChronicleMatchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleMatchView.swift; sourceTree = "<group>"; };
+		101126000000000000000017 /* ChronicleBookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleBookView.swift; sourceTree = "<group>"; };
 		1B22271B3C207E5ECD2AD241 /* AppleMapsPlaceHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMapsPlaceHandoff.swift; sourceTree = "<group>"; };
 		1D930EAD368CC7853B35494A /* DebugNavigationRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugNavigationRoute.swift; sourceTree = "<group>"; };
 		2E1F22519D406A575588CE02 /* GBLayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBLayoutContext.swift; sourceTree = "<group>"; };
@@ -140,6 +154,20 @@
 			path = Chronicle;
 			sourceTree = "<group>";
 		};
+		101126000000000000000010 /* LearnQuiz */ = {
+			isa = PBXGroup;
+			children = (
+				101126000000000000000017 /* ChronicleBookView.swift */,
+				101126000000000000000016 /* ChronicleMatchView.swift */,
+				101126000000000000000015 /* ChronicleQuizView.swift */,
+				101126000000000000000012 /* LearnQuizComponents.swift */,
+				101126000000000000000013 /* LearnQuizHomeView.swift */,
+				101126000000000000000011 /* LearnQuizPilotData.swift */,
+				101126000000000000000014 /* SceneLearnView.swift */,
+			);
+			path = LearnQuiz;
+			sourceTree = "<group>";
+		};
 		29C18B9AA5DE074DEE2233A4 /* GreatsOfBharathaTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -193,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				291D0A188BF00AB65634B378 /* Chronicle */,
+				101126000000000000000010 /* LearnQuiz */,
 				2CAF176D76684F7BB625884A /* Lesson */,
 				B8EE4101C55EA21501F66716 /* Map */,
 				D7A23AC84F04ED8249356C10 /* Parent */,
@@ -422,6 +451,9 @@
 				EE2374F1DB13184A06C4BBCA /* AppModel.swift in Sources */,
 				C3C8E7616436D7F22238B09C /* AppleMapsPlaceHandoff.swift in Sources */,
 				ACB64A9DB10FCF88E3BFFC1F /* CaptureRootView.swift in Sources */,
+				101126000000000000000007 /* ChronicleBookView.swift in Sources */,
+				101126000000000000000006 /* ChronicleMatchView.swift in Sources */,
+				101126000000000000000005 /* ChronicleQuizView.swift in Sources */,
 				A7BA06A197B5E5166A0F7BB6 /* ChronicleView.swift in Sources */,
 				B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */,
 				229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */,
@@ -452,10 +484,14 @@
 				3C4FB3ADBB894FDAC9244FBA /* HeroArcModels.swift in Sources */,
 				98B47696937C9BCD2D0E9235 /* LessonFeedback.swift in Sources */,
 				22C3E261CDC547E64D125909 /* LessonHomeView.swift in Sources */,
+				101126000000000000000002 /* LearnQuizComponents.swift in Sources */,
+				101126000000000000000003 /* LearnQuizHomeView.swift in Sources */,
+				101126000000000000000001 /* LearnQuizPilotData.swift in Sources */,
 				073C82A44999663DE9B72A3D /* MasteryState.swift in Sources */,
 				CD55EED6E4B1DFC5B1F20BCD /* ParentProgressView.swift in Sources */,
 				EC86C80AAD4DC6283501CE97 /* PlacesHubView.swift in Sources */,
 				32E281A86CD24DEF8DBD980E /* SampleContent.swift in Sources */,
+				101126000000000000000004 /* SceneLearnView.swift in Sources */,
 				EC46491021CBEFACB6398346 /* SceneLessonView.swift in Sources */,
 				6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */,
 				06EF311D881705EB5C28A94B /* ShivajiLessonStore.swift in Sources */,

--- a/GreatsOfBharatha/App/CaptureRootView.swift
+++ b/GreatsOfBharatha/App/CaptureRootView.swift
@@ -45,6 +45,8 @@ struct CaptureRootView: View {
             NavigationStack { ParentProgressView() }
         case .learnHome:
             NavigationStack { LessonHomeView() }
+        case .learnQuizHome:
+            NavigationStack { LearnQuizHomeView() }
         }
     }
 }

--- a/GreatsOfBharatha/App/ContentView.swift
+++ b/GreatsOfBharatha/App/ContentView.swift
@@ -8,9 +8,13 @@ struct ContentView: View {
         TabView(selection: $selectedTab) {
             // ── Tab 1: Story ──────────────────────────────────
             NavigationStack {
-                LessonHomeView()
+                if GBFeatureFlags.historyLearnQuizResetEnabled {
+                    LearnQuizHomeView()
+                } else {
+                    LessonHomeView()
+                }
             }
-            .tabItem { Label("Story", systemImage: "book.fill") }
+            .tabItem { Label(GBFeatureFlags.historyLearnQuizResetEnabled ? "Learn" : "Story", systemImage: "book.fill") }
             .tag(DebugTabRoute.learn)
 
             // ── Tab 2: Map ────────────────────────────────────

--- a/GreatsOfBharatha/App/DebugNavigationRoute.swift
+++ b/GreatsOfBharatha/App/DebugNavigationRoute.swift
@@ -15,6 +15,7 @@ enum CaptureSeedProfile {
 
 enum DebugNavigationRoute: String {
     case learnHome = "learn-home"
+    case learnQuizHome = "learn-quiz-home"
     case scene1 = "scene-1"
     case scene2 = "scene-2"
     case placesHub = "places-hub"
@@ -34,6 +35,8 @@ enum DebugNavigationRoute: String {
         switch (tab, destination) {
         case ("learn", ""), ("learn", "learn-home"):
             return .learnHome
+        case ("learn", "learn-quiz-home"):
+            return .learnQuizHome
         case ("learn", "scene-1"):
             return .scene1
         case ("learn", "scene-2"):
@@ -55,6 +58,8 @@ enum DebugNavigationRoute: String {
 
     var seedProfile: CaptureSeedProfile {
         switch self {
+        case .learnQuizHome:
+            return .pristine
         case .chronicleUnlocked:
             return .chronicleUnlocked
         default:

--- a/GreatsOfBharatha/Features/LearnQuiz/ChronicleBookView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/ChronicleBookView.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+
+struct ChronicleBookView: View {
+    let scenes: [LearnQuizPilotScene]
+
+    private var entries: [LearnQuizChronicleEntry] {
+        scenes.map(\.chronicleEntry) + [LearnQuizPilotData.journeyEntry]
+    }
+
+    var body: some View {
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    cover
+                    entriesSection
+                    journeyStrip
+                }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
+            }
+            .background(GBColor.Background.app)
+        }
+        .navigationTitle("Chronicle Book")
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+    }
+
+    private var cover: some View {
+        GBSurface(style: .accented(.chronicle)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                Image(systemName: "book.closed.fill")
+                    .font(.system(size: 42, weight: .bold))
+                    .foregroundStyle(.white)
+                Text("Shivaji Chronicle")
+                    .font(GBFont.display(size: 31, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                Text("A growing book of remembered places, actions, and meanings.")
+                    .font(GBFont.ui(size: 16, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.88))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var entriesSection: some View {
+        VStack(alignment: .leading, spacing: GBSpacing.small) {
+            GBSectionHeader(
+                eyebrow: "Reward states",
+                title: "Cards deepen with memory proof",
+                subtitle: "A card starts faint, then gains ink, a seal, and a remembered-again mark."
+            )
+
+            ForEach(entries) { entry in
+                ChronicleBookEntryCard(entry: entry)
+            }
+        }
+    }
+
+    private var journeyStrip: some View {
+        GBSurface(style: .elevated) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBBadge(title: "Journey so far", symbol: "map.fill", emphasis: .place)
+                HStack(alignment: .top, spacing: GBSpacing.xxSmall) {
+                    ForEach(scenes) { scene in
+                        VStack(spacing: GBSpacing.xxSmall) {
+                            ZStack {
+                                Circle()
+                                    .fill(GBColor.gradient(for: scene.art.emphasis))
+                                Text("\(scene.number)")
+                                    .font(GBFont.ui(size: 14, weight: .black))
+                                    .foregroundStyle(.white)
+                            }
+                            .frame(width: 40, height: 40)
+                            Text(scene.memoryHook)
+                                .font(GBFont.ui(size: 11, weight: .heavy))
+                                .foregroundStyle(GBColor.Content.secondary)
+                                .multilineTextAlignment(.center)
+                                .lineLimit(3)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct ChronicleBookEntryCard: View {
+    let entry: LearnQuizChronicleEntry
+
+    @ViewBuilder
+    var body: some View {
+        if entry.state == .rememberedAgain {
+            GBSurface(style: .accented(.chronicle)) {
+                content
+            }
+        } else {
+            GBSurface(style: .plain) {
+                content
+            }
+            .opacity(entry.state == .silhouette ? 0.72 : 1.0)
+        }
+    }
+
+    private var content: some View {
+        HStack(alignment: .top, spacing: GBSpacing.small) {
+            ZStack {
+                RoundedRectangle(cornerRadius: GBRadius.compact, style: .continuous)
+                    .fill(iconBackground)
+                Image(systemName: icon)
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(iconForeground)
+            }
+            .frame(width: 58, height: 58)
+
+            VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                Text(stateTitle)
+                    .font(GBFont.ui(size: 11, weight: .heavy))
+                    .textCase(.uppercase)
+                    .foregroundStyle(labelColor)
+                Text(entry.title)
+                    .font(GBFont.display(size: 20, weight: .bold))
+                    .foregroundStyle(primaryTextColor)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(entry.subtitle)
+                    .font(GBFont.ui(size: 14, weight: .bold))
+                    .foregroundStyle(secondaryTextColor)
+                Text(entry.meaning)
+                    .font(GBFont.ui(size: 14, weight: .semibold))
+                    .foregroundStyle(secondaryTextColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var icon: String {
+        switch entry.state {
+        case .silhouette: return "eye.slash.fill"
+        case .inked: return "paintbrush.pointed.fill"
+        case .sealed: return "seal.fill"
+        case .rememberedAgain: return "checkmark.seal.fill"
+        }
+    }
+
+    private var stateTitle: String {
+        switch entry.state {
+        case .silhouette: return "Silhouette"
+        case .inked: return "Inked"
+        case .sealed: return "Sealed"
+        case .rememberedAgain: return "Remembered again"
+        }
+    }
+
+    private var iconBackground: Color {
+        entry.state == .silhouette ? GBColor.State.lockedBg : GBColor.Chronicle.goldBg
+    }
+
+    private var iconForeground: Color {
+        entry.state == .silhouette ? GBColor.State.locked : GBColor.Chronicle.gold
+    }
+
+    private var labelColor: Color {
+        entry.state == .rememberedAgain ? .white.opacity(0.75) : GBColor.Content.tertiary
+    }
+
+    private var primaryTextColor: Color {
+        entry.state == .rememberedAgain ? .white : GBColor.Content.primary
+    }
+
+    private var secondaryTextColor: Color {
+        entry.state == .rememberedAgain ? .white.opacity(0.88) : GBColor.Content.secondary
+    }
+}
+
+#Preview("Chronicle Book") {
+    NavigationStack {
+        ChronicleBookView(scenes: LearnQuizPilotData.scenes)
+    }
+}

--- a/GreatsOfBharatha/Features/LearnQuiz/ChronicleMatchView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/ChronicleMatchView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+struct ChronicleMatchView: View {
+    let scenes: [LearnQuizPilotScene]
+
+    @State private var selectedLeftID: String?
+    @State private var matchedIDs: Set<String> = []
+    @State private var mismatchPair: LearnQuizMatchPair?
+
+    private var pairs: [LearnQuizMatchPair] {
+        scenes.flatMap(\.matchPairs)
+    }
+
+    var body: some View {
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    header
+                    matchGrid
+                    clueCard
+                    completionCard
+                }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
+            }
+            .background(GBColor.Background.app)
+        }
+        .navigationTitle("Chronicle Match")
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+    }
+
+    private var header: some View {
+        GBHeroCard(
+            eyebrow: "Match pairs",
+            title: "Put each place with its memory hook",
+            subtitle: "\(matchedIDs.count) of \(pairs.count) matched",
+            detail: "Tap a card on the left, then find the card on the right that belongs with it.",
+            ctaTitle: "Keep matching",
+            badgeTitle: "6 pilot pairs",
+            emphasis: .place,
+            progress: pairs.isEmpty ? nil : Double(matchedIDs.count) / Double(pairs.count)
+        )
+    }
+
+    private var matchGrid: some View {
+        HStack(alignment: .top, spacing: GBSpacing.xSmall) {
+            VStack(spacing: GBSpacing.xSmall) {
+                ForEach(pairs) { pair in
+                    matchTile(
+                        id: pair.id,
+                        text: pair.left,
+                        isSelected: selectedLeftID == pair.id,
+                        isMatched: matchedIDs.contains(pair.id),
+                        alignment: .leading
+                    ) {
+                        guard !matchedIDs.contains(pair.id) else { return }
+                        selectedLeftID = pair.id
+                        mismatchPair = nil
+                    }
+                }
+            }
+
+            VStack(spacing: GBSpacing.xSmall) {
+                ForEach(pairs.reversed()) { pair in
+                    matchTile(
+                        id: pair.id,
+                        text: pair.right,
+                        isSelected: false,
+                        isMatched: matchedIDs.contains(pair.id),
+                        alignment: .trailing
+                    ) {
+                        guard !matchedIDs.contains(pair.id), let selectedLeftID else { return }
+                        if selectedLeftID == pair.id {
+                            matchedIDs.insert(pair.id)
+                            self.selectedLeftID = nil
+                            mismatchPair = nil
+                        } else {
+                            mismatchPair = pair
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func matchTile(
+        id: String,
+        text: String,
+        isSelected: Bool,
+        isMatched: Bool,
+        alignment: HorizontalAlignment,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack {
+                if alignment == .trailing { Spacer(minLength: GBSpacing.xxSmall) }
+                Text(text)
+                    .font(GBFont.ui(size: 15, weight: .heavy))
+                    .multilineTextAlignment(alignment == .leading ? .leading : .trailing)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+                if alignment == .leading { Spacer(minLength: GBSpacing.xxSmall) }
+            }
+            .padding(GBSpacing.xSmall)
+            .frame(maxWidth: .infinity, minHeight: 64)
+            .background(tileBackground(isSelected: isSelected, isMatched: isMatched), in: RoundedRectangle(cornerRadius: GBRadius.card, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: GBRadius.card, style: .continuous)
+                    .stroke(tileBorder(isSelected: isSelected, isMatched: isMatched), lineWidth: isSelected || isMatched ? 2 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isMatched ? GBColor.Place.primary : GBColor.Content.primary)
+        .accessibilityLabel("\(text), \(isMatched ? "matched" : "not matched")")
+    }
+
+    @ViewBuilder
+    private var clueCard: some View {
+        if let selectedLeftID, let selected = pairs.first(where: { $0.id == selectedLeftID }) {
+            GBSurface(style: .elevated) {
+                Label("Now tap the matching card for \(selected.left).", systemImage: "hand.tap.fill")
+                    .font(GBFont.ui(size: 16, weight: .bold))
+                    .foregroundStyle(GBColor.Content.primary)
+            }
+        } else if let mismatchPair {
+            GBSurface(style: .elevated) {
+                VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+                    Label("Try another pair", systemImage: "arrow.counterclockwise.circle.fill")
+                        .font(GBFont.ui(size: 16, weight: .heavy))
+                        .foregroundStyle(GBColor.Story.primary)
+                    Text(mismatchPair.clue)
+                        .font(GBFont.ui(size: 15, weight: .semibold))
+                        .foregroundStyle(GBColor.Content.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var completionCard: some View {
+        if matchedIDs.count == pairs.count {
+            GBSurface(style: .accented(.chronicle)) {
+                Label("All pairs matched. A Chronicle seal is ready.", systemImage: "checkmark.seal.fill")
+                    .font(GBFont.ui(size: 17, weight: .heavy))
+                    .foregroundStyle(.white)
+            }
+        }
+    }
+
+    private func tileBackground(isSelected: Bool, isMatched: Bool) -> Color {
+        if isMatched { return GBColor.Place.bg }
+        if isSelected { return GBColor.Chronicle.goldBg }
+        return GBColor.Background.surface
+    }
+
+    private func tileBorder(isSelected: Bool, isMatched: Bool) -> Color {
+        if isMatched { return GBColor.Place.primary }
+        if isSelected { return GBColor.Chronicle.gold }
+        return GBColor.Border.default
+    }
+}
+
+#Preview("Chronicle Match") {
+    NavigationStack {
+        ChronicleMatchView(scenes: LearnQuizPilotData.scenes)
+    }
+}

--- a/GreatsOfBharatha/Features/LearnQuiz/ChronicleQuizView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/ChronicleQuizView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+struct ChronicleQuizView: View {
+    let scene: LearnQuizPilotScene
+
+    @State private var selectedAnswer: String?
+    @State private var hintIndex = 0
+
+    private var isCorrect: Bool {
+        selectedAnswer == scene.quiz.correctAnswer
+    }
+
+    var body: some View {
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    promptCard
+                    answerGrid
+                    hintCard
+                    feedbackCard
+                }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
+            }
+            .background(GBColor.Background.app)
+        }
+        .navigationTitle("Quick Quiz")
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+    }
+
+    private var promptCard: some View {
+        GBSurface(style: .accented(.story)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                GBBadge(title: scene.memoryHook, symbol: "lightbulb.fill", emphasis: .story)
+                Text(scene.quiz.question)
+                    .font(GBFont.display(size: 28, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(4)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("Try from memory first. Hints are here when you want a clue.")
+                    .font(GBFont.ui(size: 15, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.88))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var answerGrid: some View {
+        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: GBSpacing.xSmall) {
+            ForEach(scene.quiz.options, id: \.self) { option in
+                Button {
+                    selectedAnswer = option
+                } label: {
+                    HStack {
+                        Text(option)
+                            .font(GBFont.ui(size: 16, weight: .heavy))
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer()
+                        Image(systemName: selectedAnswer == option ? selectedIcon(for: option) : "circle")
+                    }
+                    .padding(GBSpacing.small)
+                    .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
+                    .background(answerBackground(for: option), in: RoundedRectangle(cornerRadius: GBRadius.card, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: GBRadius.card, style: .continuous)
+                            .stroke(answerBorder(for: option), lineWidth: selectedAnswer == option ? 2 : 1)
+                    )
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(GBColor.Content.primary)
+            }
+        }
+    }
+
+    private var hintCard: some View {
+        GBSurface(style: .elevated) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack {
+                    GBBadge(title: "Hint ladder", symbol: "sparkle.magnifyingglass", emphasis: .chronicle)
+                    Spacer()
+                    Text("\(min(hintIndex + 1, scene.quiz.hintLadder.count))/\(scene.quiz.hintLadder.count)")
+                        .font(GBFont.ui(size: 12, weight: .heavy))
+                        .foregroundStyle(GBColor.Content.tertiary)
+                }
+
+                Text(scene.quiz.hintLadder[hintIndex])
+                    .font(GBFont.ui(size: 17, weight: .bold))
+                    .foregroundStyle(GBColor.Content.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button {
+                    hintIndex = min(hintIndex + 1, scene.quiz.hintLadder.count - 1)
+                } label: {
+                    Label("Show next clue", systemImage: "arrow.down.circle.fill")
+                }
+                .buttonStyle(.gbSecondary)
+                .disabled(hintIndex >= scene.quiz.hintLadder.count - 1)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var feedbackCard: some View {
+        if let selectedAnswer {
+            GBSurface(style: isCorrect ? .accented(.chronicle) : .elevated) {
+                VStack(alignment: .leading, spacing: GBSpacing.xSmall) {
+                    Label(isCorrect ? "Remembered" : "Try with this clue", systemImage: isCorrect ? "checkmark.seal.fill" : "heart.text.square.fill")
+                        .font(GBFont.ui(size: 17, weight: .heavy))
+                        .foregroundStyle(isCorrect ? .white : GBColor.Content.primary)
+                    Text(isCorrect ? "\(selectedAnswer) is right." : scene.quiz.teachingFeedback)
+                        .font(GBFont.story(size: 18))
+                        .foregroundStyle(isCorrect ? .white.opacity(0.92) : GBColor.Content.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    private func selectedIcon(for option: String) -> String {
+        option == scene.quiz.correctAnswer ? "checkmark.circle.fill" : "arrow.counterclockwise.circle.fill"
+    }
+
+    private func answerBackground(for option: String) -> Color {
+        guard selectedAnswer == option else { return GBColor.Background.surface }
+        return option == scene.quiz.correctAnswer ? GBColor.Chronicle.goldBg : GBColor.Story.bg
+    }
+
+    private func answerBorder(for option: String) -> Color {
+        guard selectedAnswer == option else { return GBColor.Border.default }
+        return option == scene.quiz.correctAnswer ? GBColor.Chronicle.gold : GBColor.Story.primary
+    }
+}
+
+#Preview("Chronicle Quiz") {
+    NavigationStack {
+        ChronicleQuizView(scene: LearnQuizPilotData.scenes[0])
+    }
+}

--- a/GreatsOfBharatha/Features/LearnQuiz/LearnQuizComponents.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/LearnQuizComponents.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+struct LearnQuizHeroArt: View {
+    let art: LearnQuizArt
+    let title: String
+    var height: CGFloat = 184
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            RoundedRectangle(cornerRadius: GBRadius.hero, style: .continuous)
+                .fill(GBColor.gradient(for: art.emphasis))
+                .overlay {
+                    Image(systemName: art.symbol)
+                        .font(.system(size: 76, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.30))
+                        .offset(x: 92, y: -26)
+                }
+
+            VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                Image(systemName: art.symbol)
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(.white)
+                Text(title)
+                    .font(GBFont.display(size: 27, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(GBSpacing.medium)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: height)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title) illustration placeholder, asset slot \(art.assetSlot)")
+    }
+}
+
+struct LearnQuizMetadataChip: View {
+    let label: String
+    let value: String
+    var emphasis: GBEmphasis = .story
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(GBFont.ui(size: 10, weight: .heavy))
+                .textCase(.uppercase)
+                .foregroundStyle(GBColor.Content.tertiary)
+            Text(value)
+                .font(GBFont.ui(size: 13, weight: .bold))
+                .foregroundStyle(GBColor.accent(for: emphasis))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, GBSpacing.xSmall)
+        .padding(.vertical, GBSpacing.xxSmall)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(GBColor.Background.surface, in: RoundedRectangle(cornerRadius: GBRadius.compact, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: GBRadius.compact, style: .continuous)
+                .stroke(GBColor.Border.default, lineWidth: 1)
+        )
+    }
+}
+
+struct SceneLearnCard: View {
+    let scene: LearnQuizPilotScene
+    var ctaTitle: String = "Quiz me"
+    var onCTA: (() -> Void)?
+
+    var body: some View {
+        GBSurface(style: .plain, padding: GBSpacing.small) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                LearnQuizHeroArt(art: scene.art, title: scene.title)
+
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: GBSpacing.xxSmall) {
+                    LearnQuizMetadataChip(label: "Time", value: scene.timeMarker, emphasis: .story)
+                    LearnQuizMetadataChip(label: "Place", value: scene.place, emphasis: .place)
+                    LearnQuizMetadataChip(label: "Action", value: scene.actionVerb, emphasis: .chronicle)
+                    LearnQuizMetadataChip(label: "Hook", value: scene.memoryHook, emphasis: .story)
+                }
+
+                VStack(alignment: .leading, spacing: GBSpacing.xSmall) {
+                    Text(scene.subtitle)
+                        .font(GBFont.ui(size: 13, weight: .heavy))
+                        .textCase(.uppercase)
+                        .foregroundStyle(GBColor.Content.tertiary)
+                    Text(scene.story)
+                        .font(GBFont.story(size: 18))
+                        .foregroundStyle(GBColor.Content.primary)
+                        .lineSpacing(4)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(scene.meaning)
+                        .font(GBFont.ui(size: 15, weight: .semibold))
+                        .foregroundStyle(GBColor.Content.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Button(action: { onCTA?() }) {
+                    Label(ctaTitle, systemImage: "questionmark.bubble.fill")
+                }
+                .buttonStyle(.gbPrimary(scene.art.emphasis))
+            }
+        }
+    }
+}
+
+struct LearnQuizSceneRow: View {
+    let scene: LearnQuizPilotScene
+
+    var body: some View {
+        HStack(spacing: GBSpacing.small) {
+            ZStack {
+                RoundedRectangle(cornerRadius: GBRadius.compact, style: .continuous)
+                    .fill(GBColor.gradient(for: scene.art.emphasis))
+                Text("\(scene.number)")
+                    .font(GBFont.display(size: 16, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+            .frame(width: 48, height: 48)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(scene.title)
+                    .font(GBFont.ui(size: 16, weight: .bold))
+                    .foregroundStyle(GBColor.Content.primary)
+                    .lineLimit(1)
+                Text(scene.memoryHook)
+                    .font(GBFont.ui(size: 13, weight: .semibold))
+                    .foregroundStyle(GBColor.Content.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(GBColor.Content.tertiary)
+        }
+        .padding(GBSpacing.small)
+        .background(GBColor.Background.surface, in: RoundedRectangle(cornerRadius: GBRadius.card, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: GBRadius.card, style: .continuous)
+                .stroke(GBColor.Border.default, lineWidth: 1)
+        )
+    }
+}

--- a/GreatsOfBharatha/Features/LearnQuiz/LearnQuizHomeView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/LearnQuizHomeView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct LearnQuizHomeView: View {
+    private let scenes = LearnQuizPilotData.scenes
+
+    var body: some View {
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    hero
+                    continueCard
+                    sceneList
+                    reviewCard
+                }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
+            }
+            .background(GBColor.Background.app)
+        }
+        .navigationTitle("Learn & Quiz")
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+#endif
+    }
+
+    private var hero: some View {
+        GBHeroCard(
+            eyebrow: "Shivaji pilot",
+            title: "Learn, remember, build your Chronicle",
+            subtitle: "Three short scenes: Shivneri, Torna + Rajgad, and Pratapgad.",
+            detail: "Read a short story card, answer from memory, match the hook, and watch the Chronicle grow.",
+            ctaTitle: "Start with Shivneri",
+            badgeTitle: "First path",
+            emphasis: .story,
+            progress: 1.0 / 3.0
+        )
+    }
+
+    private var continueCard: some View {
+        NavigationLink {
+            if let first = scenes.first {
+                SceneLearnView(scene: first)
+            }
+        } label: {
+            GBSurface(style: .accented(.story)) {
+                HStack(spacing: GBSpacing.small) {
+                    Image(systemName: "play.circle.fill")
+                        .font(.system(size: 34, weight: .bold))
+                        .foregroundStyle(.white)
+                    VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                        Text("Continue")
+                            .font(GBFont.ui(size: 13, weight: .heavy))
+                            .textCase(.uppercase)
+                            .foregroundStyle(.white.opacity(0.78))
+                        Text("Shivneri - Birth Fort")
+                            .font(GBFont.display(size: 22, weight: .bold))
+                            .foregroundStyle(.white)
+                            .lineLimit(2)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var sceneList: some View {
+        VStack(alignment: .leading, spacing: GBSpacing.small) {
+            GBSectionHeader(
+                eyebrow: "Pilot scenes",
+                title: "Remember the first path",
+                subtitle: "One clear memory hook for each place in the opening journey."
+            )
+
+            ForEach(scenes) { scene in
+                NavigationLink {
+                    SceneLearnView(scene: scene)
+                } label: {
+                    LearnQuizSceneRow(scene: scene)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var reviewCard: some View {
+        GBSurface(style: .elevated) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack {
+                    GBBadge(title: "Due later", symbol: "rectangle.stack.fill", emphasis: .chronicle)
+                    Spacer()
+                    Text("1 review seed")
+                        .font(GBFont.ui(size: 12, weight: .bold))
+                        .foregroundStyle(GBColor.Content.secondary)
+                }
+                Text("Flashcard review slot")
+                    .font(GBFont.display(size: 21, weight: .bold))
+                    .foregroundStyle(GBColor.Content.primary)
+                Text("A quick card will bring back the memory hook after the story has had time to settle.")
+                    .font(GBFont.ui(size: 15, weight: .semibold))
+                    .foregroundStyle(GBColor.Content.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+#Preview("Learn Quiz Home") {
+    NavigationStack {
+        LearnQuizHomeView()
+    }
+    .environmentObject(AppModel())
+}

--- a/GreatsOfBharatha/Features/LearnQuiz/LearnQuizPilotData.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/LearnQuizPilotData.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+enum GBFeatureFlags {
+    static var historyLearnQuizResetEnabled: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        if let rawValue = environment["GOB_HISTORY_LEARN_QUIZ_RESET_ENABLED"],
+           ["1", "true", "yes"].contains(rawValue.lowercased()) {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: "historyLearnQuizResetEnabled")
+    }
+}
+
+struct LearnQuizPilotScene: Identifiable {
+    let id: String
+    let number: Int
+    let title: String
+    let subtitle: String
+    let timeMarker: String
+    let place: String
+    let actionVerb: String
+    let memoryHook: String
+    let story: String
+    let meaning: String
+    let quiz: LearnQuizPrompt
+    let matchPairs: [LearnQuizMatchPair]
+    let chronicleEntry: LearnQuizChronicleEntry
+    let art: LearnQuizArt
+}
+
+struct LearnQuizPrompt {
+    let question: String
+    let options: [String]
+    let correctAnswer: String
+    let hintLadder: [String]
+    let teachingFeedback: String
+}
+
+struct LearnQuizMatchPair: Identifiable {
+    let id: String
+    let left: String
+    let right: String
+    let clue: String
+}
+
+struct LearnQuizChronicleEntry: Identifiable {
+    enum State: String, CaseIterable {
+        case silhouette
+        case inked
+        case sealed
+        case rememberedAgain
+    }
+
+    let id: String
+    let title: String
+    let subtitle: String
+    let meaning: String
+    let state: State
+}
+
+struct LearnQuizArt {
+    let assetSlot: String
+    let symbol: String
+    let emphasis: GBEmphasis
+}
+
+enum LearnQuizPilotData {
+    static let scenes: [LearnQuizPilotScene] = [
+        LearnQuizPilotScene(
+            id: "learn-quiz-shivneri",
+            number: 1,
+            title: "Shivneri",
+            subtitle: "Birth Fort",
+            timeMarker: "Beginning",
+            place: "Shivneri Fort",
+            actionVerb: "Begins",
+            memoryHook: "Birth Fort",
+            story: "Shivaji Maharaj's story begins at Shivneri Fort. Jijabai helped him grow with courage, care, and a love for protecting people.",
+            meaning: "Shivneri is the first place to remember because it anchors the whole journey.",
+            quiz: LearnQuizPrompt(
+                question: "Where does Shivaji Maharaj's story begin?",
+                options: ["Shivneri", "Raigad", "Agra"],
+                correctAnswer: "Shivneri",
+                hintLadder: ["Memory hook: Birth Fort", "Place clue: a hill fort near Junnar", "Choose the fort where the journey begins."],
+                teachingFeedback: "Shivneri is the birth fort. It is where this journey begins."
+            ),
+            matchPairs: [
+                LearnQuizMatchPair(id: "shivneri-birth", left: "Shivneri", right: "Birth Fort", clue: "The beginning of the story."),
+                LearnQuizMatchPair(id: "jijabai-values", left: "Jijabai", right: "Early values", clue: "Guidance helped shape young Shivaji.")
+            ],
+            chronicleEntry: LearnQuizChronicleEntry(
+                id: "chronicle-birth-fort",
+                title: "Birth Fort Chronicle Card",
+                subtitle: "Shivneri",
+                meaning: "The journey starts at Shivneri Fort.",
+                state: .inked
+            ),
+            art: LearnQuizArt(assetSlot: "LearnQuizShivneriHero", symbol: "sunrise.fill", emphasis: .story)
+        ),
+        LearnQuizPilotScene(
+            id: "learn-quiz-torna-rajgad",
+            number: 2,
+            title: "Torna + Rajgad",
+            subtitle: "Early Forts",
+            timeMarker: "Early Swarajya",
+            place: "Torna and Rajgad",
+            actionVerb: "Builds",
+            memoryHook: "First Big Fort / Early Capital",
+            story: "Torna became an early fort victory. Rajgad grew into a planning base where ideas for Swarajya could take shape.",
+            meaning: "These forts help children remember that Swarajya was built with planning, places, and steady effort.",
+            quiz: LearnQuizPrompt(
+                question: "Which fort became an early capital and planning base?",
+                options: ["Rajgad", "Pratapgad", "Shivneri"],
+                correctAnswer: "Rajgad",
+                hintLadder: ["Memory hook: Early Capital", "Place clue: paired with Torna in the early story", "Choose Rajgad."],
+                teachingFeedback: "Rajgad is remembered as an early capital and planning base."
+            ),
+            matchPairs: [
+                LearnQuizMatchPair(id: "torna-first-big", left: "Torna", right: "First Big Fort", clue: "A strong early step."),
+                LearnQuizMatchPair(id: "rajgad-capital", left: "Rajgad", right: "Early Capital", clue: "A place for planning.")
+            ],
+            chronicleEntry: LearnQuizChronicleEntry(
+                id: "chronicle-early-forts",
+                title: "First Fort / Early Capital Card",
+                subtitle: "Torna + Rajgad",
+                meaning: "Early forts show planning and momentum.",
+                state: .sealed
+            ),
+            art: LearnQuizArt(assetSlot: "LearnQuizTornaRajgadHero", symbol: "mountain.2.fill", emphasis: .place)
+        ),
+        LearnQuizPilotScene(
+            id: "learn-quiz-pratapgad",
+            number: 3,
+            title: "Pratapgad",
+            subtitle: "Turning Point",
+            timeMarker: "Major rise",
+            place: "Pratapgad",
+            actionVerb: "Plans",
+            memoryHook: "Turning Point",
+            story: "At Pratapgad, terrain and careful planning mattered. The moment is remembered as a turning point in Shivaji Maharaj's rise.",
+            meaning: "Pratapgad helps children connect place, strategy, and courage without needing a harsh battle story.",
+            quiz: LearnQuizPrompt(
+                question: "Which fort is remembered as the turning point?",
+                options: ["Pratapgad", "Shivneri", "Torna"],
+                correctAnswer: "Pratapgad",
+                hintLadder: ["Memory hook: Turning Point", "Place clue: hill terrain and planning", "Choose Pratapgad."],
+                teachingFeedback: "Pratapgad is the turning point to remember."
+            ),
+            matchPairs: [
+                LearnQuizMatchPair(id: "pratapgad-turning", left: "Pratapgad", right: "Turning Point", clue: "The rise becomes clearer here."),
+                LearnQuizMatchPair(id: "terrain-planning", left: "Hill terrain", right: "Careful planning", clue: "Place and action worked together.")
+            ],
+            chronicleEntry: LearnQuizChronicleEntry(
+                id: "chronicle-turning-point",
+                title: "Turning Point Seal",
+                subtitle: "Pratapgad",
+                meaning: "Strategy, terrain, and courage are linked here.",
+                state: .silhouette
+            ),
+            art: LearnQuizArt(assetSlot: "LearnQuizPratapgadHero", symbol: "seal.fill", emphasis: .chronicle)
+        )
+    ]
+
+    static let journeyEntry = LearnQuizChronicleEntry(
+        id: "chronicle-journey-so-far",
+        title: "Shivaji Journey So Far",
+        subtitle: "Shivneri -> Torna/Rajgad -> Pratapgad",
+        meaning: "The first three scenes form a remembered path through time, place, and action.",
+        state: .rememberedAgain
+    )
+}

--- a/GreatsOfBharatha/Features/LearnQuiz/SceneLearnView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/SceneLearnView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct SceneLearnView: View {
+    let scene: LearnQuizPilotScene
+
+    var body: some View {
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    SceneLearnCard(scene: scene, ctaTitle: "Quiz me")
+
+                    HStack(spacing: GBSpacing.xSmall) {
+                        NavigationLink {
+                            ChronicleQuizView(scene: scene)
+                        } label: {
+                            Label("Quiz", systemImage: "questionmark.bubble.fill")
+                        }
+                        .buttonStyle(.gbPrimary(.story))
+
+                        NavigationLink {
+                            ChronicleMatchView(scenes: LearnQuizPilotData.scenes)
+                        } label: {
+                            Label("Match", systemImage: "square.grid.2x2.fill")
+                        }
+                        .buttonStyle(.gbSecondary)
+                    }
+
+                    NavigationLink {
+                        ChronicleBookView(scenes: LearnQuizPilotData.scenes)
+                    } label: {
+                        GBSurface(style: .elevated) {
+                            HStack(spacing: GBSpacing.small) {
+                                Image(systemName: "book.closed.fill")
+                                    .font(.system(size: 26, weight: .bold))
+                                    .foregroundStyle(GBColor.Chronicle.gold)
+                                VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
+                                    Text("Chronicle reward shell")
+                                        .font(GBFont.ui(size: 16, weight: .bold))
+                                        .foregroundStyle(GBColor.Content.primary)
+                                    Text(scene.chronicleEntry.title)
+                                        .font(GBFont.ui(size: 14, weight: .semibold))
+                                        .foregroundStyle(GBColor.Content.secondary)
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(GBColor.Content.tertiary)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
+            }
+            .background(GBColor.Background.app)
+        }
+        .navigationTitle(scene.memoryHook)
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+    }
+}
+
+#Preview("Scene Learn Cards") {
+    NavigationStack {
+        SceneLearnView(scene: LearnQuizPilotData.scenes[0])
+    }
+}


### PR DESCRIPTION
## Summary

Implements the PR3 UI-components-in-isolation slice for #126.

- Adds a flag-gated `LearnQuizHomeView` route behind `historyLearnQuizResetEnabled` / `GOB_HISTORY_LEARN_QUIZ_RESET_ENABLED`.
- Adds self-contained provisional SwiftUI data and screens for the three-scene Shivaji pilot: learn card, quiz shell, Chronicle Match shell, and Chronicle Book shell.
- Adds placeholder art slot names through `LearnQuizArt.assetSlot` with rendered symbolic placeholders, so future reviewed assets can replace them without reshaping the UI.
- Adds capture route support for `GOB_CAPTURE_DESTINATION=learn-quiz-home`.

## Scope Notes

This intentionally avoids PR1/PR2 dependencies. The quiz, match, and Chronicle screens use local mock/provisional state only; engines and persistent progress can wire in during later integration PRs.

Default app behavior remains unchanged unless the reset flag is enabled.

## Validation

- `git diff --check` passed.
- Confirmed `gh` authentication and pushed `feat/issue-126-pr3-ui`.

Could not run Swift/Xcode validation in this isolated environment because `xcodebuild`, `swift`, and `xcodegen` are not installed.

Closes no issue; contributes to #126.