### PR TITLE
Integrate Shivaji learn quiz reset flow

### DIFF
--- a/GreatsOfBharatha/App/CaptureRootView.swift
+++ b/GreatsOfBharatha/App/CaptureRootView.swift
@@ -13,7 +13,7 @@ struct CaptureRootView: View {
     private var captureScreen: some View {
         switch route {
         case .learnQuizReset:
-            NavigationStack { LearnQuizResetPlaceholderView() }
+            NavigationStack { LearnQuizHomeView() }
         case .scene1:
             if let scene = appModel.content.scenes.first(where: { $0.id == "scene-1-shivneri" }) {
                 NavigationStack { SceneLessonView(scene: scene) }

--- a/GreatsOfBharatha/Features/LearnQuiz/ChronicleMatchView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/ChronicleMatchView.swift
@@ -3,12 +3,18 @@ import SwiftUI
 struct ChronicleMatchView: View {
     let scenes: [LearnQuizPilotScene]
 
-    @State private var selectedLeftID: String?
-    @State private var matchedIDs: Set<String> = []
-    @State private var mismatchPair: LearnQuizMatchPair?
+    @State private var matchState = ChronicleMatchState()
 
-    private var pairs: [LearnQuizMatchPair] {
+    private var pairs: [ChronicleMatchPair] {
         scenes.flatMap(\.matchPairs)
+    }
+
+    private var leftTiles: [ChronicleMatchTile] {
+        ChronicleMatchEngine.tiles(for: pairs).filter { $0.side == .left }
+    }
+
+    private var rightTiles: [ChronicleMatchTile] {
+        Array(ChronicleMatchEngine.tiles(for: pairs).filter { $0.side == .right }.reversed())
     }
 
     var body: some View {
@@ -36,68 +42,41 @@ struct ChronicleMatchView: View {
         GBHeroCard(
             eyebrow: "Match pairs",
             title: "Put each place with its memory hook",
-            subtitle: "\(matchedIDs.count) of \(pairs.count) matched",
+            subtitle: "\(matchState.completedPairIDs.count) of \(pairs.count) matched",
             detail: "Tap a card on the left, then find the card on the right that belongs with it.",
             ctaTitle: "Keep matching",
-            badgeTitle: "6 pilot pairs",
+            badgeTitle: "\(pairs.count) pilot pairs",
             emphasis: .place,
-            progress: pairs.isEmpty ? nil : Double(matchedIDs.count) / Double(pairs.count)
+            progress: pairs.isEmpty ? nil : Double(matchState.completedPairIDs.count) / Double(pairs.count)
         )
     }
 
     private var matchGrid: some View {
         HStack(alignment: .top, spacing: GBSpacing.xSmall) {
             VStack(spacing: GBSpacing.xSmall) {
-                ForEach(pairs) { pair in
-                    matchTile(
-                        id: pair.id,
-                        text: pair.left,
-                        isSelected: selectedLeftID == pair.id,
-                        isMatched: matchedIDs.contains(pair.id),
-                        alignment: .leading
-                    ) {
-                        guard !matchedIDs.contains(pair.id) else { return }
-                        selectedLeftID = pair.id
-                        mismatchPair = nil
-                    }
+                ForEach(leftTiles) { tile in
+                    matchTile(tile: tile, alignment: .leading)
                 }
             }
 
             VStack(spacing: GBSpacing.xSmall) {
-                ForEach(pairs.reversed()) { pair in
-                    matchTile(
-                        id: pair.id,
-                        text: pair.right,
-                        isSelected: false,
-                        isMatched: matchedIDs.contains(pair.id),
-                        alignment: .trailing
-                    ) {
-                        guard !matchedIDs.contains(pair.id), let selectedLeftID else { return }
-                        if selectedLeftID == pair.id {
-                            matchedIDs.insert(pair.id)
-                            self.selectedLeftID = nil
-                            mismatchPair = nil
-                        } else {
-                            mismatchPair = pair
-                        }
-                    }
+                ForEach(rightTiles) { tile in
+                    matchTile(tile: tile, alignment: .trailing)
                 }
             }
         }
     }
 
-    private func matchTile(
-        id: String,
-        text: String,
-        isSelected: Bool,
-        isMatched: Bool,
-        alignment: HorizontalAlignment,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
+    private func matchTile(tile: ChronicleMatchTile, alignment: HorizontalAlignment) -> some View {
+        let isSelected = matchState.selectedTileID == tile.id
+        let isMatched = matchState.completedPairIDs.contains(tile.pairID)
+
+        return Button {
+            matchState = ChronicleMatchEngine.select(tileID: tile.id, state: matchState, pairs: pairs)
+        } label: {
             HStack {
                 if alignment == .trailing { Spacer(minLength: GBSpacing.xxSmall) }
-                Text(text)
+                Text(tile.text)
                     .font(GBFont.ui(size: 15, weight: .heavy))
                     .multilineTextAlignment(alignment == .leading ? .leading : .trailing)
                     .lineLimit(3)
@@ -114,34 +93,43 @@ struct ChronicleMatchView: View {
         }
         .buttonStyle(.plain)
         .foregroundStyle(isMatched ? GBColor.Place.primary : GBColor.Content.primary)
-        .accessibilityLabel("\(text), \(isMatched ? "matched" : "not matched")")
+        .accessibilityLabel("\(tile.text), \(isMatched ? "matched" : "not matched")")
     }
 
     @ViewBuilder
     private var clueCard: some View {
-        if let selectedLeftID, let selected = pairs.first(where: { $0.id == selectedLeftID }) {
+        switch matchState.lastOutcome {
+        case .selected(let tile):
             GBSurface(style: .elevated) {
-                Label("Now tap the matching card for \(selected.left).", systemImage: "hand.tap.fill")
+                Label("Now tap the matching card for \(tile.text).", systemImage: "hand.tap.fill")
                     .font(GBFont.ui(size: 16, weight: .bold))
                     .foregroundStyle(GBColor.Content.primary)
             }
-        } else if let mismatchPair {
+        case .mismatched(let clue):
             GBSurface(style: .elevated) {
                 VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
                     Label("Try another pair", systemImage: "arrow.counterclockwise.circle.fill")
                         .font(GBFont.ui(size: 16, weight: .heavy))
                         .foregroundStyle(GBColor.Story.primary)
-                    Text(mismatchPair.clue)
+                    Text(clue)
                         .font(GBFont.ui(size: 15, weight: .semibold))
                         .foregroundStyle(GBColor.Content.secondary)
                 }
             }
+        case .matched(_, let feedback, let completedSet):
+            GBSurface(style: completedSet ? .accented(.chronicle) : .elevated) {
+                Label(feedback, systemImage: "checkmark.circle.fill")
+                    .font(GBFont.ui(size: 16, weight: .heavy))
+                    .foregroundStyle(completedSet ? .white : GBColor.Content.primary)
+            }
+        case .ignored, nil:
+            EmptyView()
         }
     }
 
     @ViewBuilder
     private var completionCard: some View {
-        if matchedIDs.count == pairs.count {
+        if matchState.completedPairIDs.count == pairs.count {
             GBSurface(style: .accented(.chronicle)) {
                 Label("All pairs matched. A Chronicle seal is ready.", systemImage: "checkmark.seal.fill")
                     .font(GBFont.ui(size: 17, weight: .heavy))

--- a/GreatsOfBharatha/Features/LearnQuiz/ChronicleQuizView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/ChronicleQuizView.swift
@@ -3,11 +3,19 @@ import SwiftUI
 struct ChronicleQuizView: View {
     let scene: LearnQuizPilotScene
 
-    @State private var selectedAnswer: String?
-    @State private var hintIndex = 0
+    @State private var quizState = ChronicleQuizState()
+    @State private var result: ChronicleQuizResult?
+
+    private var selectedAnswer: String? {
+        quizState.selectedAnswer
+    }
 
     private var isCorrect: Bool {
-        selectedAnswer == scene.quiz.correctAnswer
+        result?.isCorrect == true
+    }
+
+    private var visibleHintIndex: Int {
+        max(0, min(quizState.revealedHintCount, scene.quiz.hintLadder.count) - 1)
     }
 
     var body: some View {
@@ -52,7 +60,12 @@ struct ChronicleQuizView: View {
         LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: GBSpacing.xSmall) {
             ForEach(scene.quiz.options, id: \.self) { option in
                 Button {
-                    selectedAnswer = option
+                    result = ChronicleQuizEngine.evaluate(
+                        state: quizState,
+                        challenge: scene.quiz.challenge,
+                        selectedAnswer: option
+                    )
+                    quizState = result?.nextState ?? quizState
                 } label: {
                     HStack {
                         Text(option)
@@ -82,36 +95,36 @@ struct ChronicleQuizView: View {
                 HStack {
                     GBBadge(title: "Hint ladder", symbol: "sparkle.magnifyingglass", emphasis: .chronicle)
                     Spacer()
-                    Text("\(min(hintIndex + 1, scene.quiz.hintLadder.count))/\(scene.quiz.hintLadder.count)")
+                    Text("\(min(visibleHintIndex + 1, scene.quiz.hintLadder.count))/\(scene.quiz.hintLadder.count)")
                         .font(GBFont.ui(size: 12, weight: .heavy))
                         .foregroundStyle(GBColor.Content.tertiary)
                 }
 
-                Text(scene.quiz.hintLadder[hintIndex])
+                Text(scene.quiz.hintLadder[visibleHintIndex])
                     .font(GBFont.ui(size: 17, weight: .bold))
                     .foregroundStyle(GBColor.Content.primary)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Button {
-                    hintIndex = min(hintIndex + 1, scene.quiz.hintLadder.count - 1)
+                    quizState = ChronicleQuizEngine.revealNextHint(from: quizState, challenge: scene.quiz.challenge)
                 } label: {
                     Label("Show next clue", systemImage: "arrow.down.circle.fill")
                 }
                 .buttonStyle(.gbSecondary)
-                .disabled(hintIndex >= scene.quiz.hintLadder.count - 1)
+                .disabled(quizState.revealedHintCount >= scene.quiz.hintLadder.count)
             }
         }
     }
 
     @ViewBuilder
     private var feedbackCard: some View {
-        if let selectedAnswer {
+        if selectedAnswer != nil, let result {
             GBSurface(style: isCorrect ? .accented(.chronicle) : .elevated) {
                 VStack(alignment: .leading, spacing: GBSpacing.xSmall) {
                     Label(isCorrect ? "Remembered" : "Try with this clue", systemImage: isCorrect ? "checkmark.seal.fill" : "heart.text.square.fill")
                         .font(GBFont.ui(size: 17, weight: .heavy))
                         .foregroundStyle(isCorrect ? .white : GBColor.Content.primary)
-                    Text(isCorrect ? "\(selectedAnswer) is right." : scene.quiz.teachingFeedback)
+                    Text(result.feedback)
                         .font(GBFont.story(size: 18))
                         .foregroundStyle(isCorrect ? .white.opacity(0.92) : GBColor.Content.secondary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/GreatsOfBharatha/Features/LearnQuiz/LearnQuizPilotData.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/LearnQuizPilotData.swift
@@ -151,7 +151,7 @@ enum LearnQuizPilotData {
             linkedSceneID: scene.id,
             linkedPlaceID: scene.placeAnchors.first?.id,
             linkedTimelineEventID: nil,
-            unlockRule: UnlockRule(requiredMastery: .understood, enhancedMastery: .mastered)
+            unlockRule: UnlockRule(requiredMastery: .understood, enhancedMastery: .remembered)
         )
         let progress = ChronicleProgressEngine.progress(
             for: entry,

--- a/GreatsOfBharatha/Features/LearnQuiz/LearnQuizPilotData.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/LearnQuizPilotData.swift
@@ -23,7 +23,7 @@ struct LearnQuizPilotScene: Identifiable {
     let story: String
     let meaning: String
     let quiz: LearnQuizPrompt
-    let matchPairs: [LearnQuizMatchPair]
+    let matchPairs: [ChronicleMatchPair]
     let chronicleEntry: LearnQuizChronicleEntry
     let art: LearnQuizArt
 }
@@ -34,13 +34,7 @@ struct LearnQuizPrompt {
     let correctAnswer: String
     let hintLadder: [String]
     let teachingFeedback: String
-}
-
-struct LearnQuizMatchPair: Identifiable {
-    let id: String
-    let left: String
-    let right: String
-    let clue: String
+    let challenge: RecallChallenge
 }
 
 struct LearnQuizChronicleEntry: Identifiable {
@@ -65,107 +59,146 @@ struct LearnQuizArt {
 }
 
 enum LearnQuizPilotData {
-    static let scenes: [LearnQuizPilotScene] = [
-        LearnQuizPilotScene(
-            id: "learn-quiz-shivneri",
-            number: 1,
-            title: "Shivneri",
-            subtitle: "Birth Fort",
-            timeMarker: "Beginning",
-            place: "Shivneri Fort",
-            actionVerb: "Begins",
-            memoryHook: "Birth Fort",
-            story: "Shivaji Maharaj's story begins at Shivneri Fort. Jijabai helped him grow with courage, care, and a love for protecting people.",
-            meaning: "Shivneri is the first place to remember because it anchors the whole journey.",
-            quiz: LearnQuizPrompt(
-                question: "Where does Shivaji Maharaj's story begin?",
-                options: ["Shivneri", "Raigad", "Agra"],
-                correctAnswer: "Shivneri",
-                hintLadder: ["Memory hook: Birth Fort", "Place clue: a hill fort near Junnar", "Choose the fort where the journey begins."],
-                teachingFeedback: "Shivneri is the birth fort. It is where this journey begins."
-            ),
-            matchPairs: [
-                LearnQuizMatchPair(id: "shivneri-birth", left: "Shivneri", right: "Birth Fort", clue: "The beginning of the story."),
-                LearnQuizMatchPair(id: "jijabai-values", left: "Jijabai", right: "Early values", clue: "Guidance helped shape young Shivaji.")
-            ],
-            chronicleEntry: LearnQuizChronicleEntry(
-                id: "chronicle-birth-fort",
-                title: "Birth Fort Chronicle Card",
-                subtitle: "Shivneri",
-                meaning: "The journey starts at Shivneri Fort.",
-                state: .inked
-            ),
-            art: LearnQuizArt(assetSlot: "LearnQuizShivneriHero", symbol: "sunrise.fill", emphasis: .story)
-        ),
-        LearnQuizPilotScene(
-            id: "learn-quiz-torna-rajgad",
-            number: 2,
-            title: "Torna + Rajgad",
-            subtitle: "Early Forts",
-            timeMarker: "Early Swarajya",
-            place: "Torna and Rajgad",
-            actionVerb: "Builds",
-            memoryHook: "First Big Fort / Early Capital",
-            story: "Torna became an early fort victory. Rajgad grew into a planning base where ideas for Swarajya could take shape.",
-            meaning: "These forts help children remember that Swarajya was built with planning, places, and steady effort.",
-            quiz: LearnQuizPrompt(
-                question: "Which fort became an early capital and planning base?",
-                options: ["Rajgad", "Pratapgad", "Shivneri"],
-                correctAnswer: "Rajgad",
-                hintLadder: ["Memory hook: Early Capital", "Place clue: paired with Torna in the early story", "Choose Rajgad."],
-                teachingFeedback: "Rajgad is remembered as an early capital and planning base."
-            ),
-            matchPairs: [
-                LearnQuizMatchPair(id: "torna-first-big", left: "Torna", right: "First Big Fort", clue: "A strong early step."),
-                LearnQuizMatchPair(id: "rajgad-capital", left: "Rajgad", right: "Early Capital", clue: "A place for planning.")
-            ],
-            chronicleEntry: LearnQuizChronicleEntry(
-                id: "chronicle-early-forts",
-                title: "First Fort / Early Capital Card",
-                subtitle: "Torna + Rajgad",
-                meaning: "Early forts show planning and momentum.",
-                state: .sealed
-            ),
-            art: LearnQuizArt(assetSlot: "LearnQuizTornaRajgadHero", symbol: "mountain.2.fill", emphasis: .place)
-        ),
-        LearnQuizPilotScene(
-            id: "learn-quiz-pratapgad",
-            number: 3,
-            title: "Pratapgad",
-            subtitle: "Turning Point",
-            timeMarker: "Major rise",
-            place: "Pratapgad",
-            actionVerb: "Plans",
-            memoryHook: "Turning Point",
-            story: "At Pratapgad, terrain and careful planning mattered. The moment is remembered as a turning point in Shivaji Maharaj's rise.",
-            meaning: "Pratapgad helps children connect place, strategy, and courage without needing a harsh battle story.",
-            quiz: LearnQuizPrompt(
-                question: "Which fort is remembered as the turning point?",
-                options: ["Pratapgad", "Shivneri", "Torna"],
-                correctAnswer: "Pratapgad",
-                hintLadder: ["Memory hook: Turning Point", "Place clue: hill terrain and planning", "Choose Pratapgad."],
-                teachingFeedback: "Pratapgad is the turning point to remember."
-            ),
-            matchPairs: [
-                LearnQuizMatchPair(id: "pratapgad-turning", left: "Pratapgad", right: "Turning Point", clue: "The rise becomes clearer here."),
-                LearnQuizMatchPair(id: "terrain-planning", left: "Hill terrain", right: "Careful planning", clue: "Place and action worked together.")
-            ],
-            chronicleEntry: LearnQuizChronicleEntry(
-                id: "chronicle-turning-point",
-                title: "Turning Point Seal",
-                subtitle: "Pratapgad",
-                meaning: "Strategy, terrain, and courage are linked here.",
-                state: .silhouette
-            ),
-            art: LearnQuizArt(assetSlot: "LearnQuizPratapgadHero", symbol: "seal.fill", emphasis: .chronicle)
-        )
-    ]
+    private static let pilot = SampleContent.shivajiLearnQuizResetPilot
 
-    static let journeyEntry = LearnQuizChronicleEntry(
-        id: "chronicle-journey-so-far",
-        title: "Shivaji Journey So Far",
-        subtitle: "Shivneri -> Torna/Rajgad -> Pratapgad",
-        meaning: "The first three scenes form a remembered path through time, place, and action.",
-        state: .rememberedAgain
-    )
+    static var scenes: [LearnQuizPilotScene] {
+        pilot.scenes.enumerated().map { index, scene in
+            makeScene(from: scene, number: index + 1)
+        }
+    }
+
+    static var journeyEntry: LearnQuizChronicleEntry {
+        LearnQuizChronicleEntry(
+            id: pilot.endOfPilotReward.id,
+            title: pilot.endOfPilotReward.title,
+            subtitle: pilot.endOfPilotReward.subtitle,
+            meaning: pilot.endOfPilotReward.meaning,
+            state: .rememberedAgain
+        )
+    }
+
+    private static func makeScene(from scene: ChronicleScene, number: Int) -> LearnQuizPilotScene {
+        let quizItem = scene.quizItems.first ?? fallbackQuizItem(for: scene)
+        return LearnQuizPilotScene(
+            id: scene.id,
+            number: number,
+            title: scene.title,
+            subtitle: scene.memoryHook,
+            timeMarker: scene.timeMarker,
+            place: scene.placeAnchors.map(\.name).joined(separator: " + "),
+            actionVerb: scene.actionVerb,
+            memoryHook: scene.memoryHook,
+            story: scene.childSafeStory,
+            meaning: scene.meaning,
+            quiz: makePrompt(from: quizItem),
+            matchPairs: scene.matchPairs.map(makeMatchPair),
+            chronicleEntry: makeChronicleEntry(from: scene),
+            art: art(for: scene)
+        )
+    }
+
+    private static func makePrompt(from item: QuizItem) -> LearnQuizPrompt {
+        let challenge = RecallChallenge(
+            id: item.id,
+            promptType: .openPrompt,
+            prompt: item.prompt,
+            correctAnswers: item.acceptedAnswers,
+            hintLadder: item.hintLadder,
+            feedback: RecallFeedback(success: item.successFeedback, recovery: item.recoveryFeedback),
+            masteryContribution: .understood
+        )
+        return LearnQuizPrompt(
+            question: item.prompt,
+            options: item.answerChips,
+            correctAnswer: item.acceptedAnswers.first ?? item.answerChips.first ?? "",
+            hintLadder: item.hintLadder.map(\.body),
+            teachingFeedback: item.recoveryFeedback,
+            challenge: challenge
+        )
+    }
+
+    private static func makeMatchPair(from pair: MatchPair) -> ChronicleMatchPair {
+        ChronicleMatchPair(
+            id: pair.id,
+            leftID: "\(pair.id)-left",
+            leftText: pair.left,
+            rightID: "\(pair.id)-right",
+            rightText: pair.right,
+            kind: makeMatchKind(from: pair.kind),
+            teachingClue: pair.teachingFeedback
+        )
+    }
+
+    private static func makeMatchKind(from kind: MatchPairKind) -> ChronicleMatchPairKind {
+        switch kind {
+        case .placeToHook:
+            return .placeToHook
+        case .placeToAction:
+            return .placeToAction
+        case .eventToTime:
+            return .eventToTimeMarker
+        case .actionToMeaning:
+            return .meaningToScene
+        }
+    }
+
+    private static func makeChronicleEntry(from scene: ChronicleScene) -> LearnQuizChronicleEntry {
+        let entry = ChronicleEntry(
+            id: scene.chronicleReward.id,
+            title: scene.chronicleReward.title,
+            keepsakeTitle: scene.chronicleReward.subtitle,
+            meaningStatement: scene.chronicleReward.meaning,
+            linkedSceneID: scene.id,
+            linkedPlaceID: scene.placeAnchors.first?.id,
+            linkedTimelineEventID: nil,
+            unlockRule: UnlockRule(requiredMastery: .understood, enhancedMastery: .mastered)
+        )
+        let progress = ChronicleProgressEngine.progress(
+            for: entry,
+            evidence: [.lessonSeen, .recallCorrect],
+            at: Date()
+        )
+        return LearnQuizChronicleEntry(
+            id: scene.chronicleReward.id,
+            title: scene.chronicleReward.title,
+            subtitle: scene.chronicleReward.subtitle,
+            meaning: scene.chronicleReward.meaning,
+            state: makeEntryState(from: progress.detailLevel)
+        )
+    }
+
+    private static func makeEntryState(from detailLevel: ChronicleRewardDetailLevel) -> LearnQuizChronicleEntry.State {
+        switch detailLevel {
+        case .hidden, .silhouette:
+            return .silhouette
+        case .inked:
+            return .inked
+        case .sealed:
+            return .sealed
+        case .rememberedAgain:
+            return .rememberedAgain
+        }
+    }
+
+    private static func art(for scene: ChronicleScene) -> LearnQuizArt {
+        if scene.id.contains("shivneri") {
+            return LearnQuizArt(assetSlot: "LearnQuizShivneriHero", symbol: "sunrise.fill", emphasis: .story)
+        }
+        if scene.id.contains("torna") || scene.id.contains("rajgad") {
+            return LearnQuizArt(assetSlot: "LearnQuizTornaRajgadHero", symbol: "mountain.2.fill", emphasis: .place)
+        }
+        return LearnQuizArt(assetSlot: "LearnQuizPratapgadHero", symbol: "seal.fill", emphasis: .chronicle)
+    }
+
+    private static func fallbackQuizItem(for scene: ChronicleScene) -> QuizItem {
+        QuizItem(
+            id: "\(scene.id)-fallback-quiz",
+            prompt: "What should we remember about \(scene.title)?",
+            acceptedAnswers: [scene.memoryHook],
+            answerChips: [scene.memoryHook],
+            hintLadder: [RecallHint(level: 1, title: "Memory hook", body: scene.memoryHook)],
+            successFeedback: "Yes. \(scene.memoryHook) is the memory hook.",
+            recoveryFeedback: "Remember the hook: \(scene.memoryHook)."
+        )
+    }
 }

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -88,6 +88,22 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertEqual(matchIDs.count, pilot.scenes.flatMap(\.matchPairs).count)
     }
 
+
+    func testLearnQuizUIAdapterUsesResetPilotContractsAndEngines() {
+        let scenes = LearnQuizPilotData.scenes
+        let pilot = SampleContent.shivajiLearnQuizResetPilot
+
+        XCTAssertEqual(scenes.map(\.id), pilot.scenes.map(\.id))
+        XCTAssertEqual(scenes.first?.quiz.challenge.correctAnswers, pilot.scenes.first?.quizItems.first?.acceptedAnswers)
+        XCTAssertEqual(scenes.flatMap(\.matchPairs).count, pilot.scenes.flatMap(\.matchPairs).count)
+
+        var matchState = ChronicleMatchState()
+        let firstPair = scenes.flatMap(\.matchPairs)[0]
+        matchState = ChronicleMatchEngine.select(tileID: firstPair.leftID, state: matchState, pairs: scenes.flatMap(\.matchPairs))
+        matchState = ChronicleMatchEngine.select(tileID: firstPair.rightID, state: matchState, pairs: scenes.flatMap(\.matchPairs))
+        XCTAssertTrue(matchState.completedPairIDs.contains(firstPair.id))
+    }
+
     func testLessonStorePreviewsChronicleRewardsBeforeUnlockingThem() throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
         defaults.removePersistentDomain(forName: #function)


### PR DESCRIPTION
## Summary
- Wire the learn/quiz UI shell to the #126 reset pilot content contracts in SampleContent
- Route quiz answers through ChronicleQuizEngine and match interactions through ChronicleMatchEngine
- Update capture routing to use the final LearnQuizHomeView behind the reset flow
- Add coverage proving the UI adapter uses the merged pilot contracts and engines

Part of #126.

## Validation
- git diff --check
- Local Linux host has no swift/xcodegen; CI will run iOS/Xcode gates.