### PR TITLE
[codex] Fix local narration playback

### DIFF
--- a/GreatsOfBharatha/DesignSystem/Components/GBFlashCard.swift
+++ b/GreatsOfBharatha/DesignSystem/Components/GBFlashCard.swift
@@ -21,6 +21,7 @@ struct GBFlashCardData: Identifiable, Sendable {
 final class GBNarrator: ObservableObject {
     private let synthesizer = AVSpeechSynthesizer()
     @Published private(set) var activeCardID: String? = nil
+    @Published private(set) var statusMessage: String? = nil
     private var lastRequest: (id: String, text: String)?
 
     func toggle(cardID: String, text: String) {
@@ -33,9 +34,24 @@ final class GBNarrator: ObservableObject {
     }
 
     func speak(id: String, text: String) {
-        lastRequest = (id: id, text: text)
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else {
+            statusMessage = "Nothing to read aloud yet."
+            activeCardID = nil
+            return
+        }
+
+        lastRequest = (id: id, text: trimmedText)
         synthesizer.stopSpeaking(at: .immediate)
-        let utterance = AVSpeechUtterance(string: text)
+
+        do {
+            try prepareAudioSessionForSpeech()
+            statusMessage = nil
+        } catch {
+            statusMessage = "Narration is unavailable. Check volume and try again."
+        }
+
+        let utterance = AVSpeechUtterance(string: trimmedText)
         // Slightly slower rate so young children can follow
         utterance.rate = AVSpeechUtteranceMinimumSpeechRate
             + (AVSpeechUtteranceDefaultSpeechRate - AVSpeechUtteranceMinimumSpeechRate) * 0.30
@@ -53,6 +69,14 @@ final class GBNarrator: ObservableObject {
     func stop() {
         synthesizer.stopSpeaking(at: .immediate)
         activeCardID = nil
+    }
+
+    private func prepareAudioSessionForSpeech() throws {
+#if os(iOS)
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playback, mode: .spokenAudio, options: [.duckOthers])
+        try session.setActive(true)
+#endif
     }
 }
 

--- a/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
+++ b/GreatsOfBharatha/Features/Lesson/LessonHomeView.swift
@@ -98,18 +98,28 @@ struct LessonHomeView: View {
     }
 
     private func narrationRow(text: String) -> some View {
-        HStack(spacing: GBSpacing.xSmall) {
-            narrationButton(title: "Listen", icon: "speaker.wave.2.fill") {
-                narrator.speak(id: "home-chapter-1", text: text)
+        VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+            HStack(spacing: GBSpacing.xSmall) {
+                narrationButton(title: "Listen", icon: "speaker.wave.2.fill") {
+                    narrator.speak(id: "home-chapter-1", text: text)
+                }
+                narrationButton(title: "Repeat", icon: "arrow.clockwise") {
+                    narrator.repeatLast()
+                }
+                narrationButton(title: "Stop", icon: "stop.fill") {
+                    narrator.stop()
+                }
             }
-            narrationButton(title: "Repeat", icon: "arrow.clockwise") {
-                narrator.repeatLast()
-            }
-            narrationButton(title: "Stop", icon: "stop.fill") {
-                narrator.stop()
+            .accessibilityElement(children: .contain)
+
+            if let statusMessage = narrator.statusMessage {
+                Text(statusMessage)
+                    .font(GBFont.ui(size: 13, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.86))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityLabel(statusMessage)
             }
         }
-        .accessibilityElement(children: .contain)
     }
 
     private func narrationButton(title: String, icon: String, action: @escaping () -> Void) -> some View {

--- a/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
+++ b/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
@@ -244,18 +244,28 @@ struct SceneLessonView: View {
     }
 
     private func narrationControls(text: String, id: String) -> some View {
-        HStack(spacing: GBSpacing.xSmall) {
-            narrationButton(title: "Listen", icon: "speaker.wave.2.fill") {
-                narrator.speak(id: id, text: text)
+        VStack(alignment: .leading, spacing: GBSpacing.xxSmall) {
+            HStack(spacing: GBSpacing.xSmall) {
+                narrationButton(title: "Listen", icon: "speaker.wave.2.fill") {
+                    narrator.speak(id: id, text: text)
+                }
+                narrationButton(title: "Repeat", icon: "arrow.clockwise") {
+                    narrator.repeatLast()
+                }
+                narrationButton(title: "Stop", icon: "stop.fill") {
+                    narrator.stop()
+                }
             }
-            narrationButton(title: "Repeat", icon: "arrow.clockwise") {
-                narrator.repeatLast()
-            }
-            narrationButton(title: "Stop", icon: "stop.fill") {
-                narrator.stop()
+            .accessibilityElement(children: .contain)
+
+            if let statusMessage = narrator.statusMessage {
+                Text(statusMessage)
+                    .font(GBFont.ui(size: 13, weight: .semibold))
+                    .foregroundStyle(GBColor.Content.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityLabel(statusMessage)
             }
         }
-        .accessibilityElement(children: .contain)
     }
 
     private func narrationButton(title: String, icon: String, action: @escaping () -> Void) -> some View {

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -289,6 +289,22 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertFalse(model.parentSettings.narrationEnabled)
     }
 
+    func testNarratorUsesLocalPlaybackSpeechWithFallbackMessage() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let narratorURL = repoRoot
+            .appendingPathComponent("GreatsOfBharatha/DesignSystem/Components/GBFlashCard.swift")
+        let source = try String(contentsOf: narratorURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("AVSpeechSynthesizer()"))
+        XCTAssertTrue(source.contains("AVAudioSession.sharedInstance()"))
+        XCTAssertTrue(source.contains("setCategory(.playback, mode: .spokenAudio"))
+        XCTAssertTrue(source.contains("Narration is unavailable. Check volume and try again."))
+        XCTAssertFalse(source.localizedCaseInsensitiveContains("http"))
+    }
+
     func testCorePlacesExposeMapExplorerCoordinatesAndAppleMapsLinks() throws {
         for place in SampleContent.shivajiVerticalSlice.corePlaces {
             let latitude = try XCTUnwrap(place.latitude)


### PR DESCRIPTION
## What changed
- Configured `GBNarrator` to activate an on-device `AVAudioSession` using `.playback` and `.spokenAudio` before `AVSpeechSynthesizer` speaks.
- Added a user-visible fallback status if the narration audio session cannot be prepared.
- Added a regression test that locks the narration path to local AVFoundation speech and the playback/fallback behavior.

## Root cause
The TestFlight screenshot for #125 shows the device in Silent Mode while using the lesson Listen controls. The app was calling `AVSpeechSynthesizer` without preparing a playback audio session, so speech could be muted by the hardware silent switch.

## Validation
- `git diff --check`
- Unable to run `xcodebuild test -scheme GreatsOfBharatha -destination 'platform=iOS Simulator,name=iPhone 16' -quiet` in this container because `xcodebuild` is not installed.
- Unable to run Swift CLI checks because `swift` is not installed.

Closes #125