### PR TITLE
[codex] Add map quiz highlights

### DIFF
--- a/GreatsOfBharatha/Features/Map/PlacesHubView.swift
+++ b/GreatsOfBharatha/Features/Map/PlacesHubView.swift
@@ -327,6 +327,15 @@ private struct PlaceMapExplorerSheet: View {
     let nearbyPlaces: [Place]
 
     @State private var cameraPosition: MapCameraPosition
+    @State private var mapQuizState = MapQuizState()
+
+    private var mapQuizPrompts: [MapQuizPlacePrompt] {
+        MapQuizEngine.prompts(for: nearbyPlaces)
+    }
+
+    private var highlightGroups: [MapHighlightGroup] {
+        MapQuizEngine.defaultHighlightGroups(for: nearbyPlaces)
+    }
 
     init(place: Place, nearbyPlaces: [Place]) {
         self.place = place
@@ -350,18 +359,22 @@ private struct PlaceMapExplorerSheet: View {
                     }
                 }
 
+                mapQuizPromptCard
+
                 Map(position: $cameraPosition) {
                     ForEach(nearbyPlaces.filter { $0.coordinate != nil }) { candidate in
-                        Annotation(candidate.name, coordinate: candidate.coordinate!) {
-                            VStack(spacing: 4) {
-                                Image(systemName: candidate.id == place.id ? "mappin.circle.fill" : "mappin.circle")
-                                    .font(candidate.id == place.id ? .title : .title2)
-                                    .foregroundStyle(candidate.id == place.id ? GBColor.Accent.place : GBColor.Content.primary)
-                                Text(candidate.name)
-                                    .font(.caption2.weight(.bold))
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 4)
-                                    .background(.ultraThinMaterial, in: Capsule())
+                        if let coordinate = candidate.coordinate {
+                            Annotation(annotationTitle(for: candidate), coordinate: coordinate) {
+                                Button {
+                                    withAnimation(GBMotion.bounce) {
+                                        mapQuizState = MapQuizEngine.reveal(placeID: candidate.id, in: mapQuizState)
+                                    }
+                                    GBHaptic.pinCorrect()
+                                } label: {
+                                    mapPin(for: candidate)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel(accessibilityLabel(for: candidate))
                             }
                         }
                     }
@@ -410,6 +423,107 @@ private struct PlaceMapExplorerSheet: View {
                 longitudeDelta: viewport.longitudeDelta
             )
         )
+    }
+
+    private var mapQuizPromptCard: some View {
+        GBSurface(style: .elevated) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Map quiz")
+                        .font(.headline)
+                    Spacer()
+                    Text("\(mapQuizState.revealedPlaceIDs.count)/\(mapQuizPrompts.count)")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(GBColor.Place.primary)
+                }
+
+                Text(currentQuizClue)
+                    .font(.subheadline)
+                    .foregroundStyle(GBColor.Content.secondary)
+
+                if !highlightGroups.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: GBSpacing.xSmall) {
+                            Button {
+                                withAnimation(GBMotion.spring) {
+                                    mapQuizState = MapQuizEngine.clearHighlights(from: mapQuizState)
+                                }
+                            } label: {
+                                Label("Clear", systemImage: "xmark.circle")
+                            }
+                            .buttonStyle(.gbSecondary)
+
+                            ForEach(highlightGroups) { group in
+                                Button {
+                                    withAnimation(GBMotion.spring) {
+                                        mapQuizState = MapQuizEngine.apply(group: group, to: mapQuizState)
+                                    }
+                                } label: {
+                                    Label(group.title, systemImage: mapQuizState.activeGroupID == group.id ? "mappin.and.ellipse.circle.fill" : "mappin.and.ellipse.circle")
+                                }
+                                .buttonStyle(.gbSecondary)
+                                .accessibilityHint(group.subtitle)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var currentQuizClue: String {
+        guard let prompt = mapQuizPrompts.first(where: { !mapQuizState.revealedPlaceIDs.contains($0.placeID) }) else {
+            return "Every fort name is revealed. Try a group highlight and compare the cluster."
+        }
+        return "\(prompt.anchorClue) Hook: \(prompt.memoryHook)."
+    }
+
+    private func mapPin(for candidate: Place) -> some View {
+        let isRevealed = mapQuizState.revealedPlaceIDs.contains(candidate.id)
+        let isHighlighted = mapQuizState.highlightedPlaceIDs.contains(candidate.id)
+        let isFocus = candidate.id == place.id
+
+        return VStack(spacing: 4) {
+            ZStack {
+                if isHighlighted {
+                    Circle()
+                        .stroke(GBColor.Accent.success.opacity(0.65), lineWidth: 4)
+                        .frame(width: 46, height: 46)
+                }
+
+                Image(systemName: pinIcon(for: candidate, isRevealed: isRevealed))
+                    .font(isFocus || isHighlighted ? .title : .title2)
+                    .foregroundStyle(pinColor(isFocus: isFocus, isHighlighted: isHighlighted, isRevealed: isRevealed))
+            }
+
+            Text(isRevealed ? candidate.name : "Mystery fort")
+                .font(.caption2.weight(.bold))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 4)
+                .background(.ultraThinMaterial, in: Capsule())
+        }
+    }
+
+    private func annotationTitle(for candidate: Place) -> String {
+        mapQuizState.revealedPlaceIDs.contains(candidate.id) ? candidate.name : "Mystery fort"
+    }
+
+    private func accessibilityLabel(for candidate: Place) -> String {
+        if mapQuizState.revealedPlaceIDs.contains(candidate.id) {
+            return "\(candidate.name), revealed map quiz fort."
+        }
+        return "Mystery fort near \(candidate.regionLabel). Tap to reveal."
+    }
+
+    private func pinIcon(for candidate: Place, isRevealed: Bool) -> String {
+        if !isRevealed { return "questionmark.circle.fill" }
+        return candidate.id == place.id ? "mappin.circle.fill" : "mappin.circle"
+    }
+
+    private func pinColor(isFocus: Bool, isHighlighted: Bool, isRevealed: Bool) -> Color {
+        if isHighlighted { return GBColor.Accent.success }
+        if isFocus { return GBColor.Accent.place }
+        return isRevealed ? GBColor.Content.primary : GBColor.Content.secondary
     }
 }
 

--- a/GreatsOfBharatha/Shared/Models/LearningEngines.swift
+++ b/GreatsOfBharatha/Shared/Models/LearningEngines.swift
@@ -139,6 +139,109 @@ enum ChronicleQuizEngine {
     }
 }
 
+struct MapQuizPlacePrompt: Identifiable, Codable, Equatable {
+    let id: String
+    let placeID: String
+    let hiddenTitle: String
+    let revealedTitle: String
+    let anchorClue: String
+    let memoryHook: String
+}
+
+struct MapHighlightGroup: Identifiable, Codable, Equatable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let placeIDs: Set<String>
+}
+
+struct MapQuizState: Codable, Equatable {
+    var revealedPlaceIDs: Set<String>
+    var highlightedPlaceIDs: Set<String>
+    var activeGroupID: String?
+
+    init(
+        revealedPlaceIDs: Set<String> = [],
+        highlightedPlaceIDs: Set<String> = [],
+        activeGroupID: String? = nil
+    ) {
+        self.revealedPlaceIDs = revealedPlaceIDs
+        self.highlightedPlaceIDs = highlightedPlaceIDs
+        self.activeGroupID = activeGroupID
+    }
+}
+
+enum MapQuizEngine {
+    static let puneLatitude = 18.5204
+    static let puneLongitude = 73.8567
+
+    static func prompts(for places: [Place]) -> [MapQuizPlacePrompt] {
+        places
+            .filter { $0.latitude != nil && $0.longitude != nil }
+            .map { place in
+                MapQuizPlacePrompt(
+                    id: "map-quiz-\(place.id)",
+                    placeID: place.id,
+                    hiddenTitle: "Mystery fort",
+                    revealedTitle: place.name,
+                    anchorClue: anchorClue(for: place),
+                    memoryHook: place.memoryHook
+                )
+            }
+    }
+
+    static func reveal(placeID: String, in state: MapQuizState) -> MapQuizState {
+        var nextState = state
+        nextState.revealedPlaceIDs.insert(placeID)
+        return nextState
+    }
+
+    static func apply(group: MapHighlightGroup, to state: MapQuizState) -> MapQuizState {
+        var nextState = state
+        nextState.activeGroupID = group.id
+        nextState.highlightedPlaceIDs = group.placeIDs
+        return nextState
+    }
+
+    static func clearHighlights(from state: MapQuizState) -> MapQuizState {
+        var nextState = state
+        nextState.activeGroupID = nil
+        nextState.highlightedPlaceIDs.removeAll()
+        return nextState
+    }
+
+    static func defaultHighlightGroups(for places: [Place]) -> [MapHighlightGroup] {
+        let placeIDs = Set(places.map(\.id))
+        let puneSideForts = Set(["place-torna", "place-rajgad", "place-purandar"]).intersection(placeIDs)
+        let openingJourney = Set(["place-shivneri", "place-torna", "place-rajgad", "place-pratapgad"]).intersection(placeIDs)
+
+        return [
+            MapHighlightGroup(
+                id: "pune-side-forts",
+                title: "Near Pune group",
+                subtitle: "Pune-side forts sit close together around the same landmark.",
+                placeIDs: puneSideForts
+            ),
+            MapHighlightGroup(
+                id: "opening-journey",
+                title: "Opening journey",
+                subtitle: "Reveal the first forts in the learn-and-quiz reset.",
+                placeIDs: openingJourney
+            ),
+        ].filter { !$0.placeIDs.isEmpty }
+    }
+
+    static func anchorClue(for place: Place) -> String {
+        guard let latitude = place.latitude, let longitude = place.longitude else {
+            return place.regionLabel
+        }
+
+        let northSouth = latitude >= puneLatitude ? "north" : "south"
+        let eastWest = longitude >= puneLongitude ? "east" : "west"
+        return "From Pune, look \(northSouth)-\(eastWest): \(place.regionLabel)."
+    }
+}
+
 enum ChronicleMatchPairKind: String, Codable, CaseIterable, Equatable {
     case placeToHook
     case placeToAction

--- a/GreatsOfBharathaTests/LearningEnginesTests.swift
+++ b/GreatsOfBharathaTests/LearningEnginesTests.swift
@@ -205,6 +205,38 @@ final class LearningEnginesTests: XCTestCase {
         XCTAssertEqual(progress.completedEvents, [.lessonSeen, .recallCorrect, .matchCompleted, .reviewCorrect])
     }
 
+    func testMapQuizEngineBuildsMysteryPromptsWithPuneAnchorClues() throws {
+        let places = SampleContent.shivajiVerticalSlice.corePlaces
+        let shivneriPrompt = try XCTUnwrap(MapQuizEngine.prompts(for: places).first { $0.placeID == "place-shivneri" })
+
+        XCTAssertEqual(shivneriPrompt.hiddenTitle, "Mystery fort")
+        XCTAssertEqual(shivneriPrompt.revealedTitle, "Shivneri")
+        XCTAssertTrue(shivneriPrompt.anchorClue.contains("From Pune"))
+        XCTAssertTrue(shivneriPrompt.anchorClue.contains("north-east"))
+        XCTAssertEqual(shivneriPrompt.memoryHook, "Birth Fort")
+    }
+
+    func testMapQuizEngineRevealsPlacesAndHighlightsGroupsTogether() throws {
+        let places = SampleContent.shivajiVerticalSlice.places
+        let groups = MapQuizEngine.defaultHighlightGroups(for: places)
+        let puneGroup = try XCTUnwrap(groups.first { $0.id == "pune-side-forts" })
+
+        XCTAssertEqual(puneGroup.placeIDs, ["place-torna", "place-rajgad", "place-purandar"])
+
+        var state = MapQuizState()
+        state = MapQuizEngine.reveal(placeID: "place-rajgad", in: state)
+        XCTAssertEqual(state.revealedPlaceIDs, ["place-rajgad"])
+
+        state = MapQuizEngine.apply(group: puneGroup, to: state)
+        XCTAssertEqual(state.activeGroupID, "pune-side-forts")
+        XCTAssertEqual(state.highlightedPlaceIDs, ["place-torna", "place-rajgad", "place-purandar"])
+
+        state = MapQuizEngine.clearHighlights(from: state)
+        XCTAssertNil(state.activeGroupID)
+        XCTAssertTrue(state.highlightedPlaceIDs.isEmpty)
+        XCTAssertEqual(state.revealedPlaceIDs, ["place-rajgad"])
+    }
+
     private var shivneriChallenge: RecallChallenge {
         RecallChallenge(
             id: "scene-1-shivneri-recall",


### PR DESCRIPTION
## Summary
- adds a lightweight MapQuizEngine with reveal state, multi-place highlight groups, and Pune-relative anchor clues
- updates the existing place map explorer so kids tap mystery fort pins to reveal names
- adds group buttons for highlighting several places together, including the opening journey and Pune-side forts

## Impact
This keeps the shipped MapKit place explorer as the entry point while adding the requested kid-friendly quiz behavior and multi-place highlighting. The geometry stays intentionally rough and associative around Pune rather than trying to become a full geography lesson.

Closes #135
Closes #137

## Validation
- `git diff --check`
- Unable to run `xcodebuild build-for-testing -project GreatsOfBharatha.xcodeproj -scheme GreatsOfBharatha -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`: `xcodebuild` is not installed in this Linux worker
- Unable to run `swiftlint lint`: `swiftlint` is not installed in this Linux worker
