### PR TITLE
[codex] Add learn quiz flashcard review

### DIFF
--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -27,12 +27,12 @@
 		47729BBB9C78BD293A31A6BD /* GBRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874E1F2468B251B5784486DE /* GBRadius.swift */; };
 		4C3F8F976E0CB196A3AEB41B /* GBNLRecallEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE07361DC3C1D6D864BB326 /* GBNLRecallEvaluator.swift */; };
 		5219DF64A6BC873CBD28A985 /* GBIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0048FE06EF01F9520955BAAD /* GBIcon.swift */; };
+		5222F1E15033526746FC9EBC /* FlashcardReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFCDA681F7AB90C2EDC1C6 /* FlashcardReviewView.swift */; };
 		57A372CC37EE9EDD83A56710 /* GBTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA553A6C52FF405536FB4B58 /* GBTypography.swift */; };
 		59DDE6A3CB3C27E2595A3085 /* GBSceneCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB52F4EF3B015973D3C6D088 /* GBSceneCard.swift */; };
 		5BD4A172E915378D3A9CC856 /* GBShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891FE8601621FF7A7BDE9AC6 /* GBShadow.swift */; };
 		5C9B9B95F0A16A53E02C8B38 /* SceneLearnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAB7F46ABBA5FCDA7A016BB /* SceneLearnView.swift */; };
 		5D281628DB3CC42AD77F0D7A /* LearningEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390AE8B48E7C52C376816E87 /* LearningEngines.swift */; };
-		5222F1E15033526746FC9EBC /* FlashcardReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFCDA681F7AB90C2EDC1C6 /* FlashcardReviewView.swift */; };
 		608CCC7416A6F35837C15A04 /* TimelineHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E8E42D945004543238A06E /* TimelineHubView.swift */; };
 		62EF82978E25896FA52FEAA8 /* ChronicleQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6CE8B3071CC2D92499A35E /* ChronicleQuizView.swift */; };
 		6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */; };
@@ -470,13 +470,13 @@
 				B2BA40CEB6D4E94F1608CA71 /* ContentModels.swift in Sources */,
 				229E49C4CD4DEAEF962F1BA4 /* ContentView.swift in Sources */,
 				0C3412C4E22C4B63092DB4BE /* DebugNavigationRoute.swift in Sources */,
+				5222F1E15033526746FC9EBC /* FlashcardReviewView.swift in Sources */,
 				DF919F38C0D6D11586812C90 /* GBBadge.swift in Sources */,
 				ADBA27254FB49C8AC53B58C6 /* GBButtonStyle.swift in Sources */,
 				89E3FE1D90324B34D697C540 /* GBCardStyle.swift in Sources */,
 				C59E6685BB680CF41B71A059 /* GBChildSafeAIPlan.swift in Sources */,
 				CE9E2F14877988A61A031337 /* GBChronicleCard.swift in Sources */,
 				8B7734948D0D0BE63E8E43B9 /* GBColor.swift in Sources */,
-				5222F1E15033526746FC9EBC /* FlashcardReviewView.swift in Sources */,
 				8B6F5ED2AC090236774D73A1 /* GBFlashCard.swift in Sources */,
 				F71FFA5AC6385137A61EFFE9 /* GBFortMapView.swift in Sources */,
 				96869AB017E4A3EBBE1DD23C /* GBHeroCard.swift in Sources */,

--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		5BD4A172E915378D3A9CC856 /* GBShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891FE8601621FF7A7BDE9AC6 /* GBShadow.swift */; };
 		5C9B9B95F0A16A53E02C8B38 /* SceneLearnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAB7F46ABBA5FCDA7A016BB /* SceneLearnView.swift */; };
 		5D281628DB3CC42AD77F0D7A /* LearningEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390AE8B48E7C52C376816E87 /* LearningEngines.swift */; };
+		5E7AD42C5F6B4E46BB047136 /* FlashcardReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B48D11F93314FB88EBF9DE1 /* FlashcardReviewView.swift */; };
 		608CCC7416A6F35837C15A04 /* TimelineHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E8E42D945004543238A06E /* TimelineHubView.swift */; };
 		62EF82978E25896FA52FEAA8 /* ChronicleQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6CE8B3071CC2D92499A35E /* ChronicleQuizView.swift */; };
 		6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */; };
@@ -91,6 +92,7 @@
 		390AE8B48E7C52C376816E87 /* LearningEngines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEngines.swift; sourceTree = "<group>"; };
 		3F908003C182E0D3D3047941 /* LearnQuizPilotData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizPilotData.swift; sourceTree = "<group>"; };
 		40039999B2C8D4999FB8C254 /* LessonFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonFeedback.swift; sourceTree = "<group>"; };
+		4B48D11F93314FB88EBF9DE1 /* FlashcardReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashcardReviewView.swift; sourceTree = "<group>"; };
 		596CBD0FA93B029F56E14FDF /* GBBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBBadge.swift; sourceTree = "<group>"; };
 		5A6043F267C6727A816F8CE8 /* GBSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSpacing.swift; sourceTree = "<group>"; };
 		5B68FFD09AD399FAE5A7DA5F /* ChronicleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleView.swift; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				C2A22615A77AECE2536BA1E9 /* ChronicleBookView.swift */,
 				F7731536CB354B63B77E73A4 /* ChronicleMatchView.swift */,
 				AC6CE8B3071CC2D92499A35E /* ChronicleQuizView.swift */,
+				4B48D11F93314FB88EBF9DE1 /* FlashcardReviewView.swift */,
 				2A7FCD376566BEDC5C726FF4 /* LearnQuizComponents.swift */,
 				E795D04E3E7952F19DB2D559 /* LearnQuizHomeView.swift */,
 				3F908003C182E0D3D3047941 /* LearnQuizPilotData.swift */,
@@ -473,6 +476,7 @@
 				C59E6685BB680CF41B71A059 /* GBChildSafeAIPlan.swift in Sources */,
 				CE9E2F14877988A61A031337 /* GBChronicleCard.swift in Sources */,
 				8B7734948D0D0BE63E8E43B9 /* GBColor.swift in Sources */,
+				5E7AD42C5F6B4E46BB047136 /* FlashcardReviewView.swift in Sources */,
 				8B6F5ED2AC090236774D73A1 /* GBFlashCard.swift in Sources */,
 				F71FFA5AC6385137A61EFFE9 /* GBFortMapView.swift in Sources */,
 				96869AB017E4A3EBBE1DD23C /* GBHeroCard.swift in Sources */,

--- a/GreatsOfBharatha.xcodeproj/project.pbxproj
+++ b/GreatsOfBharatha.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		5BD4A172E915378D3A9CC856 /* GBShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891FE8601621FF7A7BDE9AC6 /* GBShadow.swift */; };
 		5C9B9B95F0A16A53E02C8B38 /* SceneLearnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAB7F46ABBA5FCDA7A016BB /* SceneLearnView.swift */; };
 		5D281628DB3CC42AD77F0D7A /* LearningEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390AE8B48E7C52C376816E87 /* LearningEngines.swift */; };
-		5E7AD42C5F6B4E46BB047136 /* FlashcardReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B48D11F93314FB88EBF9DE1 /* FlashcardReviewView.swift */; };
+		5222F1E15033526746FC9EBC /* FlashcardReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFCDA681F7AB90C2EDC1C6 /* FlashcardReviewView.swift */; };
 		608CCC7416A6F35837C15A04 /* TimelineHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E8E42D945004543238A06E /* TimelineHubView.swift */; };
 		62EF82978E25896FA52FEAA8 /* ChronicleQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6CE8B3071CC2D92499A35E /* ChronicleQuizView.swift */; };
 		6DD86E4197280065B8F2187B /* ShivajiLessonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3010C8E169172E6B28BBA75 /* ShivajiLessonModels.swift */; };
@@ -92,7 +92,7 @@
 		390AE8B48E7C52C376816E87 /* LearningEngines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningEngines.swift; sourceTree = "<group>"; };
 		3F908003C182E0D3D3047941 /* LearnQuizPilotData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnQuizPilotData.swift; sourceTree = "<group>"; };
 		40039999B2C8D4999FB8C254 /* LessonFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonFeedback.swift; sourceTree = "<group>"; };
-		4B48D11F93314FB88EBF9DE1 /* FlashcardReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashcardReviewView.swift; sourceTree = "<group>"; };
+		49EFCDA681F7AB90C2EDC1C6 /* FlashcardReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashcardReviewView.swift; sourceTree = "<group>"; };
 		596CBD0FA93B029F56E14FDF /* GBBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBBadge.swift; sourceTree = "<group>"; };
 		5A6043F267C6727A816F8CE8 /* GBSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBSpacing.swift; sourceTree = "<group>"; };
 		5B68FFD09AD399FAE5A7DA5F /* ChronicleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleView.swift; sourceTree = "<group>"; };
@@ -249,7 +249,7 @@
 				C2A22615A77AECE2536BA1E9 /* ChronicleBookView.swift */,
 				F7731536CB354B63B77E73A4 /* ChronicleMatchView.swift */,
 				AC6CE8B3071CC2D92499A35E /* ChronicleQuizView.swift */,
-				4B48D11F93314FB88EBF9DE1 /* FlashcardReviewView.swift */,
+				49EFCDA681F7AB90C2EDC1C6 /* FlashcardReviewView.swift */,
 				2A7FCD376566BEDC5C726FF4 /* LearnQuizComponents.swift */,
 				E795D04E3E7952F19DB2D559 /* LearnQuizHomeView.swift */,
 				3F908003C182E0D3D3047941 /* LearnQuizPilotData.swift */,
@@ -476,7 +476,7 @@
 				C59E6685BB680CF41B71A059 /* GBChildSafeAIPlan.swift in Sources */,
 				CE9E2F14877988A61A031337 /* GBChronicleCard.swift in Sources */,
 				8B7734948D0D0BE63E8E43B9 /* GBColor.swift in Sources */,
-				5E7AD42C5F6B4E46BB047136 /* FlashcardReviewView.swift in Sources */,
+				5222F1E15033526746FC9EBC /* FlashcardReviewView.swift in Sources */,
 				8B6F5ED2AC090236774D73A1 /* GBFlashCard.swift in Sources */,
 				F71FFA5AC6385137A61EFFE9 /* GBFortMapView.swift in Sources */,
 				96869AB017E4A3EBBE1DD23C /* GBHeroCard.swift in Sources */,

--- a/GreatsOfBharatha/Features/LearnQuiz/FlashcardReviewView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/FlashcardReviewView.swift
@@ -1,0 +1,276 @@
+import SwiftUI
+
+struct FlashcardReviewView: View {
+    let cards: [LearnQuizReviewCard]
+
+    @State private var currentIndex = 0
+    @State private var isShowingBack = false
+    @State private var reviewResult: LearningReviewSchedulingResult?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var currentCard: LearnQuizReviewCard? {
+        guard cards.indices.contains(currentIndex) else { return nil }
+        return cards[currentIndex]
+    }
+
+    var body: some View {
+        GBLayoutContextReader { context in
+            ScrollView {
+                VStack(alignment: .leading, spacing: context.sectionSpacing) {
+                    header
+
+                    if let card = currentCard {
+                        flipCard(card)
+                        responseButtons(for: card)
+                        resultCard
+                    } else {
+                        emptyState
+                    }
+                }
+                .frame(maxWidth: context.maxContentWidth, alignment: .leading)
+                .padding(context.containerPadding)
+                .frame(maxWidth: .infinity)
+            }
+            .background(GBColor.Background.app)
+        }
+        .navigationTitle("Flash Cards")
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+    }
+
+    private var header: some View {
+        GBSurface(style: .accented(.chronicle)) {
+            VStack(alignment: .leading, spacing: GBSpacing.small) {
+                HStack {
+                    GBBadge(title: "Review", symbol: "rectangle.on.rectangle.angled", emphasis: .chronicle, inverted: true)
+                    Spacer()
+                    if !cards.isEmpty {
+                        Text("\(currentIndex + 1)/\(cards.count)")
+                            .font(GBFont.ui(size: 13, weight: .heavy))
+                            .foregroundStyle(.white.opacity(0.82))
+                    }
+                }
+
+                Text("Flip the card, then choose what your memory needed.")
+                    .font(GBFont.display(size: 25, weight: .bold))
+                    .foregroundStyle(.white)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func flipCard(_ card: LearnQuizReviewCard) -> some View {
+        Button {
+            flip()
+        } label: {
+            ZStack {
+                reviewFace(
+                    badge: card.sceneTitle,
+                    title: card.front,
+                    body: promptCopy(for: card),
+                    symbol: card.art.symbol,
+                    emphasis: card.art.emphasis,
+                    isBack: false
+                )
+                .opacity(isShowingBack ? 0 : 1)
+                .rotation3DEffect(.degrees(isShowingBack ? 180 : 0), axis: (x: 0, y: 1, z: 0))
+
+                reviewFace(
+                    badge: "Answer",
+                    title: card.back,
+                    body: card.meaning,
+                    symbol: "checkmark.seal.fill",
+                    emphasis: .chronicle,
+                    isBack: true
+                )
+                .opacity(isShowingBack ? 1 : 0)
+                .rotation3DEffect(.degrees(isShowingBack ? 0 : -180), axis: (x: 0, y: 1, z: 0))
+            }
+            .animation(reduceMotion ? nil : GBMotion.standard, value: isShowingBack)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isShowingBack ? "Showing answer: \(card.back). \(card.meaning)" : "Showing prompt: \(card.front). Tap to flip.")
+    }
+
+    private func reviewFace(
+        badge: String,
+        title: String,
+        body: String,
+        symbol: String,
+        emphasis: GBEmphasis,
+        isBack: Bool
+    ) -> some View {
+        ZStack(alignment: .topTrailing) {
+            RoundedRectangle(cornerRadius: GBRadius.hero, style: .continuous)
+                .fill(GBColor.gradient(for: emphasis))
+                .overlay(
+                    RoundedRectangle(cornerRadius: GBRadius.hero, style: .continuous)
+                        .fill(Color.black.opacity(isBack ? 0.32 : 0.40))
+                )
+
+            Image(systemName: symbol)
+                .font(.system(size: 76, weight: .bold))
+                .foregroundStyle(.white.opacity(0.22))
+                .padding(GBSpacing.medium)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: GBSpacing.medium) {
+                GBBadge(title: badge, symbol: isBack ? "sparkles" : "questionmark.circle.fill", emphasis: emphasis, inverted: true)
+
+                Spacer(minLength: GBSpacing.medium)
+
+                Text(title)
+                    .font(GBFont.display(size: 34, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(body)
+                    .font(GBFont.story(size: 20))
+                    .foregroundStyle(.white.opacity(0.92))
+                    .lineSpacing(4)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: GBSpacing.medium)
+
+                Label(isBack ? "Tap to see the clue side" : "Tap to flip", systemImage: "arrow.triangle.2.circlepath")
+                    .font(GBFont.ui(size: 14, weight: .heavy))
+                    .foregroundStyle(.white.opacity(0.82))
+            }
+            .padding(GBSpacing.medium)
+        }
+        .frame(minHeight: 360)
+        .clipShape(RoundedRectangle(cornerRadius: GBRadius.hero, style: .continuous))
+        .gbShadow(.card)
+    }
+
+    private func responseButtons(for card: LearnQuizReviewCard) -> some View {
+        VStack(spacing: GBSpacing.xSmall) {
+            Button {
+                record(.knewIt, for: card)
+            } label: {
+                Label("I knew it", systemImage: "checkmark.circle.fill")
+            }
+            .buttonStyle(.gbPrimary(.chronicle))
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: GBSpacing.xSmall)], spacing: GBSpacing.xSmall) {
+                Button {
+                    record(.neededClue, for: card)
+                } label: {
+                    Label("Needed a clue", systemImage: "lightbulb.fill")
+                }
+                .buttonStyle(.gbSecondary)
+
+                Button {
+                    record(.teachAgain, for: card)
+                } label: {
+                    Label("Teach me again", systemImage: "heart.text.square.fill")
+                }
+                .buttonStyle(.gbSecondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var resultCard: some View {
+        if let reviewResult {
+            GBSurface(style: .elevated) {
+                VStack(alignment: .leading, spacing: GBSpacing.xSmall) {
+                    Label(resultTitle(for: reviewResult), systemImage: "calendar.badge.clock")
+                        .font(GBFont.ui(size: 16, weight: .heavy))
+                        .foregroundStyle(GBColor.Content.primary)
+                    Text(resultDetail(for: reviewResult))
+                        .font(GBFont.ui(size: 14, weight: .semibold))
+                        .foregroundStyle(GBColor.Content.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if cards.indices.contains(currentIndex + 1) {
+                        Button {
+                            nextCard()
+                        } label: {
+                            Label("Next flash card", systemImage: "arrow.right.circle.fill")
+                        }
+                        .buttonStyle(.gbPrimary(.story))
+                        .padding(.top, GBSpacing.xxSmall)
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        GBSurface(style: .elevated) {
+            Text("No review cards are ready for this path yet.")
+                .font(GBFont.ui(size: 16, weight: .bold))
+                .foregroundStyle(GBColor.Content.secondary)
+        }
+    }
+
+    private func promptCopy(for card: LearnQuizReviewCard) -> String {
+        switch card.promptType {
+        case .openPrompt:
+            return "What place or idea does this memory hook point to?"
+        case .eventToPlaceMatch:
+            return "Which places belong with this pair?"
+        case .mapPlacement:
+            return "Where would this memory sit on the map?"
+        case .sequenceSlot:
+            return "Where does this fit in the journey?"
+        case .compareFromMemory:
+            return "Which fort or idea matches this clue?"
+        }
+    }
+
+    private func record(_ response: LearningReviewResponse, for card: LearnQuizReviewCard) {
+        let now = Date()
+        let schedule = SpacedReviewScheduler.makeInitialSchedule(from: card.learningSeed, now: now)
+        reviewResult = SpacedReviewScheduler.schedule(
+            schedule,
+            after: response,
+            promptHistory: [card.promptType],
+            now: now
+        )
+        isShowingBack = true
+        GBHaptic.chronicleReveal()
+    }
+
+    private func flip() {
+        isShowingBack.toggle()
+        GBHaptic.stepAdvance()
+    }
+
+    private func nextCard() {
+        currentIndex += 1
+        isShowingBack = false
+        reviewResult = nil
+        GBHaptic.stepAdvance()
+    }
+
+    private func resultTitle(for result: LearningReviewSchedulingResult) -> String {
+        result.shouldReviewInCurrentSession ? "We will teach it again now" : "Review saved"
+    }
+
+    private func resultDetail(for result: LearningReviewSchedulingResult) -> String {
+        if result.shouldReviewInCurrentSession {
+            return "This card stays warm because it needed more teaching."
+        }
+
+        switch result.schedule.stabilityBand {
+        case .new:
+            return "This card comes back soon."
+        case .warming:
+            return "This card comes back after a short wait."
+        case .steady:
+            return "This memory is getting steady."
+        case .durable:
+            return "This memory is becoming durable."
+        }
+    }
+}
+
+#Preview("Flashcard Review") {
+    NavigationStack {
+        FlashcardReviewView(cards: LearnQuizPilotData.reviewCards)
+    }
+}

--- a/GreatsOfBharatha/Features/LearnQuiz/LearnQuizHomeView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/LearnQuizHomeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct LearnQuizHomeView: View {
     private let scenes = LearnQuizPilotData.scenes
+    private let reviewCards = LearnQuizPilotData.reviewCards
 
     var body: some View {
         GBLayoutContextReader { context in
@@ -92,17 +93,23 @@ struct LearnQuizHomeView: View {
                 HStack {
                     GBBadge(title: "Due later", symbol: "rectangle.stack.fill", emphasis: .chronicle)
                     Spacer()
-                    Text("1 review seed")
+                    Text("\(reviewCards.count) review seeds")
                         .font(GBFont.ui(size: 12, weight: .bold))
                         .foregroundStyle(GBColor.Content.secondary)
                 }
-                Text("Flashcard review slot")
+                Text("Flashcard review")
                     .font(GBFont.display(size: 21, weight: .bold))
                     .foregroundStyle(GBColor.Content.primary)
-                Text("A quick card will bring back the memory hook after the story has had time to settle.")
+                Text("Flip quick cards for the pilot hooks, then choose I knew it, needed a clue, or teach me again.")
                     .font(GBFont.ui(size: 15, weight: .semibold))
                     .foregroundStyle(GBColor.Content.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+                NavigationLink {
+                    FlashcardReviewView(cards: reviewCards)
+                } label: {
+                    Label("Review flash cards", systemImage: "rectangle.on.rectangle.angled")
+                }
+                .buttonStyle(.gbPrimary(.chronicle))
             }
         }
     }

--- a/GreatsOfBharatha/Features/LearnQuiz/LearnQuizPilotData.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/LearnQuizPilotData.swift
@@ -25,6 +25,7 @@ struct LearnQuizPilotScene: Identifiable {
     let quiz: LearnQuizPrompt
     let matchPairs: [ChronicleMatchPair]
     let chronicleEntry: LearnQuizChronicleEntry
+    let reviewCards: [LearnQuizReviewCard]
     let art: LearnQuizArt
 }
 
@@ -52,7 +53,29 @@ struct LearnQuizChronicleEntry: Identifiable {
     let state: State
 }
 
-struct LearnQuizArt {
+struct LearnQuizReviewCard: Identifiable, Equatable {
+    let id: String
+    let sceneID: String
+    let sceneTitle: String
+    let promptType: RecallPromptType
+    let front: String
+    let back: String
+    let meaning: String
+    let cadenceDays: [Int]
+    let art: LearnQuizArt
+
+    var learningSeed: LearningReviewSeed {
+        LearningReviewSeed(
+            id: id,
+            subjectID: sceneID,
+            subjectType: .scene,
+            promptTypes: [promptType],
+            cadenceDays: cadenceDays
+        )
+    }
+}
+
+struct LearnQuizArt: Equatable {
     let assetSlot: String
     let symbol: String
     let emphasis: GBEmphasis
@@ -67,6 +90,10 @@ enum LearnQuizPilotData {
         }
     }
 
+    static var reviewCards: [LearnQuizReviewCard] {
+        scenes.flatMap(\.reviewCards)
+    }
+
     static var journeyEntry: LearnQuizChronicleEntry {
         LearnQuizChronicleEntry(
             id: pilot.endOfPilotReward.id,
@@ -79,6 +106,7 @@ enum LearnQuizPilotData {
 
     private static func makeScene(from scene: ChronicleScene, number: Int) -> LearnQuizPilotScene {
         let quizItem = scene.quizItems.first ?? fallbackQuizItem(for: scene)
+        let art = art(for: scene)
         return LearnQuizPilotScene(
             id: scene.id,
             number: number,
@@ -93,7 +121,8 @@ enum LearnQuizPilotData {
             quiz: makePrompt(from: quizItem),
             matchPairs: scene.matchPairs.map(makeMatchPair),
             chronicleEntry: makeChronicleEntry(from: scene),
-            art: art(for: scene)
+            reviewCards: scene.reviewSeeds.map { makeReviewCard(from: $0, scene: scene, art: art) },
+            art: art
         )
     }
 
@@ -140,6 +169,20 @@ enum LearnQuizPilotData {
         case .actionToMeaning:
             return .meaningToScene
         }
+    }
+
+    private static func makeReviewCard(from seed: ReviewSeed, scene: ChronicleScene, art: LearnQuizArt) -> LearnQuizReviewCard {
+        LearnQuizReviewCard(
+            id: seed.id,
+            sceneID: scene.id,
+            sceneTitle: scene.title,
+            promptType: seed.promptType,
+            front: seed.front,
+            back: seed.back,
+            meaning: seed.meaning,
+            cadenceDays: [seed.rescuedCadenceDays, seed.correctNoHintCadenceDays, 3, 7, 14],
+            art: art
+        )
     }
 
     private static func makeChronicleEntry(from scene: ChronicleScene) -> LearnQuizChronicleEntry {

--- a/GreatsOfBharatha/Features/LearnQuiz/SceneLearnView.swift
+++ b/GreatsOfBharatha/Features/LearnQuiz/SceneLearnView.swift
@@ -9,7 +9,7 @@ struct SceneLearnView: View {
                 VStack(alignment: .leading, spacing: context.sectionSpacing) {
                     SceneLearnCard(scene: scene, ctaTitle: "Quiz me")
 
-                    HStack(spacing: GBSpacing.xSmall) {
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 112), spacing: GBSpacing.xSmall)], spacing: GBSpacing.xSmall) {
                         NavigationLink {
                             ChronicleQuizView(scene: scene)
                         } label: {
@@ -21,6 +21,13 @@ struct SceneLearnView: View {
                             ChronicleMatchView(scenes: LearnQuizPilotData.scenes)
                         } label: {
                             Label("Match", systemImage: "square.grid.2x2.fill")
+                        }
+                        .buttonStyle(.gbSecondary)
+
+                        NavigationLink {
+                            FlashcardReviewView(cards: scene.reviewCards)
+                        } label: {
+                            Label("Cards", systemImage: "rectangle.on.rectangle.angled")
                         }
                         .buttonStyle(.gbSecondary)
                     }

--- a/GreatsOfBharathaTests/LearningEnginesTests.swift
+++ b/GreatsOfBharathaTests/LearningEnginesTests.swift
@@ -170,6 +170,16 @@ final class LearningEnginesTests: XCTestCase {
         XCTAssertEqual(due.map(\.subjectID), ["scene-a", "scene-b"])
     }
 
+    func testLearnQuizPilotExposesReviewSeedsAsFlashcards() {
+        let cards = LearnQuizPilotData.reviewCards
+
+        XCTAssertEqual(cards.count, 3)
+        XCTAssertEqual(cards.map(\.front), ["Birth Fort", "First Big Fort / Early Capital", "Turning Point"])
+        XCTAssertEqual(cards.map(\.back), ["Shivneri", "Torna / Rajgad", "Pratapgad"])
+        XCTAssertEqual(cards.map(\.learningSeed.subjectID), LearnQuizPilotData.scenes.map(\.id))
+        XCTAssertTrue(cards.allSatisfy { $0.learningSeed.subjectType == .scene })
+    }
+
     func testChronicleProgressEngineTransitionsFromSilhouetteToRememberedAgain() {
         let now = Date(timeIntervalSince1970: 1_800_000)
         let entry = ChronicleEntry(


### PR DESCRIPTION
## Summary

- Adds a Learn & Quiz flashcard review screen backed by the reset pilot review seeds.
- Exposes review seeds as flip-card models with front/back/meaning copy and scheduler seeds.
- Links flash cards from the Learn & Quiz home and each scene, with child-friendly outcomes: I knew it, Needed a clue, Teach me again.
- Adds unit coverage for pilot review seed to flashcard mapping.

## Validation

- Passed: `git diff --check`
- Blocked: Swift/Xcode tests could not run in this Linux container because `swift` and `xcodebuild` are not installed.

Closes #136