### PR TITLE
fix: keep wrong recall from advancing progress

### DIFF
--- a/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
+++ b/GreatsOfBharatha/Shared/Models/ShivajiLessonStore.swift
@@ -65,6 +65,7 @@ final class ShivajiLessonStore: ObservableObject {
         mastery: MasteryState,
         detail: String
     ) {
+        let safeMastery = wasSuccessful ? mastery : .witnessed
         let evidenceType: MasteryEvidenceType
         if wasSuccessful {
             switch promptType {
@@ -73,7 +74,7 @@ final class ShivajiLessonStore: ObservableObject {
             case .sequenceSlot:
                 evidenceType = .timelinePlacementSuccess
             case .openPrompt, .compareFromMemory:
-                evidenceType = mastery >= .remembered ? .reviewSuccess : .recallSuccess
+                evidenceType = safeMastery >= .remembered ? .reviewSuccess : .recallSuccess
             }
         } else {
             evidenceType = .recallAttempt
@@ -82,7 +83,7 @@ final class ShivajiLessonStore: ObservableObject {
         updateRecord(
             subjectID: subjectID,
             subjectType: subjectType,
-            newState: mastery,
+            newState: safeMastery,
             evidenceType: evidenceType,
             detail: detail
         )

--- a/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
+++ b/GreatsOfBharathaTests/GreatsOfBharathaTests.swift
@@ -138,6 +138,59 @@ final class GreatsOfBharathaTests: XCTestCase {
         XCTAssertEqual(store.chronicleUnlockState(for: guidanceEntry), .unlocked)
     }
 
+
+    func testFailedRecallDoesNotCompleteSceneAdvanceOrUnlockRewards() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let store = ShivajiLessonStore(defaults: defaults)
+        let shivneriPlace = try XCTUnwrap(SampleContent.shivajiVerticalSlice.corePlaces.first { $0.id == "place-shivneri" })
+        let guidanceEntry = try XCTUnwrap(SampleContent.shivajiHeroArc.chronicleEntry(withID: "reward-jijabai-guidance-badge"))
+
+        store.recordStoryExposure(for: "scene-1-shivneri")
+        store.recordRecallOutcome(
+            subjectID: "scene-1-shivneri",
+            promptType: .openPrompt,
+            wasSuccessful: false,
+            mastery: .remembered,
+            detail: "Wrong answer should stay an attempt"
+        )
+
+        XCTAssertEqual(store.mastery(for: "scene-1-shivneri"), .witnessed)
+        XCTAssertEqual(store.masteryRecord(for: "scene-1-shivneri")?.evidenceLog.last?.type, .recallAttempt)
+        XCTAssertEqual(store.completedScenes, 0)
+        XCTAssertEqual(store.nextSceneID, "scene-1-shivneri")
+        XCTAssertFalse(store.isUnlocked(SampleContent.birthFortCard))
+        XCTAssertEqual(store.chronicleUnlockState(for: guidanceEntry), .silhouette)
+        XCTAssertNotEqual(store.progress(for: shivneriPlace), .reviewed)
+        XCTAssertNotEqual(store.progress(for: shivneriPlace), .masteredLightly)
+    }
+
+    func testWrongChoiceRecallPreservesSupportiveFeedbackWithoutCompletionMastery() {
+        let challenge = RecallChallenge(
+            id: "scene-1-recall",
+            promptType: .openPrompt,
+            prompt: "Which fort is the birth place?",
+            correctAnswers: ["Shivneri Fort"],
+            hintLadder: [RecallHint(level: 1, title: "Anchor hint", body: "Think about the Birth Fort.")],
+            feedback: RecallFeedback(success: "Yes.", recovery: "Almost. Try the birth fort clue."),
+            masteryContribution: .remembered
+        )
+
+        let evaluation = LessonRecallEngine.submit(
+            state: LessonRecallState(),
+            challenge: challenge,
+            typedAnswer: "",
+            selectedChoiceTitle: "Rajgad Fort",
+            successMastery: challenge.masteryContribution
+        )
+
+        XCTAssertFalse(evaluation.wasSuccessful)
+        XCTAssertEqual(evaluation.masteryAwarded, .witnessed)
+        XCTAssertEqual(evaluation.revealedHintLevel, 1)
+        XCTAssertTrue(evaluation.feedbackText.contains("Try again"))
+        XCTAssertTrue(evaluation.feedbackText.contains("Birth Fort"))
+    }
+
     func testLessonStoreTracksEnrichedChronicleState() throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
         defaults.removePersistentDomain(forName: #function)


### PR DESCRIPTION
## Summary

Keeps failed recall attempts as attempts only, so wrong answers cannot accidentally grant completion-level mastery or advance the Shivaji scene loop.

## Changes

- Caps failed recall outcomes at `Witnessed` inside `ShivajiLessonStore`, regardless of caller-provided mastery.
- Preserves recall-attempt evidence/supportive feedback behavior for wrong answers.
- Adds unit coverage proving wrong recall does not complete the scene, advance `nextSceneID`, unlock Chronicle rewards, or mark places reviewed/mastered.

## Testing

- `xcodebuild test -quiet -project GreatsOfBharatha.xcodeproj -scheme GreatsOfBharatha -destination 'platform=iOS Simulator,id=C30BBB30-DFD2-4251-854B-C3B5CE250C9D' -only-testing:GreatsOfBharathaTests/GreatsOfBharathaTests/testFailedRecallDoesNotCompleteSceneAdvanceOrUnlockRewards -only-testing:GreatsOfBharathaTests/GreatsOfBharathaTests/testWrongChoiceRecallPreservesSupportiveFeedbackWithoutCompletionMastery CODE_SIGNING_ALLOWED=NO` on `ganesh-mba` ✅
- `xcodebuild test -quiet -project GreatsOfBharatha.xcodeproj -scheme GreatsOfBharatha -destination 'platform=iOS Simulator,id=C30BBB30-DFD2-4251-854B-C3B5CE250C9D' -only-testing:GreatsOfBharathaTests CODE_SIGNING_ALLOWED=NO` on `ganesh-mba` ✅

Refs ganesh47/greatsofbharatha#149