### PR TITLE
fix: improve scene CTA and accessibility

### DIFF
--- a/GreatsOfBharatha/DesignSystem/Components/GBFlashCard.swift
+++ b/GreatsOfBharatha/DesignSystem/Components/GBFlashCard.swift
@@ -183,8 +183,14 @@ struct GBFlashCardDeck: View {
                               : GBColor.Content.tertiary)
                         .frame(width: idx == currentIndex ? 24 : 7, height: 7)
                         .animation(GBMotion.quick, value: currentIndex)
+                        .accessibilityHidden(true)
                 }
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityIdentifier("story-card-carousel-progress")
+            .accessibilityLabel("Story card progress")
+            .accessibilityValue("Card \(min(currentIndex + 1, max(cards.count, 1))) of \(max(cards.count, 1))")
+            .accessibilityHint("Shows your place in the story card carousel.")
 
             // CTA
             if currentIndex == cards.count - 1 {
@@ -195,6 +201,8 @@ struct GBFlashCardDeck: View {
                 }
                 .buttonStyle(.gbPrimary(emphasis: emphasis))
                 .padding(.horizontal, GBSpacing.medium)
+                .accessibilityLabel("Continue from story cards")
+                .accessibilityHint("Moves to the next lesson activity.")
             } else if reduceMotion {
                 Button {
                     withAnimation(GBMotion.standard) { currentIndex += 1 }
@@ -205,6 +213,8 @@ struct GBFlashCardDeck: View {
                 }
                 .buttonStyle(.gbPrimary(emphasis: emphasis))
                 .padding(.horizontal, GBSpacing.medium)
+                .accessibilityLabel("Next story card")
+                .accessibilityHint("Shows the next card in the story carousel.")
             } else {
                 Label("Swipe to turn the card", systemImage: "hand.draw")
                     .font(GBFont.ui(size: 13, weight: .bold))
@@ -213,6 +223,9 @@ struct GBFlashCardDeck: View {
         }
         .padding(.bottom, GBSpacing.medium)
         .environmentObject(narrator)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Story card carousel")
+        .accessibilityValue("Card \(min(currentIndex + 1, max(cards.count, 1))) of \(max(cards.count, 1))")
     }
 }
 

--- a/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
+++ b/GreatsOfBharatha/Features/Chronicle/ChronicleView.swift
@@ -75,7 +75,7 @@ struct ChronicleView: View {
                         shelfSection(
                             eyebrow: "Held more deeply",
                             title: "Deepened keepsakes",
-                            subtitle: "These entries now carry richer meaning because your mastery went beyond the first unlock.",
+                            subtitle: "These entries shine brighter because you remembered the story again.",
                             rewards: deepenedRewards,
                             state: .deepened
                         )
@@ -166,7 +166,7 @@ struct ChronicleView: View {
 
     private var heroDetail: String {
         if dueReviewScene != nil {
-            return "A short return to a remembered scene can turn an earned keepsake into deeper mastery."
+            return "A short return to a remembered scene can help a keepsake shine brighter."
         }
         if appModel.lessonStore.unlockedChronicleCount == 0 {
             return "Story exposure lets a keepsake silhouette appear. Real Chronicle unlocks begin when you answer from memory."
@@ -507,7 +507,7 @@ private struct ChronicleShelfCard: View {
         case .earned:
             return reward.meaning
         case .deepened:
-            return reward.meaning + " This keepsake now carries a deeper Chronicle glow because your mastery went beyond the first unlock."
+            return reward.meaning + " This keepsake now has a deeper Chronicle glow because you remembered the story again."
         }
     }
 }

--- a/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
+++ b/GreatsOfBharatha/Features/Lesson/SceneLessonView.swift
@@ -145,8 +145,11 @@ struct SceneLessonView: View {
                 dotView(phase)
             }
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(phaseAccessibilityLabel)
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("scene-phase-progress")
+        .accessibilityLabel("Lesson progress")
+        .accessibilityValue(phaseAccessibilityLabel)
+        .accessibilityHint("Shows which part of the lesson is active: story, place clues, quiz, or treasure.")
     }
 
     private func dotView(_ phase: LessonPhase) -> some View {
@@ -164,7 +167,7 @@ struct SceneLessonView: View {
     private var phaseAccessibilityLabel: String {
         switch currentPhase {
         case .storyCards:  return "Step 1 of 4: Story cards"
-        case .placeReveal: return "Step 2 of 4: Where it happened"
+        case .placeReveal: return "Step 2 of 4: Place clues"
         case .recall:      return "Step 3 of 4: Quick quiz"
         case .reward:      return "Step 4 of 4: Your treasure"
         }
@@ -220,12 +223,13 @@ struct SceneLessonView: View {
                     GBHaptic.stepAdvance()
                     advanceTo(.placeReveal)
                 } label: {
-                    Label("Show me the fort", systemImage: "map.fill")
+                    Label("Move to place clues", systemImage: "map.fill")
                         .frame(maxWidth: .infinity, minHeight: GBTouch.button)
                 }
                 .buttonStyle(.gbPrimary(.story))
-                .accessibilityLabel("Show me the fort")
-                .accessibilityHint("Moves to the map for this chapter.")
+                .accessibilityIdentifier("story-move-to-place-clues-button")
+                .accessibilityLabel("Move to place clues")
+                .accessibilityHint("Moves forward to the place clues and fort map for this chapter.")
             }
             .padding(GBSpacing.medium)
             .background(GBColor.Background.surface, in: RoundedRectangle(cornerRadius: GBRadius.hero, style: .continuous))
@@ -240,7 +244,7 @@ struct SceneLessonView: View {
     }
 
     private var storyNarration: String {
-        "Chapter \(scene.number). \(scene.title). \(scene.childSafeSummary) Next, tap Show me the fort."
+        "Chapter \(scene.number). \(scene.title). \(scene.childSafeSummary) Next, tap Move to place clues."
     }
 
     private func narrationControls(text: String, id: String) -> some View {
@@ -283,20 +287,23 @@ struct SceneLessonView: View {
 
     private var placeRevealView: some View {
         VStack(spacing: GBSpacing.medium) {
-            Text("Where it happened!")
+            Text("Place clues")
                 .font(GBFont.display(size: 24, weight: .bold))
                 .foregroundStyle(GBColor.Content.primary)
                 .padding(.horizontal, GBSpacing.medium)
+                .accessibilityAddTraits(.isHeader)
 
             if let place = primaryPlace {
                 GBFortMapView(place: place)
                     .frame(height: 260)
                     .padding(.horizontal, GBSpacing.medium)
+                    .accessibilityIdentifier("place-clues-map")
 
                 HStack(spacing: GBSpacing.small) {
                     Image(systemName: GBIcon.place)
                         .font(.system(size: 28))
                         .foregroundStyle(GBColor.Place.primary)
+                        .accessibilityHidden(true)
                     VStack(alignment: .leading, spacing: GBSpacing.xxxSmall) {
                         Text(place.name)
                             .font(GBFont.display(size: 20, weight: .bold))
@@ -307,6 +314,8 @@ struct SceneLessonView: View {
                     }
                 }
                 .padding(.horizontal, GBSpacing.medium)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Place clue: \(place.name). \(place.primaryEvent)")
 
                 narrationControls(
                     text: "This is \(place.name). \(place.primaryEvent). When you are ready, tap Got it.",
@@ -330,7 +339,20 @@ struct SceneLessonView: View {
             .buttonStyle(.gbPrimary(.place))
             .padding(.horizontal, GBSpacing.medium)
             .padding(.bottom, GBSpacing.medium)
+            .accessibilityIdentifier("place-clues-got-it-button")
+            .accessibilityLabel("Got it, start quick quiz")
+            .accessibilityHint("Moves from place clues to the recall question.")
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(placeRevealAccessibilityLabel)
+        .accessibilityHint("Review the fort map and place clue, then continue to the quick quiz.")
+    }
+
+    private var placeRevealAccessibilityLabel: String {
+        if let place = primaryPlace {
+            return "Place clues for \(scene.title): \(place.name)."
+        }
+        return "Place clues for \(scene.title)."
     }
 
     // MARK: - Phase 3: MCQ recall
@@ -375,6 +397,8 @@ struct SceneLessonView: View {
                     }
                     .buttonStyle(.gbPrimary(.chronicle))
                     .padding(.horizontal, GBSpacing.medium)
+                    .accessibilityLabel("See this keepsake in my album")
+                    .accessibilityHint("Opens the Royal Chronicle and highlights the keepsake you earned.")
                 } else {
                     Text("Adventure complete!")
                         .font(GBFont.display(size: 22, weight: .bold))
@@ -455,6 +479,8 @@ private struct SimpleRecallView: View {
             }
             .padding(.horizontal, GBSpacing.medium)
             .padding(.top, GBSpacing.small)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Quick quiz question: \(challenge.prompt)")
 
             Text("Pick one choice before you collect your Chronicle reward.")
                 .font(GBFont.ui(size: 15, weight: .semibold))
@@ -505,6 +531,8 @@ private struct SimpleRecallView: View {
                 .padding(.horizontal, GBSpacing.medium)
                 .padding(.bottom, GBSpacing.medium)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
+                .accessibilityLabel("Open my treasure")
+                .accessibilityHint("Moves to the Chronicle reward reveal.")
             } else {
                 Button("Check my choice") {
                     GBHaptic.stepAdvance()
@@ -515,6 +543,8 @@ private struct SimpleRecallView: View {
                 .padding(.horizontal, GBSpacing.medium)
                 .padding(.bottom, GBSpacing.medium)
                 .accessibilityIdentifier("recall-check-choice-button")
+                .accessibilityLabel("Check my choice")
+                .accessibilityHint(recallState.selectedChoiceID == nil ? "Choose an answer first." : "Checks the selected answer.")
             }
         }
         .animation(GBMotion.quick, value: recallState.hasAnsweredCorrectly)
@@ -562,9 +592,10 @@ private struct SimpleRecallView: View {
         .buttonStyle(.plain)
         .disabled(recallState.hasAnsweredCorrectly)
         .accessibilityIdentifier("recall-choice-\(choice.id)")
-        .accessibilityLabel("Choice: \(choice.title)")
+        .accessibilityLabel("Recall choice: \(choice.title)")
         .accessibilityValue(accessibilityValue(isSelected: isSelected, showRight: showRight, showWrong: showWrong))
-        .accessibilityHint(recallState.hasAnsweredCorrectly ? "Choice checked" : "Tap to select this choice, then use Check my choice")
+        .accessibilityHint(recallState.hasAnsweredCorrectly ? "Choice checked" : "Double tap to select this choice, then use Check my choice.")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
         .animation(GBMotion.quick, value: isSelected)
     }
 

--- a/GreatsOfBharatha/Features/Map/GBFortMapView.swift
+++ b/GreatsOfBharatha/Features/Map/GBFortMapView.swift
@@ -34,6 +34,9 @@ struct GBFortMapView: View {
         .mapStyle(.standard(elevation: .realistic))
         .clipShape(RoundedRectangle(cornerRadius: GBRadius.hero, style: .continuous))
         .gbShadow(.card)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Map clue for \(place.name)")
+        .accessibilityHint("The fort pin marks where this story happened. Double tap the pin to celebrate the place.")
     }
 
     private var fortPin: some View {
@@ -73,7 +76,9 @@ struct GBFortMapView: View {
             }
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Fort pin: \(place.name). Tap to celebrate!")
+        .accessibilityLabel("Fort pin: \(place.name)")
+        .accessibilityValue(pinTapped ? "celebrated" : "not celebrated")
+        .accessibilityHint("Double tap to celebrate finding this fort clue.")
     }
 
     private var fortIconName: String {


### PR DESCRIPTION
## Summary

Improves the scene lesson handoff from story to place clues and adds a focused accessibility pass across the current lesson loop.

## Changes

- Changes the story CTA to `Move to place clues` and routes it to the visible place-clues phase with matching narration and accessibility identifiers.
- Adds VoiceOver labels, values, hints, and selected-state traits for lesson progress, story carousel progress, recall choices, place clues, map pins, and key CTAs.
- Removes child-facing Chronicle `mastery` jargon/debug-style copy from visible reward text.

## Testing

- `xcodebuild test -project GreatsOfBharatha.xcodeproj -scheme GreatsOfBharatha -destination 'platform=iOS Simulator,name=iPad (A16)'` on `ganesh-mba` — passed, 31 tests.

Refs ganesh47/greatsofbharatha#149
